### PR TITLE
fix(ci): restore the build:gh script the Pages workflow calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:static": "vite build",
     "build:client": "vite build --ssr",
     "build:server": "NODE_OPTIONS='--conditions react-server' vite build",
-    "build:app:gh": "npm run env:gh -- vite build --app",
+    "build:gh": "npm run env:gh -- vite build --app",
     "build:preview": "npm run env:preview -- npm run build --app",
     "preview:start": "npm run env:preview -- vite preview",
     "debug-build": "npm run env:dev -- vite build --app --mode=development",


### PR DESCRIPTION
**The GitHub Pages deploy has been a silent no-op**, which is why the live `/todos` is still broken even after #114 merged.

## What happened

The workflow runs:

```yaml
- run: npm run build:gh --if-present
```

The script tidy renamed `build:gh` → `build:app:gh`. **`--if-present` skips a missing script without failing**, so:

1. CI built nothing.
2. `dist/static` never existed.
3. The workflow then died at `ls -la dist/static/` — `exit code 2`.
4. Pages kept serving the previous, un-based bundle — so the live entry module still 404s and the site never hydrates.

A rename that a `--if-present` guard turns into a silent skip is a nasty combination: the build vanishes without an error at the point of failure.

## The fix

Rename `build:app:gh` back to `build:gh`, the name CI actually calls.

## Verification

```
$ npm run build:gh          → exit 0
entry:  <script type="module" src="/vite-plugin-react-server-demo-official/index-iahoot.js">
/todos: isGithubPages=true, "initialTodos":[]      ← correctly gated for Pages
```

So on the next deploy the entry resolves under the base, and `/todos` renders its Pages-gated (stubbed, empty) state instead of a broken page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)