### PR TITLE
chore: bump vite-plugin-react-server to 2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^2.3.2"
+        "vite-plugin-react-server": "^2.5.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
@@ -2799,9 +2799,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.3.2.tgz",
-      "integrity": "sha512-vCBOS07v2OPfrpnDJA96nVONviAXeAHkdY3NBHITmWijpdWaY12HMCP3UJ67xKGst8vgIE3rjXRM5hVqktfJew==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.5.0.tgz",
+      "integrity": "sha512-me8UcfHcqx0WVjJ/ZPuRGXmMJMQZVF/2qZo6js7OkS6rOoruhv72cO1xidbaApABZas0nBEAzbVM8qeSGRr+3A==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^2.3.2"
+    "vite-plugin-react-server": "^2.5.0"
   }
 }


### PR DESCRIPTION
## What

Bumps `vite-plugin-react-server` `2.3.2 → 2.5.0`.

2.5.0 adds `createHtmlStreamWithInlineFlight` (per-request flash-free SSR for dynamic routes) and refactors the build-time inline-flight injection into a shared single-source module. This demo's dynamic `/todos` route serves a prerendered HTML document and loads todos client-side after first paint, so it does not adopt the new helper here; this PR is the compatibility bump, verifying the existing static and server-action paths still pass on 2.5.0.

## Verification (at 2.5.0)

- Production build (`vite build --app`) renders all pages.
- Playwright e2e passes against the real Express prod build:
  - `addTodo` then `deleteTodo` round-trip through real `"use server"` actions backed by SQLite and persist across page reloads (not just optimistic client state).
  - A `"use client"` component that directly imports a server function calls it in a real browser.