### PR TITLE
feat: Todo app works client-side on static hosts + restore Todos nav link

### DIFF
--- a/src/components/TodoList.client.tsx
+++ b/src/components/TodoList.client.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useState } from 'react';
+import { usePersistentState } from '../hooks/usePersistentState.js';
 
 type Todo = {
   id: number;
@@ -31,7 +32,12 @@ export function TodoList({
   styles,
   isGithubPages
 }: Props) {
-  const [todos, setTodos] = useState<Todo[]>(initialTodos);
+  // On a static host (no backend) the changes only live in React state, so they
+  // would vanish on refresh. usePersistentState mirrors them to localStorage so
+  // add/toggle/delete/edit survive a reload. With a backend (NOT isGithubPages)
+  // it's disabled and behaves exactly like plain useState — the server actions
+  // are the source of truth and localStorage is left untouched.
+  const [todos, setTodos] = usePersistentState<Todo[]>('bidoof.todos', initialTodos, isGithubPages);
   const [newTodo, setNewTodo] = useState('');
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editText, setEditText] = useState('');
@@ -160,7 +166,7 @@ export function TodoList({
 
       {isGithubPages && (
         <p style={{ fontSize: '0.85em', opacity: 0.75, margin: '0.5em 0' }}>
-          ⚠️ No backend connected — changes work in the UI but aren’t saved (a refresh resets them).
+          💾 No backend — changes are saved in your browser (localStorage), not on a server.
         </p>
       )}
 

--- a/src/components/TodoList.client.tsx
+++ b/src/components/TodoList.client.tsx
@@ -20,9 +20,9 @@ type Props = {
   isGithubPages: boolean;
 };
 
-export function TodoList({ 
-  initialTodos, 
-  addTodo, 
+export function TodoList({
+  initialTodos,
+  addTodo,
   toggleTodo,
   deleteTodo,
   editTodo,
@@ -40,6 +40,22 @@ export function TodoList({
 
   const remainingCount = todos.filter(todo => !todo.completed).length;
 
+  // On a static host (e.g. GitHub Pages) the SQLite-backed server actions have
+  // no server to run on, so each operation runs CLIENT-SIDE only: the UI is
+  // fully interactive, the changes just aren't persisted (a refresh resets
+  // them). With a backend the real server actions run and persist. Either way
+  // the success path below does the same local state update.
+  const runAdd = (title: string) =>
+    isGithubPages ? Promise.resolve({ success: true, id: Date.now() }) : addTodo(title);
+  const runToggle = (id: number) =>
+    isGithubPages ? Promise.resolve({ success: true }) : toggleTodo(id);
+  const runDelete = (id: number) =>
+    isGithubPages ? Promise.resolve({ success: true }) : deleteTodo(id);
+  const runEdit = (id: number, title: string) =>
+    isGithubPages ? Promise.resolve({ success: true }) : editTodo(id, title);
+  const runClear = () =>
+    isGithubPages ? Promise.resolve({ success: true }) : clearCompletedTodos();
+
   async function handleAddTodo(e: React.FormEvent) {
     e.preventDefault();
     if (!newTodo.trim()) return;
@@ -47,7 +63,7 @@ export function TodoList({
     setLoading(true);
     setError(null);
     try {
-      const result = await addTodo(newTodo);
+      const result = await runAdd(newTodo);
       if (result.success && result.id) {
         const newTodoItem: Todo = {
           id: result.id,
@@ -70,18 +86,14 @@ export function TodoList({
     setLoading(true);
     setError(null);
     try {
-      const result = await toggleTodo(id);
+      const result = await runToggle(id);
       if (result.success) {
-        setTodos(todos.map(todo => 
+        setTodos(todos.map(todo =>
           todo.id === id ? { ...todo, completed: !todo.completed } : todo
         ));
       }
     } catch (err) {
-      if (!isGithubPages) {
-        setError('Failed to toggle todo');
-      } else {
-        setError('Failed to toggle todo. Todo page is not supported on Github Pages, it uses a database.');
-      }
+      setError('Failed to toggle todo');
       console.error(err);
     } finally {
       setLoading(false);
@@ -92,16 +104,12 @@ export function TodoList({
     setLoading(true);
     setError(null);
     try {
-      const result = await deleteTodo(id);
+      const result = await runDelete(id);
       if (result.success) {
         setTodos(todos.filter(todo => todo.id !== id));
       }
     } catch (err) {
-      if (!isGithubPages) {
-        setError('Failed to delete todo');
-      } else {
-        setError('Failed to delete todo. Todo page is not supported on Github Pages, it uses a database.');
-      }
+      setError('Failed to delete todo');
       console.error(err);
     } finally {
       setLoading(false);
@@ -110,24 +118,20 @@ export function TodoList({
 
   async function handleEditTodo(id: number) {
     if (!editText.trim()) return;
-    
+
     setLoading(true);
     setError(null);
     try {
-      const result = await editTodo(id, editText);
+      const result = await runEdit(id, editText);
       if (result.success) {
-        setTodos(todos.map(todo => 
+        setTodos(todos.map(todo =>
           todo.id === id ? { ...todo, title: editText } : todo
         ));
         setEditingId(null);
         setEditText('');
       }
     } catch (err) {
-      if (!isGithubPages) {
-        setError('Failed to edit todo');
-      } else {
-        setError('Failed to edit todo. Todo page is not supported on Github Pages, it uses a database.');
-      }
+      setError('Failed to edit todo');
       console.error(err);
     } finally {
       setLoading(false);
@@ -138,16 +142,12 @@ export function TodoList({
     setLoading(true);
     setError(null);
     try {
-      const result = await clearCompletedTodos();
+      const result = await runClear();
       if (result.success) {
         setTodos(todos.filter(todo => !todo.completed));
       }
     } catch (err) {
-      if (!isGithubPages) {
-        setError('Failed to clear completed todos');
-      } else {
-        setError('Failed to clear completed todos. Todo page is not supported on Github Pages, it uses a database.');
-      }
+      setError('Failed to clear completed todos');
       console.error(err);
     } finally {
       setLoading(false);
@@ -157,9 +157,15 @@ export function TodoList({
   return (
     <div className={styles["todo-list"]}>
       <h1>Todo List</h1>
-      
+
+      {isGithubPages && (
+        <p style={{ fontSize: '0.85em', opacity: 0.75, margin: '0.5em 0' }}>
+          ⚠️ No backend connected — changes work in the UI but aren’t saved (a refresh resets them).
+        </p>
+      )}
+
       {error && <div className={styles["error-message"]}>{error}</div>}
-      
+
       <form onSubmit={handleAddTodo}>
         <input
           type="text"
@@ -176,7 +182,7 @@ export function TodoList({
       <div className={styles["todo-stats"]}>
         <span>{remainingCount === 0 ? '' : `${remainingCount} items left`}</span>
         {todos.some(todo => todo.completed) && (
-          <button 
+          <button
             onClick={handleClearCompleted}
             disabled={loading}
             className={styles["clear-completed"]}
@@ -196,7 +202,7 @@ export function TodoList({
               disabled={loading}
             />
             {editingId === todo.id ? (
-              <form 
+              <form
                 onSubmit={(e) => {
                   e.preventDefault();
                   handleEditTodo(todo.id);
@@ -211,8 +217,8 @@ export function TodoList({
                   autoFocus
                 />
                 <button type="submit" disabled={loading}>Save</button>
-                <button 
-                  type="button" 
+                <button
+                  type="button"
                   onClick={() => {
                     setEditingId(null);
                     setEditText('');
@@ -224,7 +230,7 @@ export function TodoList({
               </form>
             ) : (
               <>
-                <span 
+                <span
                   style={{ textDecoration: todo.completed ? 'line-through' : 'none' }}
                   onDoubleClick={() => {
                     setEditingId(todo.id);
@@ -233,10 +239,10 @@ export function TodoList({
                 >
                   {todo.title}
                 </span>
-                <button 
+                <button
                   onClick={() => handleDeleteTodo(todo.id)}
                   disabled={loading}
-                  className={styles["delete-button"]} 
+                  className={styles["delete-button"]}
                 >
                   ×
                 </button>
@@ -247,4 +253,4 @@ export function TodoList({
       </ul>
     </div>
   );
-} 
+}

--- a/src/hooks/usePersistentState.ts
+++ b/src/hooks/usePersistentState.ts
@@ -1,0 +1,64 @@
+import React from "react";
+
+/**
+ * A drop-in replacement for `useState` that, when `enabled`, mirrors the value
+ * to `localStorage` and rehydrates from it. Think of it as a tiny Apollo-style
+ * local cache fallback — no dependency, no backend required.
+ *
+ * HYDRATION SAFETY: this hook is used inside a "use client" component that is
+ * rendered from an SSG'd / streamed RSC tree. The first client render MUST
+ * match the server render, which used `initial`. So we deliberately DO NOT read
+ * `localStorage` in the `useState` initializer — doing so would make the first
+ * client render differ from the server HTML and trigger a React hydration
+ * mismatch (#418 / "did not match"). Instead we:
+ *   1. Initialize state to `initial` (identical to the server render).
+ *   2. After mount, in an effect, read `localStorage` and `setState` if a
+ *      stored value exists (this runs only on the client, after hydration).
+ *   3. In another effect, write to `localStorage` whenever the value changes.
+ *
+ * When `enabled` is false this behaves exactly like plain `useState`:
+ * `localStorage` is never read or written.
+ */
+export function usePersistentState<T>(
+  key: string,
+  initial: T,
+  enabled: boolean
+): [T, React.Dispatch<React.SetStateAction<T>>] {
+  const [value, setValue] = React.useState<T>(initial);
+
+  // Track whether we've already rehydrated so the write effect doesn't fire
+  // with `initial` before we've had a chance to read the stored value.
+  const hydratedRef = React.useRef(false);
+
+  // Step 2: rehydrate from localStorage after mount (client-only, post-hydration).
+  React.useEffect(() => {
+    if (!enabled || typeof window === "undefined") return;
+    try {
+      const stored = window.localStorage.getItem(key);
+      if (stored !== null) {
+        setValue(JSON.parse(stored) as T);
+      }
+    } catch {
+      // Corrupt/unreadable storage — fall back to `initial`, already in state.
+    } finally {
+      hydratedRef.current = true;
+    }
+    // Only rehydrate once, keyed by storage key / enabled flag.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, enabled]);
+
+  // Step 3: persist on change.
+  React.useEffect(() => {
+    if (!enabled || typeof window === "undefined") return;
+    // Wait until the initial rehydration pass has run so we don't clobber a
+    // stored value with `initial` on the very first commit.
+    if (!hydratedRef.current) return;
+    try {
+      window.localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // Storage full / unavailable — ignore, the UI still works in-memory.
+    }
+  }, [key, enabled, value]);
+
+  return [value, setValue];
+}

--- a/src/page/page.tsx
+++ b/src/page/page.tsx
@@ -4,7 +4,7 @@ import styles from "../css/home.module.css";
 import packageJson from "../../package.json" with { type: "json" };
 import { Counter } from "../components/Counter.client.js";
 import type { Props } from "./props.js";
-export const Page = ({ url, title, navigation, isGithubPages }: Props) => {
+export const Page = ({ url, title, navigation }: Props) => {
   return (
     <>
       <title>{title ?? "No title"}</title>
@@ -47,13 +47,11 @@ export const Page = ({ url, title, navigation, isGithubPages }: Props) => {
                 {navigation.toErrorExample.text}
               </Link>
             </li>
-            {!isGithubPages && (
-              <li>
-                <Link to={navigation.toTodos.href} className={styles["Url"]}>
-                  {navigation.toTodos.text}
-                </Link>
-              </li>
-            )}
+            <li>
+              <Link to={navigation.toTodos.href} className={styles["Url"]}>
+                {navigation.toTodos.text}
+              </Link>
+            </li>
           </ul>
           <dl>
             <dt>Build using node version</dt>


### PR DESCRIPTION
Now that the static-host freeze is fixed (vprs 2.0.6), make the Todo demo *useful* on a static build instead of erroring:

- On a static host (no backend), the SQLite-backed server actions can't persist, so add/toggle/delete/edit run **client-side**. They now also **persist to `localStorage`**, so they survive a page refresh — an Apollo-style local cache fallback with no new dependency. The note reads '💾 No backend — changes are saved in your browser (localStorage), not on a server.' With a backend, the real server actions run and persist; `localStorage` is untouched.
- Persistence lives in a small, **hydration-safe** `usePersistentState(key, initial, enabled)` hook (`src/hooks/usePersistentState.ts`). To avoid a React hydration mismatch in this SSG/RSC tree, the `useState` initializer keeps using `initial` (matching the server render); `localStorage` is read in a post-mount effect and written in a change effect, both guarded for `typeof window` and JSON parse errors. With a backend, `enabled` is false and it behaves exactly like plain `useState`.
- Re-adds the **Todos** link to the home nav (it was hidden on GitHub-Pages builds).

Verified on a `GITHUB_PAGES=true` static build served over plain HTTP, driven headless: add a todo + reload → it persists; toggle + reload → toggle persists; delete + reload → stays deleted; typing stays responsive; **no React hydration error** in the console (no #418 / 'did not match' / '<html> cannot be a child' — zero console errors). A normal `vite build --app` (no `GITHUB_PAGES`) still builds the server-actions path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)