### PR TITLE
chore(deps): vite-plugin-react-server 3.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "^19.2.7",
         "tsx": "^4.22.4",
         "vite": "^6.4.3",
-        "vite-plugin-react-server": "^3.2.3",
+        "vite-plugin-react-server": "^3.3.0",
         "webpack-sources": "^3.5.0"
       }
     },
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.2.3.tgz",
-      "integrity": "sha512-UFpTnXnjW1Sq0DB8TqlGVVNCAdrgFGcaNjQY2MytdsTq2eK1RHl+Zqo2u3zHGlkndq2qSXNVEVF6AAoRhZtnLg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.3.0.tgz",
+      "integrity": "sha512-A7mjyxKYBmpJYa0RRo/bG+QXkWzhWCYPad8ZMnhcGZ0pFdCrrLWhEGkPoqEnaNvdfHaPa6cvoVUXI6F+lOW0uA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^19.2.7",
     "tsx": "^4.22.4",
     "vite": "^6.4.3",
-    "vite-plugin-react-server": "^3.2.3",
+    "vite-plugin-react-server": "^3.3.0",
     "webpack-sources": "^3.5.0"
   }
 }


### PR DESCRIPTION
Quiet default logs (vprs #276) + the metrics overhaul (vprs #277): warm-up first batch, per-batch overview lines, consolidated per-route file lines, and the new summary metrics. This repo doesn't wire `onMetrics`, so the visible change is a quieter default build; the richer output is one `metricWatcher` away.

`npm test` (build + Playwright e2e, incl. server actions and flash-free dynamic SSR): green on the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)