### PR TITLE
chore: migrate to vite-plugin-react-server 2.0 (stable React 19.2.7)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^1.11.3"
+        "vite-plugin-react-server": "^1.11.4"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
@@ -2096,9 +2096,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.11.3.tgz",
-      "integrity": "sha512-JM4fpBC/Z+jGbHTFsT3PITRPAqzXKPGPcXCLpPdP9Fyezp7rQGrjyYn6u3DM+glLglQzQjIPUCW6kk6eGkivCA==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.11.4.tgz",
+      "integrity": "sha512-LAtwRA1dkWTUm/yuDswmrvz+TFYKWEVSejGrq8ZhgxFbfo2vM27fCs6dFzAjqC4s9tuRgMrSg6IMvKQ9Rgt2Iw==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^1.11.4"
+        "vite-plugin-react-server": "^2.0.1"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
@@ -19,8 +19,8 @@
         "@types/react-dom": "^19.0.3",
         "acorn-loose": "^8.4.0",
         "happy-dom": "^17.1.8",
-        "react": "0.0.0-experimental-19baee81-20250725",
-        "react-dom": "0.0.0-experimental-19baee81-20250725",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
         "tsx": "^4.19.2",
         "vite": "^6.3.2",
         "webpack-sources": "^3.3.0"
@@ -1696,24 +1696,42 @@
       }
     },
     "node_modules/react": {
-      "version": "0.0.0-experimental-19baee81-20250725",
-      "resolved": "https://registry.npmjs.org/react/-/react-0.0.0-experimental-19baee81-20250725.tgz",
-      "integrity": "sha512-RQ+gon4KiEkTIyOyYeJ2g62UFj6nFNu2shh8nupRI5FXvLyaZhSuuSbHYOwk3YDJQ3cxDxCPaCYWG77G5+Af9g==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "0.0.0-experimental-19baee81-20250725",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.0.0-experimental-19baee81-20250725.tgz",
-      "integrity": "sha512-EQPmbE9e7cb3EIQDbFPQ2Iw32SIAb6hmHbz6L9SAKMn8HA5vDyhbgfPgPPMKrzwbWkaiYrwBr0SjQzABrVSkPw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "0.0.0-experimental-19baee81-20250725"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "0.0.0-experimental-19baee81-20250725"
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-server-loader": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.8.tgz",
+      "integrity": "sha512-4xYQ2QkP24Jw49hkrVXCjn97Jg1RpNS20n+kqINhABvgNgD8SKYWBNfaXiPGZg2ZfGvqgPTSZm2bHulD1eACDg==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "picocolors": "^1.1.1",
+        "source-map": "^0.7.6"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -1792,9 +1810,9 @@
       "license": "MIT"
     },
     "node_modules/scheduler": {
-      "version": "0.0.0-experimental-19baee81-20250725",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.0.0-experimental-19baee81-20250725.tgz",
-      "integrity": "sha512-XQeExbFQ3VCw4PV/OV7mA9EuYVNB6KvzqrIb17mXp5UjlQFRuUEcUDv7YDdiLc6yVf6VQc+aFBWvd2bXLBiDDw==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/send": {
@@ -1918,6 +1936,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/source-map-js": {
@@ -2096,26 +2123,23 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.11.4.tgz",
-      "integrity": "sha512-LAtwRA1dkWTUm/yuDswmrvz+TFYKWEVSejGrq8ZhgxFbfo2vM27fCs6dFzAjqC4s9tuRgMrSg6IMvKQ9Rgt2Iw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.1.tgz",
+      "integrity": "sha512-tbqPdjPTL/GkeCUwGf4tw1gPvboLsjn4j6fSCZ7rsUs66QIp7iZTj6SNQ3i+kMKTBzaoJ1WmyFvQizqjOYcmWQ==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
+        "react-server-loader": "^19.2.8",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
-      },
-      "bin": {
-        "check-react-version": "scripts/check-react-version.mjs",
-        "patch": "bin/patch.mjs"
       },
       "engines": {
         "node": "^23.7.0"
       },
       "peerDependencies": {
-        "react": ">=0.0.0-experimental-0 <1.0.0",
-        "react-dom": ">=0.0.0-experimental-0 <1.0.0",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
         "vite": "*"
       },
       "peerDependenciesMeta": {
@@ -2124,9 +2148,6 @@
         },
         "react-dom": {
           "optional": false
-        },
-        "react-server-dom-esm": {
-          "optional": true
         },
         "vite": {
           "optional": false

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build:client:dev": "npm run env:dev -- vite build --ssr --mode development",
     "build:server:dev": "npm run env:dev -- NODE_OPTIONS='--conditions=react-server' vite build --ssr --mode development",
     "debug-build": "npm run build:static:dev && npm run build:client:dev && npm run build:server:dev",
-    "clean-install": "npm install react@experimental react-dom@experimental",
+    "clean-install": "npm install react@^19.2.7 react-dom@^19.2.7",
     "patch-oss": "patch"
   },
   "author": "",
@@ -45,14 +45,14 @@
     "@types/react-dom": "^19.0.3",
     "acorn-loose": "^8.4.0",
     "happy-dom": "^17.1.8",
-    "react": "0.0.0-experimental-19baee81-20250725",
-    "react-dom": "0.0.0-experimental-19baee81-20250725",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "tsx": "^4.19.2",
     "vite": "^6.3.2",
     "webpack-sources": "^3.3.0"
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^1.11.4"
+    "vite-plugin-react-server": "^2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^1.11.3"
+    "vite-plugin-react-server": "^1.11.4"
   }
 }


### PR DESCRIPTION
Migrates the official demo/template to **vite-plugin-react-server 2.0**.

## Changes
- `vite-plugin-react-server` `^1.11.4` → `^2.0.1`
- `react` / `react-dom`: experimental → `^19.2.7` (vprs 2.0 runs on **stable React**; experimental is no longer required)
- `clean-install` script now targets stable React

vprs 2.0 moved the RSC transport into `react-server-loader` (installed automatically; bare `react-server-dom-esm/*` imports still resolve). **No plugin / `vite.config` / page changes were required.**

## Verification
- `npm run build` (`--app`): all 5 pages render, server + client + static targets build clean.
- `npm run dev:rsc`: serves the HTML shell and the RSC stream (HTTP 200).
- Home page renders in-browser (Playwright) with **zero console errors**.

> Note: this branch also carries the previously-unmerged `^1.11.4` bump commit, so the net effect brings `main` from `1.11.3` straight to `2.0.1`. Squash-merge if you'd prefer a single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)