### PR TITLE
chore(deps): bump vite-plugin-react-server to 2.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "vite-plugin-react-server": "^2.7.0"
+        "vite-plugin-react-server": "^2.8.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
@@ -2799,9 +2799,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.7.0.tgz",
-      "integrity": "sha512-b/7yFoRuIG7uAUgvo8L1j5JmiwbPG53sqxkyylDmZKpfG63trzJ/xBvh32O4B+DFIi7PMYLXFvyyqPmMvzttUQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.8.0.tgz",
+      "integrity": "sha512-+hsvKBVVZxVmvqkFfBoZTQ+R1Usq61lnIntQstVdxmDFmXDLFS8mKvuxqQ004YP4y/6Kcuy/dr2Q9bxo5VUUhg==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "vite-plugin-react-server": "^2.7.0"
+    "vite-plugin-react-server": "^2.8.0"
   }
 }


### PR DESCRIPTION
Bumps `vite-plugin-react-server` from 2.7.0 to 2.8.0.

2.8.0 adds opt-in server-action endpoint hardening (CSRF `allowedOrigins`, `maxBodyBytes` body cap, no stack traces in error responses) plus defense-in-depth path containment. All new behavior is opt-in and off by default, so this is a drop-in upgrade. This demo's Express prod fixture mounts its own server-action handler, so the new `handleServerAction` options do not change its behavior; bumping keeps the demo on the latest published plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)