### PR TITLE
chore: bump vprs to ^1.5.2 and GH Actions to Node 24 compatible

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '23.8.0'
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
       - run: npm ci
       - run: npm run build:gh --if-present
       - name: List contents
@@ -39,7 +39,7 @@ jobs:
             echo "::warning title=Invalid file permissions automatically fixed::$line"
           done
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: dist/static
 
@@ -62,4 +62,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^1.5.1"
+        "vite-plugin-react-server": "^1.5.2"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
@@ -2096,9 +2096,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.5.1.tgz",
-      "integrity": "sha512-YnlfZdigC7JX88YrLhRNm4WFZAQl4TQsN/RZ66dudj+GVk616SGXxbfhTHakD7xLZ18u/VX1l/bQfe4eFz7Obg==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.5.2.tgz",
+      "integrity": "sha512-VtLda0qRFGYawkwG+GEnaX0TExWtWLM/G5HKUgfnQ+yG4c4SQRj+TBQPrRZzH4AGM0LgeYpjRB/9pRqbJqbjjQ==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^1.5.1"
+    "vite-plugin-react-server": "^1.5.2"
   }
 }


### PR DESCRIPTION
## Summary

- **vprs bump**: `^1.5.0` → `^1.5.2`. Picks up the dev:ssr CSS module HMR fix released in v1.5.2 (`*.module.css` edits now invalidate the SSR worker's Node-cached imports and apply on reload — previously the rendered class hashes stayed at their pre-edit values).
- **GH Actions Node bump**: jobs were pinned to a Node version that's heading out of support; bumped to a 24-compatible version so CI keeps running once GH retires the older runner.

Combined into one PR matching the convention from mmc PR #88.

## Test plan

- [x] `npm install` is a clean transitive resolution; no peer-dep conflicts
- [ ] CI green on the dev:rsc/dev:ssr fixtures after merge
- [ ] (manual) `npm run dev:ssr`, edit `src/css/home.module.css`, reload page — verify the change applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)