### PR TITLE
chore: bump vite-plugin-react-server to ^1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^1.4.8"
+        "vite-plugin-react-server": "^1.5.0"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
@@ -2096,14 +2096,15 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.4.8.tgz",
-      "integrity": "sha512-hshBdPbfpHhSvvJ+BQGEFZLYgCwYdjuJV5CJrdQO+bitr8D1xZ3nScL29J2btqn8cH1fsEyZ7pzh0joxCkjOHA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.5.0.tgz",
+      "integrity": "sha512-LkeSaCn2zTE5Yme+vnrQkFCOBvuh9sIw6SaE9RrjnYMbqwzmib585zy1RTlqcvA755K0dAgLrWR+t5/JJqPyjw==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "tsx": "^4.21.0"
+        "tsx": "^4.21.0",
+        "vitefu": "^1.1.3"
       },
       "bin": {
         "check-react-version": "scripts/check-react-version.mjs",
@@ -2587,6 +2588,25 @@
         "@esbuild/win32-arm64": "0.25.12",
         "@esbuild/win32-ia32": "0.25.12",
         "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^1.4.8"
+    "vite-plugin-react-server": "^1.5.0"
   }
 }


### PR DESCRIPTION
## Summary

- Bumps `vite-plugin-react-server` from `^1.4.8` to `^1.5.0`.
- vprs 1.5.0 adds Next.js parity for node_modules `"use client"` packages — component libraries like Chakra, MUI, Mantine, react-aria, framer-motion can be imported directly into server components without a `.client.tsx` wrapper. Auto-detected via peer-deps; no config required.

## Test plan

- [x] `npm install` resolves to `vite-plugin-react-server@1.5.0` from registry
- [x] `npm run build` → 5 pages rendered, server actions + SQLite unaffected
- [ ] (post-merge) deploy pipelines green

🤖 Generated with [Claude Code](https://claude.com/claude-code)