### PR TITLE
chore: bump vite-plugin-react-server to 2.0.6 + re-enable static Todo UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^2.0.5"
+        "vite-plugin-react-server": "^2.0.6"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
@@ -2735,9 +2735,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.5.tgz",
-      "integrity": "sha512-VRjQUB0O8oIWxa1b4C3O56BiFEPm1oD4l6WpP5cxH/D2MtvMfbO+cXeTWzI7kvClyfp7SmRhW5810xclmV9VtQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.6.tgz",
+      "integrity": "sha512-es8Xa6ITynGGWGjTAY6E1CT4TaXVMi/B3/8XOzPgu1+HA4JesyXkJIQ7X1WK6veNEyaIeHilAMHOJNKwtEs0Uw==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^2.0.5"
+    "vite-plugin-react-server": "^2.0.6"
   }
 }

--- a/src/page/todos/page.tsx
+++ b/src/page/todos/page.tsx
@@ -15,33 +15,11 @@ export async function Page({
   initialTodos,
   isGithubPages
 }: Props) {
-  if (isGithubPages) {
-    return (
-      <div className={styles["TodoList"]}>
-        <Link to="/" className={styles["Link"]}> back </Link>
-        <h1>Todo List</h1>
-        <p>
-          The todo demo is disabled on the GitHub Pages build because it relies
-          on server actions backed by a SQLite database, which a static host
-          can't run.
-        </p>
-        <p>To try it locally:</p>
-        <ol>
-          <li>
-            Clone{" "}
-            <a href="https://github.com/nicobrinkkemper/vite-plugin-react-server-demo-official">
-              the demo repo
-            </a>
-          </li>
-          <li><code>npm install</code></li>
-          <li>
-            <code>npm run dev:rsc</code> (server-first) or{" "}
-            <code>npm run dev:ssr</code> (client-first)
-          </li>
-        </ol>
-      </div>
-    );
-  }
+  // The Todo UI renders on every build, including the static GitHub Pages one
+  // — the static-host freeze (vprs 2.0.6, the headless-.rsc fix) is gone.
+  // Server actions (add/toggle/delete) are backed by SQLite and can't run on a
+  // static host, so TodoList shows a graceful "needs a database" message on
+  // those (it receives `isGithubPages` for exactly that).
   return (
     <div className={styles["TodoList"]}>
       <Link to="/" className={styles["Link"]}> back </Link>


### PR DESCRIPTION
Bumps `vite-plugin-react-server` `^2.0.5` → `^2.0.6` (fixes the static/no-backend freeze: headless `.rsc` no longer leaks the full `<html>`; rsdom browser client resolves dev/prod from the mirrored mode).

Now that the freeze is fixed, **re-enables the Todo UI on static / GitHub-Pages builds** — the live `TodoList` renders instead of the 'disabled' placeholder. Server actions are SQLite-backed and can't persist on a static host, so they show TodoList's graceful 'needs a database' message; the UI itself is interactive and freeze-free.

Verified: `vite build --app` (and `GITHUB_PAGES=true`) renders clean; `/todos/` renders the live form, typing is responsive, no `<html>`-in-`#root` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)