### PR TITLE
fix(todos): base-aware back link (was hardcoded to="/", broke on GitHub Pages base path)

### DIFF
--- a/src/page/todos/page.tsx
+++ b/src/page/todos/page.tsx
@@ -13,7 +13,8 @@ export async function Page({
   clearCompletedTodos,
   getTodos,
   initialTodos,
-  isGithubPages
+  isGithubPages,
+  navigation,
 }: Props) {
   // The Todo UI renders on every build, including the static GitHub Pages one
   // — the static-host freeze (vprs 2.0.6, the headless-.rsc fix) is gone.
@@ -22,7 +23,7 @@ export async function Page({
   // those (it receives `isGithubPages` for exactly that).
   return (
     <div className={styles["TodoList"]}>
-      <Link to={import.meta.env.BASE_URL === "" ? "/" : import.meta.env.BASE_URL} className={styles["Link"]}> back </Link>
+      <Link to={navigation.back.href} className={styles["Link"]}>{navigation.back.text}</Link>
       <TodoList
         initialTodos={initialTodos}
         addTodo={addTodo}

--- a/src/page/todos/page.tsx
+++ b/src/page/todos/page.tsx
@@ -22,7 +22,7 @@ export async function Page({
   // those (it receives `isGithubPages` for exactly that).
   return (
     <div className={styles["TodoList"]}>
-      <Link to="/" className={styles["Link"]}> back </Link>
+      <Link to={import.meta.env.BASE_URL === "" ? "/" : import.meta.env.BASE_URL} className={styles["Link"]}> back </Link>
       <TodoList
         initialTodos={initialTodos}
         addTodo={addTodo}

--- a/src/page/todos/props.ts
+++ b/src/page/todos/props.ts
@@ -34,6 +34,12 @@ export const props = async () => {
     getTodos,
     initialTodos,
     isGithubPages,
+    navigation: {
+      back: {
+        href: `${import.meta.env.BASE_URL === "" ? "/" : import.meta.env.BASE_URL}`,
+        text: "Back",
+      },
+    },
   };
 };
 


### PR DESCRIPTION
The Todos page's "back" link used `to="/"`, which resolves to the **domain** root and ignores the app **base path** — so on the GitHub-Pages deploy (base `/vite-plugin-react-server-demo-official/`) it navigated off the app, while every other page's back link worked (they build it from `import.meta.env.BASE_URL` via `props.navigation.back`).

Fix: build the Todos back link from `import.meta.env.BASE_URL` the same way. Pre-existing (`to="/"` in both the old disabled-message branch and the live one), surfaced by re-enabling the Todos page on static builds.

Verified on a base-pathed build: the back link `href` is now `/vite-plugin-react-server-demo-official/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)