### PR TITLE
chore: bump vite-plugin-react-server to v3.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "^19.2.7",
         "tsx": "^4.22.4",
         "vite": "^6.4.3",
-        "vite-plugin-react-server": "^3.4.2",
+        "vite-plugin-react-server": "^3.4.3",
         "webpack-sources": "^3.5.0"
       }
     },
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.4.2.tgz",
-      "integrity": "sha512-4ZTj76qxF2bUPLqZdKveNugba2IhbygG3D0UaX3yxhP0Zd2BdSgYj720R1DE3IE/yWeDbMfi3Jy6kE9wNrExUA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.4.3.tgz",
+      "integrity": "sha512-5dAV0wXqf727+2sRXrDqY1ntIgp/onV+Vk/ukpMGPEoPxrD++fRyUAiDPVJDKsHsb+8PQ7yI5FL0lS+FaHkgpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "^19.2.7",
         "tsx": "^4.22.4",
         "vite": "^6.4.3",
-        "vite-plugin-react-server": "^3.3.0",
+        "vite-plugin-react-server": "^3.4.2",
         "webpack-sources": "^3.5.0"
       }
     },
@@ -1862,9 +1862,9 @@
       }
     },
     "node_modules/react-server-loader": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.17.tgz",
-      "integrity": "sha512-XrmiJi2gPp1Fk0s9Bq8Fs+82WCYv+TDH7GLZQqNTvYU3caaOCOoVCyMw6YEYn8JQzNukvie2QsHqQcOvQUsHoA==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.18.tgz",
+      "integrity": "sha512-grrUSq8rVeI4eBnY1Uv9pu+IgCwQiLGJkCHVyhZ6rihwfpPa7KNl8mosaJDQZGqddYWmBH9D2IRifddKxuzpFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2112,15 +2112,15 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.3.0.tgz",
-      "integrity": "sha512-A7mjyxKYBmpJYa0RRo/bG+QXkWzhWCYPad8ZMnhcGZ0pFdCrrLWhEGkPoqEnaNvdfHaPa6cvoVUXI6F+lOW0uA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.4.2.tgz",
+      "integrity": "sha512-4ZTj76qxF2bUPLqZdKveNugba2IhbygG3D0UaX3yxhP0Zd2BdSgYj720R1DE3IE/yWeDbMfi3Jy6kE9wNrExUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "react-server-loader": "^19.2.17 || 0.0.0-experimental-172742b4-20260716",
+        "react-server-loader": "^19.2.18 || 0.0.0-experimental-172742b4-20260716.1",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^19.2.7",
     "tsx": "^4.22.4",
     "vite": "^6.4.3",
-    "vite-plugin-react-server": "^3.4.2",
+    "vite-plugin-react-server": "^3.4.3",
     "webpack-sources": "^3.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^19.2.7",
     "tsx": "^4.22.4",
     "vite": "^6.4.3",
-    "vite-plugin-react-server": "^3.3.0",
+    "vite-plugin-react-server": "^3.4.2",
     "webpack-sources": "^3.5.0"
   }
 }


### PR DESCRIPTION
Bumps vite-plugin-react-server to v3.4.3 (supersedes the 3.4.2 bump on this branch; 3.4.3 adds SSG shell-render error surfacing on top of the 3.4.2 dev fixes).

`build:preview` verified green on the registry install. Note: this repo has no shell-throwing client components, so the new fail-loud SSG behavior changes nothing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)