### PR TITLE
chore: bump vite-plugin-react-server to v3.4.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "^19.2.7",
         "tsx": "^4.22.4",
         "vite": "^6.4.3",
-        "vite-plugin-react-server": "^3.4.3",
+        "vite-plugin-react-server": "^3.4.6",
         "webpack-sources": "^3.5.0"
       }
     },
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.4.3.tgz",
-      "integrity": "sha512-5dAV0wXqf727+2sRXrDqY1ntIgp/onV+Vk/ukpMGPEoPxrD++fRyUAiDPVJDKsHsb+8PQ7yI5FL0lS+FaHkgpA==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.4.6.tgz",
+      "integrity": "sha512-4C80UZ+/gppvcaeCazEh35CrU4dZGpNZHTQDbvxPCtsRf4dtm5zZPGxdqi4cvU4a6JL1tXx/9DQStRENGrxT4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^19.2.7",
     "tsx": "^4.22.4",
     "vite": "^6.4.3",
-    "vite-plugin-react-server": "^3.4.3",
+    "vite-plugin-react-server": "^3.4.6",
     "webpack-sources": "^3.5.0"
   }
 }


### PR DESCRIPTION
Bumps vite-plugin-react-server to v3.4.6 (serving-origin URLs — a baked PUBLIC_ORIGIN can no longer split the module graph into two Reacts on an origin mismatch; plus the 3.4.4/3.4.5 dev and test-infra fixes).

`build:preview` verified green on the registry install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)