### PR TITLE
style(error, bidoof): error-message layout + BDSP sprite placement + tidy

### DIFF
--- a/src/css/errorBoundary.module.css
+++ b/src/css/errorBoundary.module.css
@@ -9,13 +9,29 @@
     margin: 0;
     padding: 0;
 }
-.ErrorBoundary p {
+.ErrorMessage p {
     font-size: 1rem;
     margin: 0;
     padding: 0;
 }
-.ErrorBoundary pre {
+.ErrorMessage pre {
     font-size: 1rem;
+    margin: 0;
+    padding: 0;
+    max-width: 100vw;
+    overflow: scroll;
+    padding-bottom: 1rem;
+    color: white;
+}
+
+.ErrorMessage {
+    display: flex;
+    flex-direction: column;
+    max-width: 100vw;
+}
+.ErrorMessage h1 {
+    font-size: 2rem;
+    font-weight: bold;
     margin: 0;
     padding: 0;
 }

--- a/src/css/errorBoundary.module.css.d.ts
+++ b/src/css/errorBoundary.module.css.d.ts
@@ -1,5 +1,7 @@
 declare const styles: {
     ErrorBoundary: string;
+    ErrorMessage: string;
+    ErrorStack: string;
 };
 
 export default styles;

--- a/src/page/bidoof/page.tsx
+++ b/src/page/bidoof/page.tsx
@@ -33,13 +33,7 @@ export const Page = (props: Props) => {
         </Link>
         <div className={styles["TitleRow"]}>
           <h1>{props?.title ?? props.name}</h1>
-          {props.bdspSprite ? (
-            <img
-              src={props.bdspSprite}
-              alt={`${props.name} Brilliant Diamond and Shining Pearl sprite`}
-              className={styles["TitleSprite"]}
-            />
-          ) : null}
+
         </div>
         <div className={styles["Images"]}>
           <WalkingBidoof
@@ -84,7 +78,13 @@ export const Page = (props: Props) => {
             endpoint={props.bidoofEndpoint}
             data={getApiResponse(props)}
           />
-        </div>
+        </div>{props.bdspSprite ? (
+          <img
+            src={props.bdspSprite}
+            alt={`${props.name} Brilliant Diamond and Shining Pearl sprite`}
+            className={styles["TitleSprite"]}
+          />
+        ) : null}
       </div>
     </>
   );

--- a/src/page/error-example/page.tsx
+++ b/src/page/error-example/page.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { ErrorBoundary } from "../../components/ErrorBoundary.client.js";
 import { Link } from "../../components/Link.client.js";
 import type { Props } from "./props.js";
@@ -18,10 +17,10 @@ export const Page = (props: Props) => {
         <Link to={props.navigation.back.href} className={styles["Link"]}>
           {props.navigation.back.text}
         </Link>
-          <ErrorBoundary>
-            <p>This page rendered without errors.</p>
-            <TestError throwError={props.throwError} />
-          </ErrorBoundary>
+        <ErrorBoundary>
+          <p>This page rendered without errors.</p>
+          <TestError throwError={props.throwError} />
+        </ErrorBoundary>
       </div>
     </>
   );


### PR DESCRIPTION
CSS/layout tweaks (moved off `main` into a PR, as usual):

- **errorBoundary.module.css** — rework the error display: `.ErrorBoundary` → `.ErrorMessage` (matches `ErrorMessage.tsx`, which already uses `styles["ErrorMessage"]`), flex-column container, scrollable `<pre>` for long messages, `h1` styling.
- **bidoof/page.tsx** — move the BDSP sprite out of the title row to after the images.
- **error-example/page.tsx** — drop the unused React import, fix indentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)