### PR TITLE
chore: bump vite-plugin-react-server to ^1.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^1.9.0"
+        "vite-plugin-react-server": "^1.10.0"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
@@ -2096,9 +2096,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.9.0.tgz",
-      "integrity": "sha512-kE0BvJUZfEjznCNhVyrwZVpiynPFsnrewlLbrG5A6DFsr/U8/dnIBrUDnaIDLwbotAe7sxLqe49B1ruVQLTjng==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.10.0.tgz",
+      "integrity": "sha512-rMRPPnuGoIGgpN/LEwRHoJPEKyNv0z4kkSwgXV9RCfckK7lzSONsy6Hi0ZSfF+J/0g6d2l47V+H9TE7e15Qx7A==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^1.9.0"
+    "vite-plugin-react-server": "^1.10.0"
   }
 }


### PR DESCRIPTION
## Summary

Bumps `vite-plugin-react-server` from `^1.9.0` to `^1.10.0` and updates the lockfile.

1.10.0 adds directive-based `"use client"` hosting — a top-of-file `"use client"` directive is now detected, hosted, and emitted as a client chunk in the static build, so the `.client.` filename suffix is no longer required. It also fixes handling of compound client filenames (e.g. `X.Y.tsx`) in the static build. This bump picks those up.

## Test plan

- [x] `npm install` — installed version confirmed `1.10.0`
- [x] `npm run build` passes — static build rendered 5 pages successfully (the meaningful signal for 1.10.0's static-build changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)