### PR TITLE
chore: bump vite-plugin-react-server to 2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^2.1.0"
+        "vite-plugin-react-server": "^2.2.0"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
@@ -2288,9 +2288,9 @@
       }
     },
     "node_modules/react-server-loader": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.8.tgz",
-      "integrity": "sha512-4xYQ2QkP24Jw49hkrVXCjn97Jg1RpNS20n+kqINhABvgNgD8SKYWBNfaXiPGZg2ZfGvqgPTSZm2bHulD1eACDg==",
+      "version": "19.2.9",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.9.tgz",
+      "integrity": "sha512-UQ87YKr1S6rQb7kzfuBGZ1YOU0O/8JZkvO994py5l9R2p3UfkQigm3KH3hawP0Oxq9XBMHNEq922gBD3lXOyNA==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
@@ -2735,14 +2735,14 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.1.0.tgz",
-      "integrity": "sha512-Q0KuSSHCf31h3aGQahfwhaxTP0Ec2LJorMSWycH3acg1EhfO7aBPpR1AKRXG6/CHaAgwRErZ1ZgXce+tV8kKDA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.2.0.tgz",
+      "integrity": "sha512-dX1hscB7YDbDBkwsuvRBmaoXn/4UQveqt1ku5CQ7s4OMeiIB/wZvqJADA/RRjPcUszHjKXydZxDlovRWFXLHYA==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "react-server-loader": "^19.2.8",
+        "react-server-loader": "^19.2.8 || >=0.0.0-0 <0.0.1",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },
@@ -2750,8 +2750,8 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7",
+        "react": "^19.2.7 || >=0.0.0-0 <0.0.1",
+        "react-dom": "^19.2.7 || >=0.0.0-0 <0.0.1",
         "vite": "*"
       },
       "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^2.1.0"
+    "vite-plugin-react-server": "^2.2.0"
   }
 }


### PR DESCRIPTION
Bumps `vite-plugin-react-server` to **2.2.0** (and its transitive `react-server-loader` to 19.2.9).

2.2.0 keeps React out of the plugin-import graph and ships `react-server-loader` as a regular dependency, so the stable transport installs transitively — this demo needs no peer declaration, just the version bump. Lockfile updated; nothing else changes.