### PR TITLE
feat(bidoof): walking sprites, JSON viewer, and BDSP title art

### DIFF
--- a/src/components/JsonViewer.tsx
+++ b/src/components/JsonViewer.tsx
@@ -1,0 +1,114 @@
+import * as React from "react";
+import styles from "../css/jsonViewer.module.css";
+
+interface JsonViewerProps {
+  /** HTTP method label shown in the request bar. */
+  method?: string;
+  /** Request URL shown in the header. */
+  endpoint: string;
+  /** JSON payload to render. */
+  data: unknown;
+}
+
+interface JsonNodeProps {
+  value: unknown;
+  depth: number;
+}
+
+/**
+ * Renders a single JSON value with syntax highlighting for prerendered output.
+ */
+function JsonNode({ value, depth }: JsonNodeProps) {
+  const pad = "  ".repeat(depth);
+
+  if (value === null) {
+    return <span className={styles["Null"]}>null</span>;
+  }
+
+  if (typeof value === "boolean") {
+    return <span className={styles["Boolean"]}>{String(value)}</span>;
+  }
+
+  if (typeof value === "number") {
+    return <span className={styles["Number"]}>{String(value)}</span>;
+  }
+
+  if (typeof value === "string") {
+    return <span className={styles["String"]}>{JSON.stringify(value)}</span>;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return <span className={styles["Punctuation"]}>[]</span>;
+    }
+
+    return (
+      <>
+        <span className={styles["Punctuation"]}>[</span>
+        {value.map((item, index) => (
+          <React.Fragment key={index}>
+            {"\n"}
+            {"  ".repeat(depth + 1)}
+            <JsonNode value={item} depth={depth + 1} />
+            {index < value.length - 1 ? (
+              <span className={styles["Punctuation"]}>,</span>
+            ) : null}
+          </React.Fragment>
+        ))}
+        {"\n"}
+        {pad}
+        <span className={styles["Punctuation"]}>]</span>
+      </>
+    );
+  }
+
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>);
+
+    if (entries.length === 0) {
+      return <span className={styles["Punctuation"]}>{"{}"}</span>;
+    }
+
+    return (
+      <>
+        <span className={styles["Punctuation"]}>{"{"}</span>
+        {entries.map(([key, entryValue], index) => (
+          <React.Fragment key={key}>
+            {"\n"}
+            {"  ".repeat(depth + 1)}
+            <span className={styles["Key"]}>{JSON.stringify(key)}</span>
+            <span className={styles["Punctuation"]}>: </span>
+            <JsonNode value={entryValue} depth={depth + 1} />
+            {index < entries.length - 1 ? (
+              <span className={styles["Punctuation"]}>,</span>
+            ) : null}
+          </React.Fragment>
+        ))}
+        {"\n"}
+        {pad}
+        <span className={styles["Punctuation"]}>{"}"}</span>
+      </>
+    );
+  }
+
+  return <span className={styles["String"]}>{JSON.stringify(value)}</span>;
+}
+
+/**
+ * Server-rendered JSON viewer with a request header and syntax-highlighted body.
+ */
+export function JsonViewer({ method = "GET", endpoint, data }: JsonViewerProps) {
+  return (
+    <section className={styles["Viewer"]} aria-label="API response">
+      <header className={styles["Header"]}>
+        <span className={styles["Method"]}>{method}</span>
+        <code className={styles["Endpoint"]}>{endpoint}</code>
+      </header>
+      <pre className={styles["Pre"]}>
+        <code className={styles["Code"]}>
+          <JsonNode value={data} depth={0} />
+        </code>
+      </pre>
+    </section>
+  );
+}

--- a/src/components/WalkingBidoof.client.tsx
+++ b/src/components/WalkingBidoof.client.tsx
@@ -1,26 +1,25 @@
 "use client";
 
 import * as React from "react";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 
 interface WalkingBidoofProps {
-  src: string;
+  srcBack: string;
+  srcFront: string;
   alt: string;
   index: number;
 }
 
-export const WalkingBidoof = ({ src, alt, index }: WalkingBidoofProps) => {
+export const WalkingBidoof = ({ srcBack, srcFront, alt, index }: WalkingBidoofProps) => {
   const [position, setPosition] = useState({
     x: Math.random() * 70 + 10, // Start between 10% and 80% of screen width
     y: Math.random() * 70 + 10, // Start between 10% and 80% of screen height
   });
-  
+
   const [velocity, setVelocity] = useState({
     x: (Math.random() - 0.5) * 0.5, // Random velocity between -0.25 and 0.25
     y: (Math.random() - 0.5) * 0.5,
   });
-
-  const [direction, setDirection] = useState<"left" | "right">("right");
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -34,7 +33,6 @@ export const WalkingBidoof = ({ src, alt, index }: WalkingBidoofProps) => {
         if (newX <= 0 || newX >= 90) {
           newVelocityX = -newVelocityX * (0.8 + Math.random() * 0.4);
           newX = Math.max(0, Math.min(90, newX));
-          setDirection(newVelocityX > 0 ? "right" : "left");
         }
         if (newY <= 0 || newY >= 90) {
           newVelocityY = -newVelocityY * (0.8 + Math.random() * 0.4);
@@ -45,7 +43,6 @@ export const WalkingBidoof = ({ src, alt, index }: WalkingBidoofProps) => {
         if (Math.random() < 0.02) {
           newVelocityX = (Math.random() - 0.5) * 0.8;
           newVelocityY = (Math.random() - 0.5) * 0.8;
-          setDirection(newVelocityX > 0 ? "right" : "left");
         }
 
         if (newVelocityX !== velocity.x || newVelocityY !== velocity.y) {
@@ -59,9 +56,14 @@ export const WalkingBidoof = ({ src, alt, index }: WalkingBidoofProps) => {
     return () => clearInterval(interval);
   }, [velocity]);
 
+  const absVx = Math.abs(velocity.x);
+  const absVy = Math.abs(velocity.y);
+  const facingBack = velocity.y < 0 && absVy >= absVx;
+  const flipMirror = facingBack ? velocity.x < 0 : velocity.x > 0;
+
   return (
     <img
-      src={src}
+      src={facingBack ? srcBack : srcFront}
       alt={alt}
       style={{
         position: "fixed",
@@ -70,7 +72,7 @@ export const WalkingBidoof = ({ src, alt, index }: WalkingBidoofProps) => {
         width: "120px",
         height: "120px",
         objectFit: "contain",
-        transform: direction === "left" ? "scaleX(-1)" : "scaleX(1)",
+        transform: flipMirror ? "scaleX(-1)" : "scaleX(1)",
         transition: "transform 0.3s ease",
         zIndex: 10 + index,
         pointerEvents: "none",
@@ -79,4 +81,3 @@ export const WalkingBidoof = ({ src, alt, index }: WalkingBidoofProps) => {
     />
   );
 };
-

--- a/src/css/bidoof.module.css
+++ b/src/css/bidoof.module.css
@@ -1,27 +1,46 @@
 .Bidoof {
     font-size: 50px;
-    background-color: #0F0;
+    background-color: rgb(0, 255, 0);
     color: white;
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
-    max-width: 100%;
-    min-width: 100px;
-    min-height: 100%;
+    justify-content: flex-start;
+    box-sizing: border-box;
+    width: 100%;
+    min-height: 100vh;
     padding: 0;
     margin: 0;
 }
+.JsonSection {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    width: min(1024px, calc(100% - 2rem));
+    min-height: 0;
+    margin: 1rem 1rem 1rem;
+    align-self: center;
+}
 
-.Code {
-    font-size: 20px;
-    background-color: #111;
-    max-width: 100%;
-    min-width: 100px;
-    overflow-x: auto;
-    color: white;
-    padding: 10px;
-    border-radius: 5px;
+.TitleRow {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    padding:2rem 0;
+    font-family:Verdana, Geneva, Tahoma, sans-serif
+}
+
+.Bidoof h1 {
+    margin: 0;
+    color: #3b2400
+}
+
+.TitleSprite {
+    width: 192px;
+    height: 192px;
+    object-fit: contain;
+    image-rendering: pixelated;
 }
 
 .Image {

--- a/src/css/bidoof.module.css.d.ts
+++ b/src/css/bidoof.module.css.d.ts
@@ -1,9 +1,11 @@
 declare const styles: {
     Bidoof: string;
-    Code: string;
     Image: string;
     Images: string;
+    JsonSection: string;
     Link: string;
+    TitleRow: string;
+    TitleSprite: string;
 };
 
-export default styles
+export default styles;

--- a/src/css/jsonViewer.module.css
+++ b/src/css/jsonViewer.module.css
@@ -1,0 +1,81 @@
+.Viewer {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    min-height: 0;
+    border-radius: 10px;
+    overflow: hidden;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+    border: 1px solid #30363d;
+    font-family: "Courier New", Courier, monospace;
+}
+
+.Header {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    background: #161b22;
+    border-bottom: 1px solid #30363d;
+    font-size: 0.9rem;
+}
+
+.Method {
+    flex-shrink: 0;
+    padding: 0.15rem 0.5rem;
+    border-radius: 4px;
+    background: #238636;
+    color: #ffffff;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    font-size: 0.75rem;
+}
+
+.Endpoint {
+    color: #c9d1d9;
+    overflow-x: auto;
+    white-space: nowrap;
+}
+
+.Pre {
+    flex: 1 1 auto;
+    min-height: 0;
+    margin: 0;
+    padding: 1rem 1.25rem;
+    background: #0d1117;
+    overflow: auto;
+    font-size: 0.85rem;
+    line-height: 1.6;
+}
+
+.Code {
+    color: #c9d1d9;
+    white-space: pre;
+}
+
+.Key {
+    color: #79c0ff;
+}
+
+.String {
+    color: #a5d6ff;
+}
+
+.Number {
+    color: #d2a8ff;
+}
+
+.Boolean {
+    color: #ff7b72;
+}
+
+.Null {
+    color: #8b949e;
+    font-style: italic;
+}
+
+.Punctuation {
+    color: #c9d1d9;
+}

--- a/src/css/jsonViewer.module.css.d.ts
+++ b/src/css/jsonViewer.module.css.d.ts
@@ -1,0 +1,16 @@
+declare const styles: {
+    Boolean: string;
+    Code: string;
+    Endpoint: string;
+    Header: string;
+    Key: string;
+    Method: string;
+    Null: string;
+    Number: string;
+    Pre: string;
+    Punctuation: string;
+    String: string;
+    Viewer: string;
+};
+
+export default styles;

--- a/src/page/bidoof/fallbackData.ts
+++ b/src/page/bidoof/fallbackData.ts
@@ -41,6 +41,8 @@ export const fallbackData = {
       name: "diamond-pearl",
       url: "https://pokeapi.co/api/v2/version-group/8/",
     },
+    bdspSprite:
+      "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-viii/brilliant-diamond-shining-pearl/399.png",
   };
 
   export type FallbackData = typeof fallbackData;

--- a/src/page/bidoof/page.tsx
+++ b/src/page/bidoof/page.tsx
@@ -1,7 +1,26 @@
 import { Link } from "../../components/Link.client.js";
+import { JsonViewer } from "../../components/JsonViewer.js";
 import styles from "../../css/bidoof.module.css";
 import * as React from "react";
 import type { Props } from "./props.js";
+import { WalkingBidoof } from "../../components/WalkingBidoof.client.js";
+
+/** Page metadata keys excluded from the API response viewer. */
+const pageMetaKeys = new Set([
+  "title",
+  "description",
+  "favicon",
+  "bidoofEndpoint",
+  "pokemonEndpoint",
+  "bdspSprite",
+  "navigation",
+]);
+
+function getApiResponse(props: Props) {
+  return Object.fromEntries(
+    Object.entries(props).filter(([key]) => !pageMetaKeys.has(key)),
+  );
+}
 
 export const Page = (props: Props) => {
   return (
@@ -12,44 +31,60 @@ export const Page = (props: Props) => {
         <Link to={props.navigation.back.href} className={styles["Link"]}>
           {props.navigation.back.text}
         </Link>
-        <h1>{props.name}</h1>
-        <div className={styles["Images"]}>
-          <img
-            src={props.sprites.front_shiny}
-            alt={props.name}
-            className={styles["Image"]}
-          />
-          <img
-            src={props.sprites.back_shiny}
-            alt={props.name}
-            className={styles["Image"]}
-          />
+        <div className={styles["TitleRow"]}>
+          <h1>{props?.title ?? props.name}</h1>
+          {props.bdspSprite ? (
+            <img
+              src={props.bdspSprite}
+              alt={`${props.name} Brilliant Diamond and Shining Pearl sprite`}
+              className={styles["TitleSprite"]}
+            />
+          ) : null}
         </div>
         <div className={styles["Images"]}>
-          <img
-            src={props.sprites.front_female}
+          <WalkingBidoof
+            srcBack={props.sprites.back_shiny}
+            srcFront={props.sprites.front_shiny}
             alt={props.name}
-            className={styles["Image"]}
+            index={0}
           />
-          <img
-            src={props.sprites.back_female}
+          <WalkingBidoof
+            srcBack={props.sprites.back_shiny}
+            srcFront={props.sprites.front_shiny}
             alt={props.name}
-            className={styles["Image"]}
+            index={1}
+          />
+          <WalkingBidoof
+            srcBack={props.sprites.back_female}
+            srcFront={props.sprites.front_female}
+            alt={props.name}
+            index={2}
+          />
+          <WalkingBidoof
+            srcBack={props.sprites.back_female}
+            srcFront={props.sprites.front_female}
+            alt={props.name}
+            index={3}
+          />
+          <WalkingBidoof
+            srcBack={props.sprites.back_shiny}
+            srcFront={props.sprites.front_shiny}
+            alt={props.name}
+            index={4}
+          />
+          <WalkingBidoof
+            srcBack={props.sprites.back_shiny}
+            srcFront={props.sprites.front_shiny}
+            alt={props.name}
+            index={5}
           />
         </div>
-        <div className={styles["Images"]}>
-          <img
-            src={props.sprites.front_shiny}
-            alt={props.name}
-            className={styles["Image"]}
-          />
-          <img
-            src={props.sprites.back_shiny}
-            alt={props.name}
-            className={styles["Image"]}
+        <div className={styles["JsonSection"]}>
+          <JsonViewer
+            endpoint={props.bidoofEndpoint}
+            data={getApiResponse(props)}
           />
         </div>
-        <code className={styles["Code"]}>{JSON.stringify(props)}</code>
       </div>
     </>
   );

--- a/src/page/bidoof/props.ts
+++ b/src/page/bidoof/props.ts
@@ -5,6 +5,8 @@ export const props = async () => {
     title: "Bidoof",
     description: "It's bidoof.",
     favicon: `${import.meta.env.PUBLIC_ORIGIN}${import.meta.env.BASE_URL}bidoof.png`,
+    bidoofEndpoint: "https://pokeapi.co/api/v2/pokemon-form/399/",
+    pokemonEndpoint: "https://pokeapi.co/api/v2/pokemon/399/",
     navigation: {
       back: {
         href: `${import.meta.env.BASE_URL === "" ? "/" : import.meta.env.BASE_URL}`,
@@ -16,24 +18,33 @@ export const props = async () => {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 5000); // 5s timeout
 
-    const res = await fetch("https://pokeapi.co/api/v2/pokemon-form/399/", {
-      signal: controller.signal,
-    });
+    const [formRes, pokemonRes] = await Promise.all([
+      fetch(baseProps.bidoofEndpoint, { signal: controller.signal }),
+      fetch(baseProps.pokemonEndpoint, { signal: controller.signal }),
+    ]);
     clearTimeout(timeoutId);
 
-    if (!res.ok) {
-      throw new Error(`Failed to fetch Bidoof: ${res.status}`);
+    if (!formRes.ok) {
+      throw new Error(`Failed to fetch Bidoof: ${formRes.status}`);
     }
-    const body = await res.json();
+    const body = await formRes.json();
+    const pokemon = pokemonRes.ok ? await pokemonRes.json() : null;
+    const bdspSprite =
+      pokemon?.sprites?.versions?.["generation-viii"]?.[
+        "brilliant-diamond-shining-pearl"
+      ]?.front_default ?? null;
+
     return {
       ...baseProps,
       ...(body as FallbackData),
+      bdspSprite,
     };
   } catch (error) {
     // Fallback data
     return {
       ...baseProps,
       ...fallbackData,
+      bdspSprite: fallbackData.bdspSprite,
     };
   }
 };


### PR DESCRIPTION
## Summary
- Replace static Bidoof sprite images with six `WalkingBidoof` instances that bounce around the page, switching between front/back sprites based on movement and mirroring correctly for each orientation
- Add a server-rendered `JsonViewer` with syntax highlighting for the PokeAPI form response, prerendered at build time and sized to grow to the bottom of the viewport
- Fetch the generation-viii Brilliant Diamond / Shining Pearl sprite from `/pokemon/399/` and display it beside the page title

## Test plan
- [ ] Open `/bidoof` and confirm six Bidoof wander the page with correct front/back sprites and horizontal mirroring
- [ ] Confirm the BDSP sprite appears next to the title
- [ ] Confirm the JSON viewer shows formatted, syntax-highlighted API data with a GET header bar
- [ ] Confirm the JSON panel expands to fill remaining viewport height with green background behind it
- [ ] Verify the page still prerender/builds successfully (`npm run build:static`)


Made with [Cursor](https://cursor.com)