### PR TITLE
refactor(todos): use the shared navigation.back pattern for the back link

### DIFF
--- a/src/page/todos/page.tsx
+++ b/src/page/todos/page.tsx
@@ -13,7 +13,8 @@ export async function Page({
   clearCompletedTodos,
   getTodos,
   initialTodos,
-  isGithubPages
+  isGithubPages,
+  navigation,
 }: Props) {
   // The Todo UI renders on every build, including the static GitHub Pages one
   // — the static-host freeze (vprs 2.0.6, the headless-.rsc fix) is gone.
@@ -22,7 +23,7 @@ export async function Page({
   // those (it receives `isGithubPages` for exactly that).
   return (
     <div className={styles["TodoList"]}>
-      <Link to={import.meta.env.BASE_URL === "" ? "/" : import.meta.env.BASE_URL} className={styles["Link"]}> back </Link>
+      <Link to={navigation.back.href} className={styles["Link"]}>{navigation.back.text}</Link>
       <TodoList
         initialTodos={initialTodos}
         addTodo={addTodo}

--- a/src/page/todos/page.tsx
+++ b/src/page/todos/page.tsx
@@ -22,7 +22,7 @@ export async function Page({
   // those (it receives `isGithubPages` for exactly that).
   return (
     <div className={styles["TodoList"]}>
-      <Link to="/" className={styles["Link"]}> back </Link>
+      <Link to={import.meta.env.BASE_URL === "" ? "/" : import.meta.env.BASE_URL} className={styles["Link"]}> back </Link>
       <TodoList
         initialTodos={initialTodos}
         addTodo={addTodo}

--- a/src/page/todos/props.ts
+++ b/src/page/todos/props.ts
@@ -34,6 +34,12 @@ export const props = async () => {
     getTodos,
     initialTodos,
     isGithubPages,
+    navigation: {
+      back: {
+        href: `${import.meta.env.BASE_URL === "" ? "/" : import.meta.env.BASE_URL}`,
+        text: "Back",
+      },
+    },
   };
 };
 

--- a/src/page/todos/props.ts
+++ b/src/page/todos/props.ts
@@ -2,6 +2,12 @@ import { addTodo, toggleTodo, deleteTodo, editTodo, clearCompletedTodos, getTodo
 
 export const props = async () => {
   const isGithubPages = process.env.GITHUB_PAGES === 'true';
+  const navigation = {
+    back: {
+      href: `${import.meta.env.BASE_URL === "" ? "/" : import.meta.env.BASE_URL}`,
+      text: "Back",
+    },
+  };
   if (isGithubPages) {
     return {
       title: "Todos",
@@ -13,12 +19,7 @@ export const props = async () => {
       getTodos,
       initialTodos: [],
       isGithubPages,
-      navigation: {
-        back: {
-          href: `${import.meta.env.BASE_URL === "" ? "/" : import.meta.env.BASE_URL}`,
-          text: "Back",
-        },
-      },
+      navigation,
     };
   }
   let initialTodos = await getTodos();
@@ -40,12 +41,7 @@ export const props = async () => {
     getTodos,
     initialTodos,
     isGithubPages,
-    navigation: {
-      back: {
-        href: `${import.meta.env.BASE_URL === "" ? "/" : import.meta.env.BASE_URL}`,
-        text: "Back",
-      },
-    },
+    navigation,
   };
 };
 

--- a/src/page/todos/props.ts
+++ b/src/page/todos/props.ts
@@ -13,6 +13,12 @@ export const props = async () => {
       getTodos,
       initialTodos: [],
       isGithubPages,
+      navigation: {
+        back: {
+          href: `${import.meta.env.BASE_URL === "" ? "/" : import.meta.env.BASE_URL}`,
+          text: "Back",
+        },
+      },
     };
   }
   let initialTodos = await getTodos();


### PR DESCRIPTION
Switches the Todos back link to `props.navigation.back` like the other pages (instead of the inline `BASE_URL`), and adds `navigation.back` to the `isGithubPages` props branch too — without it, the GitHub-Pages build crashed in SSG (`Cannot read properties of undefined (reading 'back')`). Verified: base-pathed build renders all pages, back link href = the base path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)