### PR TITLE
chore: bump vite-plugin-react-server to ^1.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^1.7.1"
+        "vite-plugin-react-server": "^1.8.0"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
@@ -2096,9 +2096,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.7.1.tgz",
-      "integrity": "sha512-b/id/q1ztgG+DcJOIi1XBoqu8xW2g2H06/ulGJTdS4NmWpb8YzkDgAFX7waxSwyBN21sXytpyD9MobF/X8xElw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.8.0.tgz",
+      "integrity": "sha512-hv56grbQ/S3tVl014Agj68JmtaBmhKYoL+OlKbKofqg1Rde7BlTRkZA5DSyPKP5CXn9DGXSdZqN8FBfV1y2c4A==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^1.7.1"
+    "vite-plugin-react-server": "^1.8.0"
   }
 }


### PR DESCRIPTION
## Summary

Bumps `vite-plugin-react-server` from `^1.7.1` to `^1.8.0`.

1.8.0 is an additive, non-breaking minor: opt-in `./utils/rsc-client` subpath plus public hosting of the vendored `react-server-dom-esm` (with an ESM `client.browser` entry). Nothing this demo imports changes — just picking up the new release.

## Test plan

- [x] `npm install` clean (vprs 1.8.0)
- [x] `npm run build` (`--app`) — 5 pages rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)