### PR TITLE
chore: bump vite-plugin-react-server to ^1.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^1.10.0"
+        "vite-plugin-react-server": "^1.11.0"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
@@ -2096,9 +2096,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.10.0.tgz",
-      "integrity": "sha512-rMRPPnuGoIGgpN/LEwRHoJPEKyNv0z4kkSwgXV9RCfckK7lzSONsy6Hi0ZSfF+J/0g6d2l47V+H9TE7e15Qx7A==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.11.0.tgz",
+      "integrity": "sha512-dkQ5NiTW3R/q9w9G0hmQrh1qnEEBuD4HniU7+YkrOEZsmxD2F2ycufxrRdRiOQcK4+vMPDlVy5VTMg8qkuZ8bg==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^1.10.0"
+    "vite-plugin-react-server": "^1.11.0"
   }
 }


### PR DESCRIPTION
## Summary

Bumps `vite-plugin-react-server` from `^1.10.0` to `^1.11.0`.

### Highlights from 1.11.0

- **Storybook static build fix.** `storybook build` previously broke for any vprs consumer (dangling `virtual:react-server/hmr` import, manager never booted). Now resolved via a `resolveId`+`load` stub. Affects Chromatic / hosted Storybook / visual-regression pipelines.
- **Unified client-module detector.** The 11 places across the plugin that each answered "is this a client module?" now route through one helper. Default behaviour tightened: the `loader.isClientComponent*` defaults moved from a loose substring matcher to the strict `.client.[cm]?[jt]sx?$` filename OR top-of-file `"use client"` directive form. Consumers using the canonical conventions (every realistic case) are unaffected.
- **`await worker.terminate()`** in the static-build cleanup finally blocks. Eliminates a post-build async leak where libuv-level handles in the worker could fire after the build's promise resolved, racing the caller's cwd restoration.
- `createRollupLikeHash` dedup (internal), new docs page on module-resolution escape hatches.

## Verification

- `npm install` resolves `vite-plugin-react-server@1.11.0`.
- `npm run build` passes end-to-end (client build + SSR build + static page render of all 5 pages). This is exactly the path that 1.11.0's `await worker.terminate()` cleanup improves, so a green build here is the meaningful signal.

## Test plan

- [x] `npm install` updates lockfile to 1.11.0
- [x] `npm run build` completes without errors
- [ ] Optional: re-run on CI to confirm no regression in the published build pipeline