### PR TITLE
chore: bump vprs to ^1.5.1 and GH Actions to Node 24 compatible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^1.5.0"
+        "vite-plugin-react-server": "^1.5.1"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
@@ -2096,9 +2096,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.5.0.tgz",
-      "integrity": "sha512-LkeSaCn2zTE5Yme+vnrQkFCOBvuh9sIw6SaE9RrjnYMbqwzmib585zy1RTlqcvA755K0dAgLrWR+t5/JJqPyjw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.5.1.tgz",
+      "integrity": "sha512-YnlfZdigC7JX88YrLhRNm4WFZAQl4TQsN/RZ66dudj+GVk616SGXxbfhTHakD7xLZ18u/VX1l/bQfe4eFz7Obg==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^1.5.0"
+    "vite-plugin-react-server": "^1.5.1"
   }
 }


### PR DESCRIPTION
## Summary
- Bumps `vite-plugin-react-server` from `^1.5.0` to `^1.5.1`.
- Bumps GitHub Actions to clear Node.js 20 deprecation warning on the Pages deploy:
  - `actions/checkout@v4` → `v6`
  - `actions/setup-node@v3` → `v6`
  - `actions/configure-pages@v4` → `v6`
  - `actions/upload-pages-artifact@v3` → `v5`
  - `actions/deploy-pages@v4` → `v5`

## Test plan
- [x] `npm install` resolves vprs to `1.5.1`
- [x] `npm run build` succeeds locally
- [ ] CI Pages deploy succeeds without the Node 20 deprecation warning