### PR TITLE
chore: bump vite-plugin-react-server to ^1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^1.6.0"
+        "vite-plugin-react-server": "^1.7.0"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
@@ -2096,9 +2096,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.6.0.tgz",
-      "integrity": "sha512-v/ciDT9KfrnQzLweJGxYabW5Q3lGeHxBqUnohXOGQXNOllTyQOXcI1DIZceSCRK8vQjyCBgT/rybh1IBIxVukQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.7.0.tgz",
+      "integrity": "sha512-kytKXsP7p34tHbDlcxuiovrT7nAhjKNll54UQzyLXo51n7QcG4A4eWnAgpNmW1Z9vORfapf1faNnkGM9mmTSCA==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^1.6.0"
+    "vite-plugin-react-server": "^1.7.0"
   }
 }


### PR DESCRIPTION
## Summary

Bumps \`vite-plugin-react-server\` from \`^1.6.0\` to \`^1.7.0\`.

1.7.0 is a cleanup release: it removes the legacy non-runner code
paths and the Node ESM CSS/react/env loader registrations now that
the Vite ModuleRunner is the sole dev:ssr loader (upstream PR #47).
No public API changes that bidoof relies on.

The undocumented \`VPRS_RUNNER=0\` opt-out introduced in 1.6.0 is
gone — bidoof never set it, so this is a no-op for runtime
behaviour.

## Test plan
- [x] \`npm install\` clean.
- [x] \`npm run build\` — 5 static pages rendered in 759ms.
- [ ] CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)