### PR TITLE
chore: bump vite-plugin-react-server to 2.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^2.0.7"
+        "vite-plugin-react-server": "^2.0.8"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
@@ -2735,9 +2735,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.7.tgz",
-      "integrity": "sha512-yrf0BIa31wUZaDODbXzVmdZPHZMAizLLGejEWXI3m51MCoYfT3WH9RitxlVNe0fW8sW25OyWNlAKBRAXd3gctg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.8.tgz",
+      "integrity": "sha512-ye2s2fWnHFMkdUvPRvd7qyHujIBvlKjM/fxReN47hz/n/E2813zQjG0dNV/8bP31TvHKPpJL1MBa5nMTdD+zqQ==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^2.0.7"
+    "vite-plugin-react-server": "^2.0.8"
   }
 }


### PR DESCRIPTION
Bumps `vite-plugin-react-server` to **^2.0.8**, picking up the dev:ssr client-graph CSS HMR fix (vprs #98) — client-graph CSS modules now hot-update under `dev:ssr` without a manual refresh.

Build verified: `npm run build` renders all 5 static pages clean against 2.0.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)