### PR TITLE
chore(deps): vite-plugin-react-server 3.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "^19.2.7",
         "tsx": "^4.22.4",
         "vite": "^6.4.3",
-        "vite-plugin-react-server": "^3.2.0",
+        "vite-plugin-react-server": "^3.2.1",
         "webpack-sources": "^3.5.0"
       }
     },
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.2.0.tgz",
-      "integrity": "sha512-QVSQf4sb2f/7cVgaZOlxGAILDTOiiKElxrLBtD8DIbt++sDLnT1dUzJ4RaBWyAxS+xwEZDXO2jnbXvAFQVfJyg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.2.1.tgz",
+      "integrity": "sha512-wlmUNtCXk9elJYXn+vfoIV3PQkqs6KzFlI0goe3XyKKG+1FglpsRnLMJzYgGZW6DPw04tNuL52uFsY4ot+2gQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "^19.2.7",
         "tsx": "^4.22.4",
         "vite": "^6.4.3",
-        "vite-plugin-react-server": "^3.1.6",
+        "vite-plugin-react-server": "^3.2.0",
         "webpack-sources": "^3.5.0"
       }
     },
@@ -1862,9 +1862,9 @@
       }
     },
     "node_modules/react-server-loader": {
-      "version": "19.2.16",
-      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.16.tgz",
-      "integrity": "sha512-XKvj9VhvziYlCYEJMvMrId/guwKzQ2uknDRRSZ2N+4b5wIinMwy3eer8DcpY+8JQnXQ+qUwTuC1BDNYZFMuJbw==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.17.tgz",
+      "integrity": "sha512-XrmiJi2gPp1Fk0s9Bq8Fs+82WCYv+TDH7GLZQqNTvYU3caaOCOoVCyMw6YEYn8JQzNukvie2QsHqQcOvQUsHoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2112,15 +2112,15 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.1.6.tgz",
-      "integrity": "sha512-4Apnlds5779xCv8ifqkllFvFa1Jzk5YA/afQ3DC4t2p3TtjNMt0Ti9EW6t4Ei25M67fpvAt51bhTd8TsfKUM6g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.2.0.tgz",
+      "integrity": "sha512-QVSQf4sb2f/7cVgaZOlxGAILDTOiiKElxrLBtD8DIbt++sDLnT1dUzJ4RaBWyAxS+xwEZDXO2jnbXvAFQVfJyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "react-server-loader": "^19.2.16 || 0.0.0-experimental-c0c39a6b-20260709.1",
+        "react-server-loader": "^19.2.17 || 0.0.0-experimental-172742b4-20260716",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^19.2.7",
     "tsx": "^4.22.4",
     "vite": "^6.4.3",
-    "vite-plugin-react-server": "^3.1.6",
+    "vite-plugin-react-server": "^3.2.0",
     "webpack-sources": "^3.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^19.2.7",
     "tsx": "^4.22.4",
     "vite": "^6.4.3",
-    "vite-plugin-react-server": "^3.2.0",
+    "vite-plugin-react-server": "^3.2.1",
     "webpack-sources": "^3.5.0"
   }
 }


### PR DESCRIPTION
Bump to the released 3.2.1 (was opened at 3.2.0; 3.2.1 adds portable dist artifacts — client-reference proxies import the transport by its canonical bare specifier instead of a machine-absolute path).

Verified locally at 3.2.1: full e2e green on the prod build — server actions persist, direct client→server function import, flash-free dynamic SSR with zero refetch. This repo hosts a partial rsl copy under `dist/server/node_modules`, which is the exact shadow case the 3.2.1 fix had to survive; `dist/server` now carries zero absolute paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZW2we53tR9EXzdwFgpujs