### PR TITLE
demo+test: client-imported server function (Server Functions parity)

### DIFF
--- a/e2e/todos.spec.ts
+++ b/e2e/todos.spec.ts
@@ -39,4 +39,22 @@ test.describe("todos server actions (prod build)", () => {
     await page.reload();
     await expect(page.locator("li", { hasText: title })).toHaveCount(0);
   });
+
+  test("a client component that directly imports a server function can call it", async ({
+    page,
+  }) => {
+    // ServerFnProbe is a "use client" component that imports getTodos (a
+    // "use server" action) directly and calls it on click. vprs rewrites the
+    // import to a createServerReference proxy, so the click round-trips to the
+    // server. Proves the client-import half of Server Functions parity in a
+    // real browser (server body never shipped; the call hits the server).
+    await page.goto("/todos/");
+    await page.waitForLoadState("networkidle");
+    await page.waitForTimeout(1000);
+
+    const probe = page.getByTestId("server-fn-probe");
+    await expect(probe).toHaveText("Probe server fn");
+    await probe.click();
+    await expect(probe).toHaveText(/server says: \d+ todos/);
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^2.2.0"
+        "vite-plugin-react-server": "^2.3.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
@@ -2352,9 +2352,9 @@
       }
     },
     "node_modules/react-server-loader": {
-      "version": "19.2.9",
-      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.9.tgz",
-      "integrity": "sha512-UQ87YKr1S6rQb7kzfuBGZ1YOU0O/8JZkvO994py5l9R2p3UfkQigm3KH3hawP0Oxq9XBMHNEq922gBD3lXOyNA==",
+      "version": "19.2.10",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.10.tgz",
+      "integrity": "sha512-5tjavvJvvijZmRXIBP+AxJPiKv8JdLa6EB/m4hqUyc8rg3kxPA6JIWtxh+n45VCj/f7JTrf2UuNSNw84RuNQ5g==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
@@ -2799,14 +2799,14 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.2.0.tgz",
-      "integrity": "sha512-dX1hscB7YDbDBkwsuvRBmaoXn/4UQveqt1ku5CQ7s4OMeiIB/wZvqJADA/RRjPcUszHjKXydZxDlovRWFXLHYA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.3.0.tgz",
+      "integrity": "sha512-a3JlibPe8L43rk+o3R5q+PZGMjXUw8uvIWUF6Hp7A5sBOKxdCbNx4aThoWUJTLGBKWzGwbYusZuj9hkJb87JUQ==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "react-server-loader": "^19.2.8 || >=0.0.0-0 <0.0.1",
+        "react-server-loader": "^19.2.10 || >=0.0.0-0 <0.0.1",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^2.3.0"
+        "vite-plugin-react-server": "^2.3.1"
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
@@ -2799,9 +2799,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.3.0.tgz",
-      "integrity": "sha512-a3JlibPe8L43rk+o3R5q+PZGMjXUw8uvIWUF6Hp7A5sBOKxdCbNx4aThoWUJTLGBKWzGwbYusZuj9hkJb87JUQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.3.1.tgz",
+      "integrity": "sha512-n7xUBZ6iFyd1vjz3rcvMPg9PMkzma5hKJtRbYz0a4FcZNclitFBMEWwxYxcN9DsJdHnOPjY6d74UHYVjGK31zA==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^2.2.0"
+    "vite-plugin-react-server": "^2.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^2.3.0"
+    "vite-plugin-react-server": "^2.3.1"
   }
 }

--- a/src/components/ServerFnProbe.client.tsx
+++ b/src/components/ServerFnProbe.client.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import React, { useState } from "react";
+// Server Functions pattern: a client component imports a "use server" action
+// DIRECTLY (not via props) and calls it. vprs rewrites this import into a
+// createServerReference proxy that POSTs to the server — so the body never
+// ships to the browser and the call round-trips. This is the client-import
+// half of Next.js parity (the prop-passing half is the TodoList above).
+import { getTodos } from "../server/actions/todoActions.server.js";
+
+export function ServerFnProbe() {
+  const [count, setCount] = useState<number | null>(null);
+  return (
+    <button
+      type="button"
+      data-testid="server-fn-probe"
+      onClick={async () => {
+        const todos = await getTodos();
+        setCount(todos.length);
+      }}
+    >
+      {count === null ? "Probe server fn" : `server says: ${count} todos`}
+    </button>
+  );
+}

--- a/src/page/todos/page.tsx
+++ b/src/page/todos/page.tsx
@@ -3,6 +3,7 @@ import { TodoList } from "../../components/TodoList.client.js";
 import type { Props } from "./props.js";
 import styles from "../../css/todoStyles.module.css";
 import { Link } from "../../components/Link.client.js";
+import { ServerFnProbe } from "../../components/ServerFnProbe.client.js";
 
 
 export async function Page({
@@ -35,6 +36,7 @@ export async function Page({
         styles={styles}
         isGithubPages={isGithubPages}
       />
+      {!isGithubPages && <ServerFnProbe />}
     </div>
   );
 }


### PR DESCRIPTION
> Draft / held until the vprs release that ships client-imported server-function support (stacked on the prod-e2e PR).

Demonstrates and tests the **client-import half** of Server Functions parity: a `"use client"` component (`ServerFnProbe`) that imports a `"use server"` action **directly** and calls it on click. vprs rewrites the import to a `createServerReference` proxy that POSTs to the server.

- `ServerFnProbe.client.tsx` — imports `getTodos` directly, shows the live server count on click. Rendered on `/todos/` behind `!isGithubPages` (needs the backend).
- e2e extended to drive it in Chromium: click → round-trips → button shows `server says: N todos`.

Verified end-to-end against the prod express build with the develop vprs (both the props-pattern actions and this client-imported one pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)