### PR TITLE
chore: bump vite-plugin-react-server to ^1.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^1.11.0"
+        "vite-plugin-react-server": "^1.11.1"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
@@ -2096,9 +2096,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.11.0.tgz",
-      "integrity": "sha512-dkQ5NiTW3R/q9w9G0hmQrh1qnEEBuD4HniU7+YkrOEZsmxD2F2ycufxrRdRiOQcK4+vMPDlVy5VTMg8qkuZ8bg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.11.1.tgz",
+      "integrity": "sha512-jwHCxAwzCvroL7zGZZdUn6tPU5z6Jp7te5nRQj7OGQETR/W2uWRrs3Fl9Mjiv95gRPMXdLt/cJNZ3hIGnvm1EQ==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^1.11.0"
+    "vite-plugin-react-server": "^1.11.1"
   }
 }


### PR DESCRIPTION
Picks up the 1.11.1 hotfix for the `src/client.tsx`-entry filename-detection regression. Build passes locally.