### PR TITLE
chore(deps): bump vite-plugin-react-server to 2.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^2.6.0"
+        "vite-plugin-react-server": "^2.7.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
@@ -2799,9 +2799,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.6.0.tgz",
-      "integrity": "sha512-xoTJlni0+JHgjcgq7fqtDvs+Q5zkKZAtyNyOPRS1Rqa0KbPECB+GbUJzRo2shKjyrxkOzTXJYmt4OyM3iMEBtw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.7.0.tgz",
+      "integrity": "sha512-b/7yFoRuIG7uAUgvo8L1j5JmiwbPG53sqxkyylDmZKpfG63trzJ/xBvh32O4B+DFIi7PMYLXFvyyqPmMvzttUQ==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^2.6.0"
+    "vite-plugin-react-server": "^2.7.0"
   }
 }


### PR DESCRIPTION
Adopt the latest vite-plugin-react-server release (2.7.0) in the official demo.

This supersedes #102 (which bumped to 2.6.1, never merged). Going straight to 2.7.0.

Verified locally: full `npm run build` (`vite build --app`) succeeds, all 5 pages render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)