### PR TITLE
chore: bump vite-plugin-react-server to ^1.11.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^1.11.3"
+        "vite-plugin-react-server": "^1.11.4"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
@@ -2096,9 +2096,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.11.3.tgz",
-      "integrity": "sha512-JM4fpBC/Z+jGbHTFsT3PITRPAqzXKPGPcXCLpPdP9Fyezp7rQGrjyYn6u3DM+glLglQzQjIPUCW6kk6eGkivCA==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.11.4.tgz",
+      "integrity": "sha512-LAtwRA1dkWTUm/yuDswmrvz+TFYKWEVSejGrq8ZhgxFbfo2vM27fCs6dFzAjqC4s9tuRgMrSg6IMvKQ9Rgt2Iw==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^1.11.3"
+    "vite-plugin-react-server": "^1.11.4"
   }
 }


### PR DESCRIPTION
Picks up vite-plugin-react-server 1.11.4 — per-environment `resolve.conditions` fix.