### PR TITLE
fix: use BASE_URL env var for base path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,5 +4,6 @@ import { getCondition } from "vite-plugin-react-server/config";
 import config from "./vite.react.config.ts";
 console.log(getCondition());
 export default defineConfig({
+  base: process.env.BASE_URL || "/",
   plugins: vitePluginReactServer(config),
 });

--- a/vite.react.config.ts
+++ b/vite.react.config.ts
@@ -30,7 +30,7 @@ export default {
   Html: `src/Html.tsx`,
   verbose: false,
   moduleBasePath: "/",
-  moduleBaseURL: process.env.VITE_BASE_URL || "/",
+  moduleBaseURL: process.env.BASE_URL || process.env.VITE_BASE_URL || "/",
   serverEntry: "src/server/index.ts",
   css: {
     inlineThreshold: 10000,


### PR DESCRIPTION
Same fix as mmc PR #69. `VITE_BASE_URL` isn't available during Vite config resolution (only after `.env` expansion). Use `process.env.BASE_URL` which is set by the env scripts.