### PR TITLE
chore: follow vprs README — use vite-plugin-react-server/virtual types

### DIFF
--- a/src/page/tsconfig.json
+++ b/src/page/tsconfig.json
@@ -6,7 +6,7 @@
         "types": [
             "vite/client",
             "node",
-            "react/experimental"
+            "vite-plugin-react-server/virtual"
         ]
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,10 +34,10 @@
       "rootDir": "./",
       // We collect all of our compiled files into the dist folder so that we do not clutter our source directories with distilled files.
       "outDir": "dist",
-      // We tell the transpiler that we are using vite and that we want to use the client types. This makes sure that our import.meta.env types are available, as well as the experimental react types.
+      // The plugin's recommended types config: vite/client gives us import.meta.env basics, vite-plugin-react-server/virtual adds typing for the virtual:react-server/hmr module, the custom HMR event, and PUBLIC_ORIGIN.
       "types": [
         "vite/client",
-        "react/experimental"
+        "vite-plugin-react-server/virtual"
       ],
       "resolvePackageJsonImports": true,
       "resolvePackageJsonExports": true,


### PR DESCRIPTION
## Summary

The plugin's README recommends:

\`\`\`json
{ "compilerOptions": { "types": ["vite/client", "vite-plugin-react-server/virtual"] } }
\`\`\`

But this demo (the canonical "follow this template") had \`["vite/client", "react/experimental"]\` in both tsconfigs. So neither the \`virtual:react-server/hmr\` module (imported in \`src/client.tsx\`) nor \`import.meta.env.PUBLIC_ORIGIN\` was getting ambient typing from the plugin.

## Changes

- \`tsconfig.json\` — swap \`react/experimental\` for \`vite-plugin-react-server/virtual\`; rewrite the comment
- \`src/page/tsconfig.json\` — same swap (kept \`node\` since this is a server-side compile config)

\`react/experimental\` types are no longer needed: the only experimental React API previously in use was \`use()\`, which shipped stable in React 19.

## Test plan

- [x] \`npm run build\` succeeds
- [x] \`npm run build:gh\` succeeds
- [ ] Editor (VS Code) no longer flags \`virtual:react-server/hmr\` or \`PUBLIC_ORIGIN\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)