### PR TITLE
chore: bump vite-plugin-react-server to 1.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "1.2.3"
+        "vite-plugin-react-server": "1.2.4"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
@@ -2660,9 +2660,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.2.3.tgz",
-      "integrity": "sha512-/r5DxexV2Mv9WvAaefQRNhDpxOKtuIuz7vUFGR6os6G0V+kvNPlMoEQIbWlTevkohGJi+5aYjeht/JATzlKEEw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.2.4.tgz",
+      "integrity": "sha512-mMRbe8DnLcTAgLbFyTYBKjM67erTVJl0DFQhb6xXpGzwJ+i6Swk78QbeI/voEXJYMQMpVhkkRHG5KhaGlQmB8A==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "1.2.4"
+    "vite-plugin-react-server": "1.2.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "1.2.3"
+    "vite-plugin-react-server": "1.2.4"
   }
 }

--- a/src/client.tsx
+++ b/src/client.tsx
@@ -5,14 +5,11 @@ import "./css/globalStyles.css";
 import { createReactFetcher } from "vite-plugin-react-server/utils";
 import { useRscHmr } from "virtual:react-server/hmr";
 import { ErrorBoundary } from "./components/ErrorBoundary.client.js";
+// PUBLIC_ORIGIN is provided by vite-plugin-react-server/virtual types,
+// but re-declared here for noPropertyAccessFromIndexSignature compatibility
 declare global {
   interface ImportMetaEnv {
-    BASE_URL: string
-    MODE: string
-    DEV: boolean
-    PROD: boolean
-    SSR: boolean
-    PUBLIC_ORIGIN: string
+    readonly PUBLIC_ORIGIN: string;
   }
 }
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,7 +37,8 @@
       // We tell the transpiler that we are using vite and that we want to use the client types. This makes sure that our import.meta.env types are available, as well as the experimental react types.
       "types": [
         "vite/client",
-        "react/experimental"
+        "react/experimental",
+        "vite-plugin-react-server/virtual"
       ],
       "resolvePackageJsonImports": true,
       "resolvePackageJsonExports": true,


### PR DESCRIPTION
Bumps vite-plugin-react-server from 1.2.3 to 1.2.4.

**Changes in 1.2.4:**
- fix: handle Vite preload helper injection before directives