### PR TITLE
chore: bump vite-plugin-react-server to ^1.4.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^1.4.6"
+        "vite-plugin-react-server": "^1.4.7"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
@@ -2096,9 +2096,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.4.6.tgz",
-      "integrity": "sha512-0QOid5AyBdLcAnZaKyJ7HaVCV1XLoiRjceDeSyUmJuVTJWWAOz9f3Rqd3FE8dkPkGoia4aehOZ5imWOi02wQEQ==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.4.7.tgz",
+      "integrity": "sha512-7NqGZYJ71jOIc8kMc3bcddLoIGeJTw6xl8gVkH/w04xNApSq1HQiOAKcL/BPJ2yt3cIyhsRHCUxex0l9hzpmMQ==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
@@ -2113,8 +2113,8 @@
         "node": "^23.7.0"
       },
       "peerDependencies": {
-        "react": ">=0.0.0-experimental-0",
-        "react-dom": ">=0.0.0-experimental-0",
+        "react": ">=0.0.0-experimental-0 <1.0.0",
+        "react-dom": ">=0.0.0-experimental-0 <1.0.0",
         "vite": "*"
       },
       "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^1.4.6"
+    "vite-plugin-react-server": "^1.4.7"
   }
 }


### PR DESCRIPTION
Picks up the bd-lr4 fix that narrows vprs's peerDependencies.react / react-dom to >=0.0.0-experimental-0 <1.0.0, so npm hard-fails when the plugin is paired with stable React 19.x instead of resolving silently to a broken pairing.

Verified: npm run build:preview is green against the new version.