### PR TITLE
chore: bump vite-plugin-react-server to v1.4.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^1.4.4"
+        "vite-plugin-react-server": "^1.4.6"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
@@ -2096,9 +2096,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.4.4.tgz",
-      "integrity": "sha512-eHpS7ysv3D5fiVPSAGYs2ark9rHIxziRWlO1T7K9xSR08ih/afzjwEMWs/dJ3rMBd5UblcY+Bb7TFP+JTWPVSQ==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.4.6.tgz",
+      "integrity": "sha512-0QOid5AyBdLcAnZaKyJ7HaVCV1XLoiRjceDeSyUmJuVTJWWAOz9f3Rqd3FE8dkPkGoia4aehOZ5imWOi02wQEQ==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^1.4.4"
+    "vite-plugin-react-server": "^1.4.6"
   }
 }


### PR DESCRIPTION
Bumps `vite-plugin-react-server` to v1.4.6.

Per `vite-plugin-react-server/docs/releasing.md` step 4.