### PR TITLE
chore(deps): vite-plugin-react-server 3.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "vite-plugin-react-server": "^3.1.3"
+        "vite-plugin-react-server": "^3.1.4"
       },
       "devDependencies": {
         "@playwright/test": "^1.61.1",
@@ -2044,14 +2044,14 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.1.3.tgz",
-      "integrity": "sha512-BRQ8WxzhskOtrb89OaaPhYzYnExxh2RIw5W414/P/exGKu0Uzdghkz+IkzfhsFOC/ouvesZxA5cGhLG3jjfELQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.1.4.tgz",
+      "integrity": "sha512-UrpOcfxp12acM6XrMoeR0AvZ3goWrSENQkDrs7aX+JeP+5zlpieQ0Wzx17+6teUlTvH+WRd4U+IqH53u+qUr3Q==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "react-server-loader": "^19.2.12 || >=0.0.0-0 <0.0.1",
+        "react-server-loader": "^19.2.16 || 0.0.0-experimental-c0c39a6b-20260709.1",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },

--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "webpack-sources": "^3.5.0"
   },
   "dependencies": {
-    "vite-plugin-react-server": "^3.1.3"
+    "vite-plugin-react-server": "^3.1.4"
   }
 }


### PR DESCRIPTION
3.1.4 changes **no plugin source**. It locks the `react-server-loader` range to `^19.2.16 || 0.0.0-experimental-c0c39a6b-20260709.1`, excluding every rsl that carries a known regression:

- **19.2.12–14** — classified a client component from its **filename**, which stubbed out the plugin's own `stream/index.client.js` in our server build and killed this app's no-`--conditions` production server.
- **19.2.15** — the `"use server"` gate stopped seeing directives in nested functions (React's canonical inline Server Function), so those modules were never transformed.

Our lockfile already had rsl 19.2.16; this makes it **enforced** rather than incidental.

## Verification

- `npm run build` — clean.
- **e2e 3/3**, including *flash-free dynamic SSR: live todos in the initial HTML, hydrate with zero refetch* — on the plain-Node production server, no `--conditions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)