### PR TITLE
chore(deps): bump vite-plugin-react-server to 2.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^2.5.0"
+        "vite-plugin-react-server": "^2.6.1"
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
@@ -2799,9 +2799,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.5.0.tgz",
-      "integrity": "sha512-me8UcfHcqx0WVjJ/ZPuRGXmMJMQZVF/2qZo6js7OkS6rOoruhv72cO1xidbaApABZas0nBEAzbVM8qeSGRr+3A==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.6.1.tgz",
+      "integrity": "sha512-PqZOlgj9nYdw6x4YxDojd/ssQL3ulZ2keAMNYgOQPhL37lZaFHxNp9lRJJieuJrWIA+p7dHRmDniMJAIi+Xavg==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^2.5.0"
+    "vite-plugin-react-server": "^2.6.1"
   }
 }


### PR DESCRIPTION
Bumps `vite-plugin-react-server` 2.5.0 → **2.6.1**.

2.6.1 fixes the root package entrypoints: published 2.6.0 pointed `main`/`module` → `dist/plugin/index.js` and `types` → `dist/plugin/index.d.ts`, none of which were in the tarball. 2.6.1 points them at the emitted `dist/index.*` and adds a `types` condition to the root export.

Verified: `npm install` resolves 2.6.1 with `main`/`types` pointing at existing files, and the SSG build (`npm run build`) renders all 5 pages cleanly.