### PR TITLE
refactor(client): adopt vprs startClient, drop the hand-rolled entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "vite-plugin-react-server": "^2.10.0"
+        "vite-plugin-react-server": "^3.1.1"
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
@@ -1766,9 +1766,9 @@
       }
     },
     "node_modules/react-server-loader": {
-      "version": "19.2.11",
-      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.11.tgz",
-      "integrity": "sha512-BPuj4ef8DAUkNdXhw4UNrJm5JRiWffVXjoS9WqYKasljy5bD5yVVscphurQmw8Hth/COAgnojVXDD7oAyCrI5w==",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.14.tgz",
+      "integrity": "sha512-hlSqNImloYIKbZ3+Iz7fGqam77t2q8QKJx9+SyKcsclabcii+1sa5eFWwPnzkd+8CfJQQYQG0srGvrmHJCQKVg==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
@@ -2018,14 +2018,14 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.10.0.tgz",
-      "integrity": "sha512-JmyaHaATN2g1Jgbo18XmEmh0roLSCHvDsp/STkr37SW3ohvqkCmZXpv7I6WnBUgD89FALcEREg/b7Lid1KZ2Rg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.1.1.tgz",
+      "integrity": "sha512-02neWKDmy5GiZA1KFZhm2nHa+AbbIbv+3Mh/tydVNWLincBXkhvHW2DVPU2wXiSA9QWtlyUMqglaRSPGvEHZqA==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "react-server-loader": "^19.2.11 || >=0.0.0-0 <0.0.1",
+        "react-server-loader": "^19.2.12 || >=0.0.0-0 <0.0.1",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },
@@ -2035,7 +2035,7 @@
       "peerDependencies": {
         "react": "^19.2.7 || >=0.0.0-0 <0.0.1",
         "react-dom": "^19.2.7 || >=0.0.0-0 <0.0.1",
-        "vite": "*"
+        "vite": "^6.3.5 || ^7 || ^8"
       },
       "peerDependenciesMeta": {
         "react": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "vite-plugin-react-server": "^3.1.1"
+        "vite-plugin-react-server": "^3.1.2"
       },
       "devDependencies": {
         "@playwright/test": "^1.61.1",
@@ -2044,9 +2044,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.1.1.tgz",
-      "integrity": "sha512-02neWKDmy5GiZA1KFZhm2nHa+AbbIbv+3Mh/tydVNWLincBXkhvHW2DVPU2wXiSA9QWtlyUMqglaRSPGvEHZqA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.1.2.tgz",
+      "integrity": "sha512-2icYBv0sTbQ1IiUQEo0tJ23qYajTZBl38DpWkLmGz8s36muvhMf4Avy2Dckf3ncZAHpggnMotcvqMMaOFHnuyQ==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "webpack-sources": "^3.3.0"
   },
   "dependencies": {
-    "vite-plugin-react-server": "^2.10.0"
+    "vite-plugin-react-server": "^3.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "webpack-sources": "^3.5.0"
   },
   "dependencies": {
-    "vite-plugin-react-server": "^3.1.1"
+    "vite-plugin-react-server": "^3.1.2"
   }
 }

--- a/src/client.tsx
+++ b/src/client.tsx
@@ -1,84 +1,26 @@
-import React, { useCallback, useEffect, useState, useTransition } from "react";
+"use client";
+import * as React from "react";
 import type { ReactNode } from "react";
-import { createRoot, hydrateRoot } from "react-dom/client";
-import "./css/globalStyles.css";
-import { createReactFetcher } from "vite-plugin-react-server/utils";
-import { useRscHmr } from "virtual:react-server/hmr";
+import { startClient } from "vite-plugin-react-server/router/client";
 import { ErrorBoundary } from "./components/ErrorBoundary.client.js";
+import "./css/globalStyles.css";
 
 /**
- * Client-side React Server Components entry.
+ * bidoof client entry.
  *
- * Initial render: the route's flight is taken from the inline payload baked into
- * the document when present (the static build inlines it; the dynamic /todos
- * document inlines its live per-request flight — see server/start.tsx), else
- * fetched as `.rsc`. Either way it's decoded to a ReactNode BEFORE mount, rendered
- * directly — a synchronous first render with no Suspense boundary so hydrateRoot
- * matches the server markup. (use()-ing the pending thenable, or wrapping the
- * root in a client-only <Suspense> the server never rendered, mismatches the
- * prerender → React #418.)
+ * vprs's `startClient` is the supplied client entry: it assembles the headless
+ * router, initial-flight hydration (consuming the payload inlined into the
+ * document on first paint — the static build's baked flight and /todos' live
+ * per-request flight alike), client-side navigation, and RSC HMR. The whole
+ * hand-rolled App / popstate / refetch / hydrateRoot boilerplate collapses to
+ * this one call; the ErrorBoundary is injected through `wrap`.
  *
- * Navigation / HMR: fetch the target route's flight, await the decode, then
- * swap it in within a transition — keeping the current page visible, still with
- * no Suspense boundary.
+ * Navigation flows through <Link> (pushState + popstate), which the router
+ * listens for; scroll-to-top on a click lives in <Link>. No `patterns` are
+ * needed — bidoof reads no route params via useParams.
  */
-const App: React.FC<{ initialNode: ReactNode }> = ({ initialNode }) => {
-  const [content, setContent] = useState<ReactNode>(initialNode);
-  const [, startTransition] = useTransition();
-
-  const go = useCallback((url: string, scrollToTop = true) => {
-    if (scrollToTop && "scrollTo" in window) window.scrollTo(0, 0);
-    Promise.resolve(
-      createReactFetcher({
-        url,
-        moduleBaseURL: import.meta.env.BASE_URL,
-        publicOrigin: import.meta.env.PUBLIC_ORIGIN,
-      })
-    )
-      .then((node) => startTransition(() => setContent(node as ReactNode)))
-      .catch(() => {
-        /* superseded by a later navigation — that render wins */
-      });
-  }, []);
-
-  // Browser + <Link> navigation (Link dispatches popstate with state.to).
-  useEffect(() => {
-    const onPopState = (e: PopStateEvent) =>
-      go(e.state?.to ?? window.location.pathname);
-    window.addEventListener("popstate", onPopState);
-    return () => window.removeEventListener("popstate", onPopState);
-  }, [go]);
-
-  // HMR: refetch the current route when server components change (no scroll).
-  useRscHmr((url) => go(url, false));
-
-  return <ErrorBoundary>{content}</ErrorBoundary>;
-};
-
-const rootElement = document.getElementById("root");
-if (!rootElement) throw new Error("Root element not found");
-
-// Fully resolve the initial payload (dynamic flight-client import + decode) to a
-// node, then mount: hydrateRoot when the server sent prerendered/SSR'd markup,
-// createRoot for an empty (JS-rendered) shell.
-Promise.resolve(
-  createReactFetcher({
-    url: window.location.pathname,
-    moduleBaseURL: import.meta.env.BASE_URL,
-    publicOrigin: import.meta.env.PUBLIC_ORIGIN,
-  })
-).then(
-  (initialNode) => {
-    if (rootElement.hasChildNodes()) {
-      hydrateRoot(rootElement, <App initialNode={initialNode as ReactNode} />);
-    } else {
-      createRoot(rootElement).render(
-        <App initialNode={initialNode as ReactNode} />
-      );
-    }
-  },
-  (error) => {
-    // Stay on the server-rendered HTML rather than mounting a broken tree.
-    console.error("[bidoof] initial RSC payload failed to load", error);
-  }
-);
+startClient({
+  moduleBaseURL: import.meta.env.BASE_URL,
+  publicOrigin: import.meta.env.PUBLIC_ORIGIN,
+  wrap: (node: ReactNode) => <ErrorBoundary>{node}</ErrorBoundary>,
+});

--- a/src/components/Link.client.tsx
+++ b/src/components/Link.client.tsx
@@ -30,6 +30,10 @@ export const Link: React.FC<{
         }
       const newState = { to: newTo };
       if(window.location.pathname !== newTo) {
+        // Scroll-to-top on a real link click. The hand-rolled client's popstate
+        // handler used to do this; startClient replaces that handler and does not
+        // force scroll, so browser back/forward keep their restored position.
+        if ("scrollTo" in window) window.scrollTo(0, 0);
         try {
           window.history.pushState(newState, "", e.currentTarget.href);
           window.dispatchEvent(new PopStateEvent("popstate", { state: newState }));

--- a/src/server/start.tsx
+++ b/src/server/start.tsx
@@ -7,7 +7,7 @@ import {
   toNodeListener,
 } from "vite-plugin-react-server/request-handler";
 import { collectManifestCss } from "vite-plugin-react-server/helpers";
-import { createEdgeHandler } from "vite-plugin-react-server/stream";
+import { createEdgeHandler } from "vite-plugin-react-server/stream/client";
 import type { CssContent } from "vite-plugin-react-server/types";
 import type { Manifest } from "vite";
 


### PR DESCRIPTION
## What

Replaces the hand-rolled client entry with vprs's supplied `startClient`, and bumps `vite-plugin-react-server` 2.10 → 3.1.1.

The old `client.tsx` hand-assembled an `App` shell, `createReactFetcher`, a `popstate` handler, RSC HMR, and the `createRoot`/`hydrateRoot` mount (~84 lines). `startClient` does all of that:

```ts
startClient({
  moduleBaseURL: import.meta.env.BASE_URL,
  publicOrigin: import.meta.env.PUBLIC_ORIGIN,
  wrap: (node) => <ErrorBoundary>{node}</ErrorBoundary>,
});
```

- `ErrorBoundary` is injected via `wrap`.
- Scroll-to-top on a link click moves into `<Link>` — `startClient`'s nav handler doesn't force scroll, so browser back/forward keep their restored position (arguably better than the old always-scroll-on-popstate).
- `start.tsx`'s `createEdgeHandler` import moves to the `/stream/client` subpath: 3.x reclassified it to the client stream variant, so the react-server-condition server index no longer re-exports it. This was the only source break in the 2.x → 3.x bump.

Net: 34 insertions, 88 deletions.

## Verified

- Production build green (300-page static + edge bundle).
- Real-browser `dev:rsc` load: client hydration is clean, page is interactive (client-side nav works). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)