### PR TITLE
test: prod server-action e2e (+ fix broken server entry)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 dist
 node_modules
 todos.db
+# Playwright
+test-results
+playwright-report

--- a/e2e/todos.spec.ts
+++ b/e2e/todos.spec.ts
@@ -39,4 +39,22 @@ test.describe("todos server actions (prod build)", () => {
     await page.reload();
     await expect(page.locator("li", { hasText: title })).toHaveCount(0);
   });
+
+  test("a client component that directly imports a server function can call it", async ({
+    page,
+  }) => {
+    // ServerFnProbe is a "use client" component that imports getTodos (a
+    // "use server" action) directly and calls it on click. vprs rewrites the
+    // import to a createServerReference proxy, so the click round-trips to the
+    // server. Proves the client-import half of Server Functions parity in a
+    // real browser (server body never shipped; the call hits the server).
+    await page.goto("/todos/");
+    await page.waitForLoadState("networkidle");
+    await page.waitForTimeout(1000);
+
+    const probe = page.getByTestId("server-fn-probe");
+    await expect(probe).toHaveText("Probe server fn");
+    await probe.click();
+    await expect(probe).toHaveText(/server says: \d+ todos/);
+  });
 });

--- a/e2e/todos.spec.ts
+++ b/e2e/todos.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Prod server-action round-trip, end to end.
+ *
+ * Drives the production Express build (real `"use server"` actions backed by
+ * SQLite — not the GitHub-Pages stub path). Proves an action's effect actually
+ * persists server-side by reloading between steps: a client-only optimistic
+ * update would survive the first assert but NOT the post-reload one.
+ */
+test.describe("todos server actions (prod build)", () => {
+  test("add persists across reload, then delete persists", async ({ page }) => {
+    const title = `e2e-${Date.now()}`;
+
+    await page.goto("/todos/");
+    // The page is prerendered HTML; wait for the client bundle to hydrate before
+    // interacting, or the click lands before React attaches the handler.
+    await page.waitForLoadState("networkidle");
+    await page.waitForTimeout(1000);
+
+    // Add a uniquely-named todo via the real addTodo server action.
+    await page.getByPlaceholder("Add a new todo...").fill(title);
+    await page.getByRole("button", { name: "Add" }).click();
+    await expect(page.locator("li", { hasText: title })).toBeVisible();
+
+    // Reload: the todo must still be there — proves addTodo hit the DB, not just
+    // local component state.
+    await page.reload();
+    await expect(page.locator("li", { hasText: title })).toBeVisible();
+
+    // Delete it via the real deleteTodo server action.
+    await page
+      .locator("li", { hasText: title })
+      .getByRole("button", { name: "×" })
+      .click();
+    await expect(page.locator("li", { hasText: title })).toHaveCount(0);
+
+    // Reload: it must stay gone — proves deleteTodo persisted.
+    await page.reload();
+    await expect(page.locator("li", { hasText: title })).toHaveCount(0);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "vite-plugin-react-server": "^2.2.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.0",
         "@types/express": "^5.0.2",
         "@types/node": "^22.15.17",
         "@types/react": "^19.0.9",
@@ -773,6 +774,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2174,6 +2191,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^2.2.0"
+        "vite-plugin-react-server": "^2.3.1"
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
@@ -2352,9 +2352,9 @@
       }
     },
     "node_modules/react-server-loader": {
-      "version": "19.2.9",
-      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.9.tgz",
-      "integrity": "sha512-UQ87YKr1S6rQb7kzfuBGZ1YOU0O/8JZkvO994py5l9R2p3UfkQigm3KH3hawP0Oxq9XBMHNEq922gBD3lXOyNA==",
+      "version": "19.2.10",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.10.tgz",
+      "integrity": "sha512-5tjavvJvvijZmRXIBP+AxJPiKv8JdLa6EB/m4hqUyc8rg3kxPA6JIWtxh+n45VCj/f7JTrf2UuNSNw84RuNQ5g==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
@@ -2799,14 +2799,14 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.2.0.tgz",
-      "integrity": "sha512-dX1hscB7YDbDBkwsuvRBmaoXn/4UQveqt1ku5CQ7s4OMeiIB/wZvqJADA/RRjPcUszHjKXydZxDlovRWFXLHYA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.3.1.tgz",
+      "integrity": "sha512-n7xUBZ6iFyd1vjz3rcvMPg9PMkzma5hKJtRbYz0a4FcZNclitFBMEWwxYxcN9DsJdHnOPjY6d74UHYVjGK31zA==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "react-server-loader": "^19.2.8 || >=0.0.0-0 <0.0.1",
+        "react-server-loader": "^19.2.10 || >=0.0.0-0 <0.0.1",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "demo": "rm todos.db && NODE_ENV=production PUBLIC_ORIGIN='http://localhost:3000' BASE_URL='/' npm run build && NODE_ENV=production NODE_OPTIONS='--conditions react-server' node dist/server/server",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "demo": "rm -f todos.db && NODE_ENV=production PUBLIC_ORIGIN='http://localhost:3000' BASE_URL='/' npm run build && NODE_ENV=production NODE_OPTIONS='--conditions react-server' node dist/server/server/index-*.js",
+    "test": "npm run test:e2e",
+    "test:e2e": "NODE_ENV=production PUBLIC_ORIGIN='http://localhost:3000' BASE_URL='/' npm run build && playwright test",
     "dev:rsc": "npm run env:dev-server -- vite",
     "dev:ssr": "npm run env:start -- vite",
     "preview": "npm run build:static:preview && npm run build:client:preview && npm run build:server:preview && npm run preview:start",
@@ -39,6 +40,7 @@
   "license": "ISC",
   "description": "",
   "devDependencies": {
+    "@playwright/test": "^1.61.0",
     "@types/express": "^5.0.2",
     "@types/node": "^22.15.17",
     "@types/react": "^19.0.9",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^2.2.0"
+    "vite-plugin-react-server": "^2.3.1"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * E2E config for the demo's PRODUCTION server-action path.
+ *
+ * The build is done first (see the `test:e2e` script) — keeping it OUT of the
+ * webServer command so we don't nest a Vite build under the browser process
+ * tree. Playwright then starts the plain Node/Express prod server and drives a
+ * real browser against it.
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: false,
+  workers: 1,
+  reporter: "list",
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    // The Express prod server. Its entry (src/server/index.ts) is emitted
+    // hashed, so we glob it rather than `node dist/server/server` (which can't
+    // resolve a hashed index). Plain Node, so it survives in the background;
+    // the build already ran before Playwright.
+    command:
+      "BASE_URL=/ PUBLIC_ORIGIN=http://localhost:3000 NODE_ENV=production NODE_OPTIONS='--conditions=react-server' node dist/server/server/index-*.js",
+    url: "http://localhost:3000/todos/",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/src/components/ServerFnProbe.client.tsx
+++ b/src/components/ServerFnProbe.client.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import React, { useState } from "react";
+// Server Functions pattern: a client component imports a "use server" action
+// DIRECTLY (not via props) and calls it. vprs rewrites this import into a
+// createServerReference proxy that POSTs to the server — so the body never
+// ships to the browser and the call round-trips. This is the client-import
+// half of Next.js parity (the prop-passing half is the TodoList above).
+import { getTodos } from "../server/actions/todoActions.server.js";
+
+export function ServerFnProbe() {
+  const [count, setCount] = useState<number | null>(null);
+  return (
+    <button
+      type="button"
+      data-testid="server-fn-probe"
+      onClick={async () => {
+        const todos = await getTodos();
+        setCount(todos.length);
+      }}
+    >
+      {count === null ? "Probe server fn" : `server says: ${count} todos`}
+    </button>
+  );
+}

--- a/src/page/todos/page.tsx
+++ b/src/page/todos/page.tsx
@@ -3,6 +3,7 @@ import { TodoList } from "../../components/TodoList.client.js";
 import type { Props } from "./props.js";
 import styles from "../../css/todoStyles.module.css";
 import { Link } from "../../components/Link.client.js";
+import { ServerFnProbe } from "../../components/ServerFnProbe.client.js";
 
 
 export async function Page({
@@ -35,6 +36,7 @@ export async function Page({
         styles={styles}
         isGithubPages={isGithubPages}
       />
+      {!isGithubPages && <ServerFnProbe />}
     </div>
   );
 }


### PR DESCRIPTION
The demo had **no tests** (`test` was the npm stub). This gives it a real end-to-end check of the production server-action path — and fixes a bug found along the way.

## E2E
`e2e/todos.spec.ts` (Playwright) drives the **production express build**:
1. add a uniquely-named todo → it appears,
2. **reload** → still there (proves `addTodo` persisted to SQLite, not just local component state),
3. delete it → gone,
4. **reload** → stays gone (proves `deleteTodo` persisted).

The reload-between-steps is the point: a client-only optimistic update would pass the first assert but fail after reload. Server log during the run confirms the real round-trip (`Handling server action → addTodo … → deleteTodo`). The spec waits for hydration before interacting — a click before React attaches is silently lost (that bit me first).

Run with `npm run test:e2e` (prod build, then Playwright starts the express server via `webServer`).

## Bug fix
The server entry (`src/server/index.ts`) is emitted **hashed**, so `node dist/server/server` — what the `demo` script ran — fails with `MODULE_NOT_FOUND`. The `demo` script and the e2e now launch the actual entry via `dist/server/server/index-*.js`.

> Follow-up worth considering: pin the server entry to a stable filename so the glob isn't needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)