### PR TITLE
ci: add concurrency group to prevent duplicate page artifacts

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read


### PR DESCRIPTION
Prevents multiple deployments from running simultaneously, which caused duplicate `github-pages` artifacts and failed deploys.