### PR TITLE
chore: drop redundant ImportMetaEnv hacks

### DIFF
--- a/src/client.tsx
+++ b/src/client.tsx
@@ -5,16 +5,6 @@ import "./css/globalStyles.css";
 import { createReactFetcher } from "vite-plugin-react-server/utils";
 import { useRscHmr } from "virtual:react-server/hmr";
 import { ErrorBoundary } from "./components/ErrorBoundary.client.js";
-declare global {
-  interface ImportMetaEnv {
-    BASE_URL: string
-    MODE: string
-    DEV: boolean
-    PROD: boolean
-    SSR: boolean
-    PUBLIC_ORIGIN: string
-  }
-}
 /**
  * Client-side React Server Components implementation
  *

--- a/src/page/page.tsx
+++ b/src/page/page.tsx
@@ -1,4 +1,3 @@
-/// <reference types="vite/client" />
 import * as React from "react";
 import { Link } from "../components/Link.client.js";
 import styles from "../css/home.module.css";

--- a/src/types/meta-env.d.ts
+++ b/src/types/meta-env.d.ts
@@ -1,8 +1,0 @@
-declare global {    
-  interface ImportMetaEnv {
-    readonly BASE_URL: string;
-    readonly PUBLIC_ORIGIN: string;
-  }
-}       
-
-export {};


### PR DESCRIPTION
## Summary

Follow-up to #62. With `vite-plugin-react-server/virtual` now in tsconfig types, three hand-rolled type hacks are duplicates and can go.

## Changes

- Delete `src/types/meta-env.d.ts` — re-declared `BASE_URL` (provided by `vite/client`) and `PUBLIC_ORIGIN` (now provided by `vite-plugin-react-server/virtual`)
- Drop the inline `declare global { interface ImportMetaEnv { ... } }` block from `src/client.tsx` — same fields, same coverage from the imported types
- Drop the `/// <reference types="vite/client" />` triple-slash from `src/page/page.tsx` — `vite/client` is in `tsconfig.json` `compilerOptions.types`, so the directive is redundant

`src/types/react-server-dom-esm.d.ts` is intentionally left alone — `react-server-dom-esm` ships no types of its own and `src/server/start.tsx` imports from it directly.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run build:gh` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)