### PR TITLE
fix(e2e): repair the prod-server e2e — unhashed entry glob + react-server-loader 19.2.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1802,9 +1802,9 @@
       }
     },
     "node_modules/react-server-loader": {
-      "version": "19.2.12",
-      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.12.tgz",
-      "integrity": "sha512-uSFL5gvJsx6WCzT6ByDxS7KH7Zw3zO1bNefNPRo/BbFUMqoy9pJammpupPUQnHFMq9F339s2OOlYCtNRLA4BHA==",
+      "version": "19.2.16",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.16.tgz",
+      "integrity": "sha512-XKvj9VhvziYlCYEJMvMrId/guwKzQ2uknDRRSZ2N+4b5wIinMwy3eer8DcpY+8JQnXQ+qUwTuC1BDNYZFMuJbw==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,12 +21,17 @@ export default defineConfig({
   },
   projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
   webServer: {
-    // The Express prod server. Its entry (src/server/index.ts) is emitted
-    // hashed, so we glob it rather than `node dist/server/server` (which can't
-    // resolve a hashed index). Plain Node, so it survives in the background;
-    // the build already ran before Playwright.
+    // The Express prod server (src/server/index.ts), started with NO
+    // `--conditions react-server` — deliberately. The single-isolate edge build
+    // exists so production runs on plain Node; needing the flag here would mean
+    // that promise is broken.
+    //
+    // The glob tolerates both the plain and the content-hashed entry name: which
+    // one the server build emits has changed across plugin versions, and pinning
+    // `index-*.js` silently stopped matching once it was emitted unhashed.
+    // Plain Node, so it survives in the background; the build ran before this.
     command:
-      "BASE_URL=/ PUBLIC_ORIGIN=http://localhost:3000 NODE_ENV=production node dist/server/server/index-*.js",
+      "BASE_URL=/ PUBLIC_ORIGIN=http://localhost:3000 NODE_ENV=production node dist/server/server/index*.js",
     url: "http://localhost:3000/todos/",
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,


### PR DESCRIPTION
The Playwright suite has been red since the single-isolate edge build landed, and nothing noticed — **CI runs only `build:gh`, never Playwright.**

## Two failures, stacked

**1. The webServer never started.** It globbed `dist/server/server/index-*.js`, but the server build now emits the entry **unhashed** as `index.js`. The glob matched nothing, Node exited `MODULE_NOT_FOUND`, and not a single test ran.

**2. Past that, the server died on load asserting the `react-server` condition** — which is precisely what the single-isolate edge build exists to avoid. Production is supposed to run on plain Node.

The cause of (2) was upstream. `react-server-loader` classified any module named `*.client.js` as a client component **from the filename**. That caught the plugin's own `stream/index.client.js` — server-side stream infrastructure whose `.client` suffix names a build-**condition** variant, nothing to do with `"use client"` — and replaced all 19 of its exports with throw-on-call client-reference stubs, while injecting the react-server-only transport into it. This server imports `createEdgeHandler` from exactly that module, so it asserted the condition on load; and had it got past that, `createEdgeHandler` was a function whose only behaviour was to throw.

Fixed upstream in react-server-loader 19.2.15/19.2.16 (classification is directive-only now). Our lockfile was still pinned to 19.2.12.

## Changes

- `playwright.config.ts` — glob tolerates both the plain and content-hashed entry name. The comment now states the invariant under test: **the production server runs on plain Node with no `--conditions react-server`.** If it ever needs the flag again, that is the bug, not the config.
- `package-lock.json` — `react-server-loader` 19.2.12 → 19.2.16.

## Result

```
✓ todos server actions (prod build) › add persists across reload, then delete persists
✓ todos server actions (prod build) › a client component that directly imports a server function can call it
✓ todos server actions (prod build) › flash-free dynamic SSR: live todos in the initial HTML, hydrate with zero refetch

3 passed
```

Green against published `vite-plugin-react-server@3.1.3` + `react-server-loader@19.2.16`. Wiring this into the plugin's CI is the companion change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)