### PR TITLE
chore: bump vite-plugin-react-server to 2.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^2.0.6"
+        "vite-plugin-react-server": "^2.0.7"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
@@ -2735,9 +2735,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.6.tgz",
-      "integrity": "sha512-es8Xa6ITynGGWGjTAY6E1CT4TaXVMi/B3/8XOzPgu1+HA4JesyXkJIQ7X1WK6veNEyaIeHilAMHOJNKwtEs0Uw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.7.tgz",
+      "integrity": "sha512-yrf0BIa31wUZaDODbXzVmdZPHZMAizLLGejEWXI3m51MCoYfT3WH9RitxlVNe0fW8sW25OyWNlAKBRAXd3gctg==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^2.0.6"
+    "vite-plugin-react-server": "^2.0.7"
   }
 }


### PR DESCRIPTION
Bumps vprs `^2.0.6` → `^2.0.7` to pick up the **dev:rsc client-graph CSS HMR fix**: editing a CSS module reached through a `"use client"` component now hot-updates in dev instead of requiring a manual refresh.

Build verified with 2.0.7 (renders all pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)