### PR TITLE
chore: bump vite-plugin-react-server to ^1.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^1.8.0"
+        "vite-plugin-react-server": "^1.9.0"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
@@ -2096,9 +2096,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.8.0.tgz",
-      "integrity": "sha512-hv56grbQ/S3tVl014Agj68JmtaBmhKYoL+OlKbKofqg1Rde7BlTRkZA5DSyPKP5CXn9DGXSdZqN8FBfV1y2c4A==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.9.0.tgz",
+      "integrity": "sha512-kE0BvJUZfEjznCNhVyrwZVpiynPFsnrewlLbrG5A6DFsr/U8/dnIBrUDnaIDLwbotAe7sxLqe49B1ruVQLTjng==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^1.8.0"
+    "vite-plugin-react-server": "^1.9.0"
   }
 }


### PR DESCRIPTION
## Summary

Bumps `vite-plugin-react-server` from `^1.8.0` to `^1.9.0` (additive, non-breaking: adds the `vite-plugin-react-server/storybook` preset + a build fix). Nothing this demo imports changes.

## Test plan

- [x] `npm install` clean (vprs 1.9.0)
- [x] `npm run build` (`--app`) — 5 pages rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)