### PR TITLE
chore: bump vite-plugin-react-server to ^1.11.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^1.11.1"
+        "vite-plugin-react-server": "^1.11.2"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
@@ -2096,9 +2096,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.11.1.tgz",
-      "integrity": "sha512-jwHCxAwzCvroL7zGZZdUn6tPU5z6Jp7te5nRQj7OGQETR/W2uWRrs3Fl9Mjiv95gRPMXdLt/cJNZ3hIGnvm1EQ==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.11.2.tgz",
+      "integrity": "sha512-o9EKmEvKSTtvHrBhYSwdjvfvckylHz/5GcBYfRqd1nrikf4ED0dyZrKHeDQUZsM+y1fE+Ep1P4qEgRXybf3b6w==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^1.11.1"
+    "vite-plugin-react-server": "^1.11.2"
   }
 }


### PR DESCRIPTION
Picks up 1.11.2 — autoDiscover no longer competes with index.html for entry-point discovery.