### PR TITLE
chore(deps): bump vite-plugin-react-server to 2.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^2.3.1"
+        "vite-plugin-react-server": "^2.3.2"
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
@@ -2799,9 +2799,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.3.1.tgz",
-      "integrity": "sha512-n7xUBZ6iFyd1vjz3rcvMPg9PMkzma5hKJtRbYz0a4FcZNclitFBMEWwxYxcN9DsJdHnOPjY6d74UHYVjGK31zA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.3.2.tgz",
+      "integrity": "sha512-vCBOS07v2OPfrpnDJA96nVONviAXeAHkdY3NBHITmWijpdWaY12HMCP3UJ67xKGst8vgIE3rjXRM5hVqktfJew==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^2.3.1"
+    "vite-plugin-react-server": "^2.3.2"
   }
 }


### PR DESCRIPTION
Bumps `vite-plugin-react-server` from 2.3.1 to 2.3.2.

2.3.2 fixes a static-build hang: a `<Suspense>` boundary whose resolved content backpressured the HTML prerender lost the stream's `drain` event, so the build never settled and aborted at its timeout. The HTML worker now pipes into a real `node:stream.Writable`, restoring backpressure.

Verified locally: `npm run build` prerenders 5 pages, exit 0.