### PR TITLE
chore: configure the deploy base once — drop the VITE_BASE_URL/VITE_PUBLIC_ORIGIN mirrors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "^19.2.7",
         "tsx": "^4.22.4",
         "vite": "^6.4.3",
-        "vite-plugin-react-server": "^3.2.1",
+        "vite-plugin-react-server": "^3.2.3",
         "webpack-sources": "^3.5.0"
       }
     },
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.2.1.tgz",
-      "integrity": "sha512-wlmUNtCXk9elJYXn+vfoIV3PQkqs6KzFlI0goe3XyKKG+1FglpsRnLMJzYgGZW6DPw04tNuL52uFsY4ot+2gQg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.2.3.tgz",
+      "integrity": "sha512-UFpTnXnjW1Sq0DB8TqlGVVNCAdrgFGcaNjQY2MytdsTq2eK1RHl+Zqo2u3zHGlkndq2qSXNVEVF6AAoRhZtnLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
     "dev:rsc": "npm run env:dev-server -- vite",
     "dev:ssr": "npm run env:start -- vite",
     "preview": "npm run build:preview && npm run preview:start",
-    "env:gh": "GITHUB_PAGES=true PUBLIC_ORIGIN='https://nicobrinkkemper.github.io' VITE_PUBLIC_ORIGIN='https://nicobrinkkemper.github.io' BASE_URL='/vite-plugin-react-server-demo-official/' VITE_BASE_URL='/vite-plugin-react-server-demo-official/'",
-    "env:preview": "PUBLIC_ORIGIN='http://localhost:4173' VITE_PUBLIC_ORIGIN='http://localhost:4173' BASE_URL='/vite-plugin-react-server-demo-official/' VITE_BASE_URL='/vite-plugin-react-server-demo-official/'",
-    "env:dev": "NODE_ENV=development BASE_URL='/' VITE_BASE_URL='/' PUBLIC_ORIGIN='http://localhost:5173' VITE_PUBLIC_ORIGIN='http://localhost:5173' VITE_PUBLIC_ORIGIN='http://localhost:5173'",
+    "env:gh": "GITHUB_PAGES=true PUBLIC_ORIGIN='https://nicobrinkkemper.github.io' BASE_URL='/vite-plugin-react-server-demo-official/'",
+    "env:preview": "PUBLIC_ORIGIN='http://localhost:4173' BASE_URL='/vite-plugin-react-server-demo-official/'",
+    "env:dev": "NODE_ENV=development BASE_URL='/' PUBLIC_ORIGIN='http://localhost:5173'",
     "env:dev-server": "NODE_OPTIONS='--conditions react-server' npm run env:dev",
-    "env:start": "NODE_ENV=development BASE_URL='/' VITE_BASE_URL='/' VITE_PUBLIC_ORIGIN='http://localhost:5173' VITE_PUBLIC_ORIGIN='http://localhost:5173'",
+    "env:start": "NODE_ENV=development BASE_URL='/' PUBLIC_ORIGIN='http://localhost:5173'",
     "build": "NODE_OPTIONS='--conditions react-server' vite build --app",
     "build:static": "vite build",
     "build:client": "vite build --ssr",
@@ -44,7 +44,7 @@
     "react-dom": "^19.2.7",
     "tsx": "^4.22.4",
     "vite": "^6.4.3",
-    "vite-plugin-react-server": "^3.2.1",
+    "vite-plugin-react-server": "^3.2.3",
     "webpack-sources": "^3.5.0"
   }
 }

--- a/src/page/error-example/props.ts
+++ b/src/page/error-example/props.ts
@@ -3,7 +3,7 @@ declare global {
     env: {
       VITE_DEV: boolean;
       NODE_ENV: string;
-      VITE_BASE_URL: string;
+      PUBLIC_ORIGIN: string;
     };
   }
 }

--- a/src/page/props.ts
+++ b/src/page/props.ts
@@ -1,5 +1,6 @@
 export const props = (url: string) => {
-  const origin = import.meta.env.VITE_PUBLIC_ORIGIN ?? "";
+  // Baked by vprs from the plugin's `publicOrigin` option ("" when unset).
+  const origin = import.meta.env.PUBLIC_ORIGIN ?? "";
   const base = import.meta.env.BASE_URL ?? "/";
   let pathname = origin.includes("//")
     ? new URL(base, origin).pathname

--- a/vite.react.config.ts
+++ b/vite.react.config.ts
@@ -30,7 +30,9 @@ export default {
   Html: "src/Html.tsx",
   verbose: false,
   moduleBasePath: "/",
-  moduleBaseURL: process.env.BASE_URL || process.env.VITE_BASE_URL || "/",
+  // No moduleBaseURL: vprs ≥3.2.3 takes Vite's `base` (vite.config.ts reads
+  // BASE_URL), so the deploy base is configured once.
+  publicOrigin: process.env.PUBLIC_ORIGIN || "",
   serverEntry: "src/server/index.ts",
   css: {
     inlineThreshold: 10000,


### PR DESCRIPTION
Since vite-plugin-react-server 3.2.3 the plugin takes the deploy base from Vite's own `config.base` and mirrors it into the build env itself, so the workaround from #114 (exporting `VITE_BASE_URL`/`VITE_PUBLIC_ORIGIN` alongside the bare vars in every env script) is no longer needed — this repo now demonstrates the intended spelling: configure `base` once, in Vite.

- env scripts (`env:gh`, `env:preview`, `env:dev`, `env:start`): only the bare `BASE_URL`/`PUBLIC_ORIGIN` remain (also removes a duplicated `VITE_PUBLIC_ORIGIN` in `env:dev`, and `env:start` gains the bare `PUBLIC_ORIGIN` it was missing).
- `vite.react.config.ts`: the explicit `moduleBaseURL` line is gone (config.base carries it); `publicOrigin` is now passed as a plugin option from bare `PUBLIC_ORIGIN`.
- `src/page/props.ts`: reads the vprs-baked `import.meta.env.PUBLIC_ORIGIN` instead of the raw `VITE_PUBLIC_ORIGIN` env var.
- vprs bumped to `^3.2.3`.

Verified: `npm run build:gh` emits the base-prefixed bootstrap module URL on every SSG page (`/`, `/bidoof`, `/todos` checked) — the un-prefixed spelling of that URL is exactly what broke the GitHub Pages deploy before #114 — and bakes the origin into absolute URLs; `npm test` (build + Playwright e2e) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)