### PR TITLE
chore(deps): bump vite-plugin-react-server to 2.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^2.3.2"
+        "vite-plugin-react-server": "^2.4.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
@@ -2799,9 +2799,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.3.2.tgz",
-      "integrity": "sha512-vCBOS07v2OPfrpnDJA96nVONviAXeAHkdY3NBHITmWijpdWaY12HMCP3UJ67xKGst8vgIE3rjXRM5hVqktfJew==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.4.0.tgz",
+      "integrity": "sha512-vpMHpdyiIj47Exx6kqIgZZWgqxF2bvAEJbYnpHC0EgYUA/1IZiuXig9xpChsjaM4pF4atH0nT9DwT8Y3IkDVVg==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^2.3.2"
+    "vite-plugin-react-server": "^2.4.0"
   }
 }


### PR DESCRIPTION
Bumps `vite-plugin-react-server` to **2.4.0** (new `react-static/inlineFlightPayload` export + createReactFetcher inline-payload read; `/utils` cross-condition export-parity fix).

Verified locally: `npm install` resolves 2.4.0; `npm run build:preview` prerenders all 5 pages with no errors.

Both `package.json` and `package-lock.json` are committed (CI uses `npm ci`).