### PR TITLE
chore: bump vite-plugin-react-server to v1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^1.3.6"
+        "vite-plugin-react-server": "^1.4.0"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
@@ -23,7 +23,7 @@
         "react-dom": "0.0.0-experimental-19baee81-20250725",
         "tsx": "^4.19.2",
         "vite": "^6.3.2",
-        "vite-plugin-react-server": "^1.3.6",
+        "vite-plugin-react-server": "^1.4.0",
         "webpack-sources": "^3.3.0"
       }
     },
@@ -2167,9 +2167,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.3.6.tgz",
-      "integrity": "sha512-lyvyd7LXQDZERHNHOT9jHzQxb+ibhgsZ25rG1lZBeEAqnJr6nx2NgRsxIEENng9ex+R/Ruk/q84Y1MU06heJYQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.4.0.tgz",
+      "integrity": "sha512-CvjsLEuLZf5wse5T+nHJXDkH4GV8RxATbCSTr/28Rye9i8gle637f6nqNWTP+tJ4Tr+cB5v8D72zp2ForStwuQ==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -50,10 +50,10 @@
     "tsx": "^4.19.2",
     "vite": "^6.3.2",
     "webpack-sources": "^3.3.0",
-    "vite-plugin-react-server": "^1.3.6"
+    "vite-plugin-react-server": "^1.4.0"
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^1.3.6"
+    "vite-plugin-react-server": "^1.4.0"
   }
 }


### PR DESCRIPTION
Bumps vite-plugin-react-server to v1.4.0

Changes in v1.4.0:
- Fix: server environment no longer triggers page reload for client component changes
- Fix: CSS changes trigger RSC refetch (inlined styles handled correctly)
- Fix: Migrated HMR from legacy handleHotUpdate to Vite 6 per-environment hotUpdate API
- Fix: flaky client component HMR test