### PR TITLE
style(home): dark background + higher-contrast url color

### DIFF
--- a/src/css/home.module.css
+++ b/src/css/home.module.css
@@ -1,6 +1,7 @@
 .Home {
     font-size: 50px;
     color: white;
+    background-color: #000008;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -13,7 +14,8 @@
 .Url {
     font-size: 20px;
     display: inline;
-    color: #0004ff;
+    color: #ffff;
+    background-color: #000008;
     text-decoration: underline;
     font-weight: bold;
 }


### PR DESCRIPTION
Small demo styling tweak on the home page: adds a dark background (`#000008`) to `.Home` and `.Url`, and bumps the URL link color to white for contrast against it.

Split out from the vprs 2.0 migration (#81) so it lands independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)