### PR TITLE
chore: bump vite-plugin-react-server to 2.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^2.5.0"
+        "vite-plugin-react-server": "^2.6.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
@@ -2799,9 +2799,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.5.0.tgz",
-      "integrity": "sha512-me8UcfHcqx0WVjJ/ZPuRGXmMJMQZVF/2qZo6js7OkS6rOoruhv72cO1xidbaApABZas0nBEAzbVM8qeSGRr+3A==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.6.0.tgz",
+      "integrity": "sha512-xoTJlni0+JHgjcgq7fqtDvs+Q5zkKZAtyNyOPRS1Rqa0KbPECB+GbUJzRo2shKjyrxkOzTXJYmt4OyM3iMEBtw==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^2.5.0"
+    "vite-plugin-react-server": "^2.6.0"
   }
 }


### PR DESCRIPTION
Bumps `vite-plugin-react-server` `^2.5.0 → ^2.6.0`.

2.6.0 adds an opt-in `build.inlineFlight` (flash-free first render). This demo intentionally **does not** enable it: `/todos` is dynamic and its data must stay live per request, so a build-time inlined payload would pin it to a stale (empty) snapshot on reload. So this is a plain version bump — behavior unchanged. (Flash-free for the static routes here would want per-route inlineFlight control, a separate follow-up.)

## Verification

Production build + Playwright e2e green: `addTodo`/`deleteTodo` round-trip through real `"use server"` actions and persist across reloads, and a `"use client"` component that directly imports a server function calls it in the browser.