### PR TITLE
fix(build): keep /components out of the document wrapper (fixes GH-Pages CI)

### DIFF
--- a/src/Css.tsx
+++ b/src/Css.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import type { CssComponentType, CssContent } from "vite-plugin-react-server/types";
+
+// Inlined copy of vite-plugin-react-server/components' Css. The hosted component
+// cannot be imported into the document wrapper (Html.tsx): in the no-flag
+// `vite build` (build:static:gh) it collapses the whole document to a fragment
+// with no <html> root. vprs 3.1.0's degraded-document guard now surfaces that as
+// a hard build error instead of shipping it silently, so a local copy is needed
+// until the underlying no-flag hosted-Css degrade is fixed upstream. Emits a
+// <style> for inline CSS or a <link> for an external stylesheet.
+export const Css: CssComponentType = ({ cssFiles }) => {
+  if (!cssFiles) return null;
+  const cssFilesArray = Array.isArray(cssFiles)
+    ? cssFiles
+    : Array.from(cssFiles.values());
+  if (!cssFilesArray.length) return null;
+  const arr = cssFilesArray.map((cssFile: CssContent) => {
+    const {
+      as: As = React.Fragment,
+      id,
+      children,
+      precedence,
+      type,
+      ...rest
+    } = cssFile;
+    if (
+      As !== "link" &&
+      (typeof children === "string" || React.isValidElement(children))
+    ) {
+      return (
+        <As {...rest} type={type ?? "text/css"} key={id}>
+          {children ?? null}
+        </As>
+      );
+    }
+    return <As {...rest} key={id} precedence={precedence} />;
+  });
+  if (!arr.length) return null;
+  return arr;
+};

--- a/src/Html.tsx
+++ b/src/Html.tsx
@@ -1,9 +1,14 @@
 import React from "react";
 import type { HtmlProps } from "vite-plugin-react-server/types";
-import { Css, Root as DefaultRoot } from "vite-plugin-react-server/components";
+import { Css } from "./Css";
 
+// NB: the document wrapper imports nothing from vite-plugin-react-server/components.
+// Loading that barrel here degrades the whole document to a fragment (no <html>
+// root) in the no-flag `vite build` (build:static:gh), so `Css` is a local copy
+// and `Root` comes from props (the plugin supplies it) rather than a /components
+// default. See src/Css.tsx.
 export const Html: React.FC<HtmlProps> = ({
-  Root = DefaultRoot,
+  Root,
   cssFiles,
   globalCss,
   pageProps = {},


### PR DESCRIPTION
## Problem

CI (`build:gh`) went red after the vprs 3.1.2 bump: the no-flag `build:static:gh` (`vite build`) degraded **every** route to a fragment with no `<html>` root. vprs 3.1.0's degraded-document guard surfaces that as a hard build error rather than shipping it silently (as 2.11 did) — so the break is a *newly-surfaced* pre-existing degrade, not a fresh regression.

## Cause

Importing from `vite-plugin-react-server/components` in `Html.tsx` loads that barrel inside the reverse-condition RSC worker of the no-flag build, where it collapses the whole document to a fragment. It was **both** `Css` and `Root` (the `/components` import itself is the trigger, not the component code).

## Fix

The document wrapper imports nothing from `/components` (matching how mmc's `MmcHtml` already works):
- `Css` → local copy in `src/Css.tsx`
- `Root` → taken from props (the plugin supplies it) instead of a `/components` default

Verified: `build:gh` renders all 5 pages with `<html>` roots, exit 0.

## Upstream

This is a workaround for a `vite-plugin-react-server` bug — `/components` should be usable in the document wrapper of a no-flag build. Tracked upstream; once fixed, this local `Css` copy and the props-only `Root` can be reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)