### PR TITLE
fix(bd-pg4): disable todo demo on GitHub Pages build

### DIFF
--- a/src/page/page.tsx
+++ b/src/page/page.tsx
@@ -5,7 +5,7 @@ import styles from "../css/home.module.css";
 import packageJson from "../../package.json" assert { type: "json" };
 import { Counter } from "../components/Counter.client.js";
 import type { Props } from "./props.js";
-export const Page = ({ url, title, navigation }: Props) => {
+export const Page = ({ url, title, navigation, isGithubPages }: Props) => {
   return (
     <>
       <title>{title ?? "No title"}</title>
@@ -48,11 +48,13 @@ export const Page = ({ url, title, navigation }: Props) => {
                 {navigation.toErrorExample.text}
               </Link>
             </li>
-            <li>
-              <Link to={navigation.toTodos.href} className={styles["Url"]}>
-                {navigation.toTodos.text}
-              </Link>
-            </li>
+            {!isGithubPages && (
+              <li>
+                <Link to={navigation.toTodos.href} className={styles["Url"]}>
+                  {navigation.toTodos.text}
+                </Link>
+              </li>
+            )}
           </ul>
           <dl>
             <dt>Build using node version</dt>

--- a/src/page/props.ts
+++ b/src/page/props.ts
@@ -8,11 +8,13 @@ export const props = (url: string) => {
   const bidoofURL = pathname + "bidoof/";
   const errorExampleURL = pathname + "error-example/";
   const todosURL = pathname + "todos/";
+  const isGithubPages = process.env.GITHUB_PAGES === "true";
   return {
     url,
     title: "vite-plugin-react-server demo",
     description: "Home page",
     baseUrl: import.meta.env.BASE_URL,
+    isGithubPages,
     navigation: {
       toBidoof: {
         href: bidoofURL,

--- a/src/page/todos/page.tsx
+++ b/src/page/todos/page.tsx
@@ -15,6 +15,33 @@ export async function Page({
   initialTodos,
   isGithubPages
 }: Props) {
+  if (isGithubPages) {
+    return (
+      <div className={styles["TodoList"]}>
+        <Link to="/" className={styles["Link"]}> back </Link>
+        <h1>Todo List</h1>
+        <p>
+          The todo demo is disabled on the GitHub Pages build because it relies
+          on server actions backed by a SQLite database, which a static host
+          can't run.
+        </p>
+        <p>To try it locally:</p>
+        <ol>
+          <li>
+            Clone{" "}
+            <a href="https://github.com/nicobrinkkemper/vite-plugin-react-server-demo-official">
+              the demo repo
+            </a>
+          </li>
+          <li><code>npm install</code></li>
+          <li>
+            <code>npm run dev:rsc</code> (server-first) or{" "}
+            <code>npm run dev:ssr</code> (client-first)
+          </li>
+        </ol>
+      </div>
+    );
+  }
   return (
     <div className={styles["TodoList"]}>
       <Link to="/" className={styles["Link"]}> back </Link>

--- a/src/page/todos/props.ts
+++ b/src/page/todos/props.ts
@@ -1,8 +1,21 @@
 import { addTodo, toggleTodo, deleteTodo, editTodo, clearCompletedTodos, getTodos } from '../../server/actions/todoActions.server.js';
 
 export const props = async () => {
+  const isGithubPages = process.env.GITHUB_PAGES === 'true';
+  if (isGithubPages) {
+    return {
+      title: "Todos",
+      addTodo,
+      toggleTodo,
+      deleteTodo,
+      editTodo,
+      clearCompletedTodos,
+      getTodos,
+      initialTodos: [],
+      isGithubPages,
+    };
+  }
   let initialTodos = await getTodos();
-  const isGithubPages = process.env.VITE_GITHUB_PAGES === 'true';
   // set some todo if there are no todos
   if (initialTodos.length === 0) {
     await addTodo('Clone the repo');
@@ -20,7 +33,7 @@ export const props = async () => {
     clearCompletedTodos,
     getTodos,
     initialTodos,
-    isGithubPages
+    isGithubPages,
   };
 };
 


### PR DESCRIPTION
## Summary

Fixes the browser-freeze when opening `/todos/` on the published GH Pages demo. The todo page calls server actions backed by SQLite, which a static host can't run — the failing requests hung the browser.

The page already had an `isGithubPages` flag plumbed through, but it was dead: `props.ts` read `process.env.VITE_GITHUB_PAGES` while the build script only sets `GITHUB_PAGES=true`. So the live `<TodoList>` rendered on GH Pages anyway.

## Changes

- Read `process.env.GITHUB_PAGES` in `src/page/todos/props.ts` and `src/page/props.ts`
- Skip `getTodos()` / seeding in `todos/props.ts` when `isGithubPages` (no server actions called at all)
- Render a "disabled on GitHub Pages — clone to try locally" stub from `src/page/todos/page.tsx` instead of `<TodoList>` when `isGithubPages`
- Hide the Todos nav link from the home page when `isGithubPages`

## Test plan

- [x] `npm run build:gh` — `/todos/index.html` contains the stub message; home `index.html` does NOT contain a Todos link
- [x] `npm run build` (default) — `/todos/index.html` still renders the live `<TodoList>`; home still shows the Todos link
- [ ] Visual smoke on the deployed GH Pages once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)