### PR TITLE
chore: bump vite-plugin-react-server to 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^2.0.7"
+        "vite-plugin-react-server": "^2.1.0"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
@@ -2735,9 +2735,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.7.tgz",
-      "integrity": "sha512-yrf0BIa31wUZaDODbXzVmdZPHZMAizLLGejEWXI3m51MCoYfT3WH9RitxlVNe0fW8sW25OyWNlAKBRAXd3gctg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.1.0.tgz",
+      "integrity": "sha512-Q0KuSSHCf31h3aGQahfwhaxTP0Ec2LJorMSWycH3acg1EhfO7aBPpR1AKRXG6/CHaAgwRErZ1ZgXce+tV8kKDA==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
@@ -2747,7 +2747,7 @@
         "vitefu": "^1.1.3"
       },
       "engines": {
-        "node": "^23.7.0"
+        "node": ">=22"
       },
       "peerDependencies": {
         "react": "^19.2.7",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^2.0.7"
+    "vite-plugin-react-server": "^2.1.0"
   }
 }


### PR DESCRIPTION
Updates vite-plugin-react-server from 2.0.7 to 2.1.0. Preview build verified against the new version: 5 pages rendered, no output changes.

Supersedes the stale chore/bump-vprs-2.0.8 branch, which never got a PR.

Release notes: https://github.com/nicobrinkkemper/vite-plugin-react-server/pull/120

🤖 Generated with [Claude Code](https://claude.com/claude-code)