### PR TITLE
test(fixture): client-graph CSS module on the always-visible Counter

### DIFF
--- a/src/components/Counter.client.tsx
+++ b/src/components/Counter.client.tsx
@@ -1,10 +1,11 @@
 "use client";
 import React from "react";
+import styles from "../css/counterStyles.module.css";
 
 export function Counter() {
   const [count, setCount] = React.useState<number>();
   return (
-    <button onClick={() => setCount((count ?? 0) + 1)}>
+    <button className={styles["Counter"]} onClick={() => setCount((count ?? 0) + 1)}>
       Click count: {count ?? 0}
     </button>
   );

--- a/src/css/counterStyles.module.css
+++ b/src/css/counterStyles.module.css
@@ -1,0 +1,11 @@
+/*
+ * Client-graph CSS module: imported directly by the "use client" component
+ * Counter.client.tsx. This lives in the CLIENT module graph (not the RSC
+ * server graph), which is the path exercised by vprs's dev:rsc client-CSS
+ * HMR regression test (test/e2e/dev-rsc-client-css-hmr.spec.ts in the vprs
+ * repo). The explicit rgb() color is asserted byte-for-byte by that test.
+ */
+.Counter {
+    color: rgb(255, 0, 0);
+    font-weight: bold;
+}

--- a/src/css/counterStyles.module.css.d.ts
+++ b/src/css/counterStyles.module.css.d.ts
@@ -1,0 +1,5 @@
+declare const styles: {
+    Counter: string;
+};
+
+export default styles


### PR DESCRIPTION
## Why

The vprs e2e suite needs a CSS module that lives **directly in the client module graph** and is **always visible** on first paint, to exercise dev:rsc HMR for client-component CSS.

Before this change, every `*.module.css` in this fixture was either:
- reachable through a **server** component (`home.module.css`, `todoStyles.module.css` — the latter is imported by the server page and passed into the client `TodoList` as a prop), or
- only rendered on error (`errorBoundary.module.css`, via the error boundary).

None covered the always-visible client-graph case.

## What

- New `src/css/counterStyles.module.css` (+ matching `.d.ts`) with a `.Counter` rule (explicit `rgb()` color asserted by the vprs test).
- `Counter.client.tsx` (`"use client"`) now imports it directly and applies `styles["Counter"]` to its button.

`Counter` is always rendered on the home page, so the CSS is in the client graph on first paint. No behavioral change to the demo beyond the button color/weight.

Pairs with the vprs PR adding `test/e2e/dev-rsc-client-css-hmr.spec.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)