### PR TITLE
chore: bump vite-plugin-react-server to ^1.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^1.7.0"
+        "vite-plugin-react-server": "^1.7.1"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
@@ -2096,9 +2096,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.7.0.tgz",
-      "integrity": "sha512-kytKXsP7p34tHbDlcxuiovrT7nAhjKNll54UQzyLXo51n7QcG4A4eWnAgpNmW1Z9vORfapf1faNnkGM9mmTSCA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.7.1.tgz",
+      "integrity": "sha512-b/id/q1ztgG+DcJOIi1XBoqu8xW2g2H06/ulGJTdS4NmWpb8YzkDgAFX7waxSwyBN21sXytpyD9MobF/X8xElw==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^1.7.0"
+    "vite-plugin-react-server": "^1.7.1"
   }
 }


### PR DESCRIPTION
## Summary

Bumps `vite-plugin-react-server` from `^1.7.0` to `^1.7.1`. The 1.7.1 release surfaces previously-swallowed page/root module-load errors in dev (both `dev:rsc` and `dev:ssr`) — see vprs PR #49.

## Test plan

- [x] `npm install` clean
- [x] `npm run build:preview` — 5 pages render
- [x] Playwright e2e (run from vprs against this repo linked) — 20/20 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)