### PR TITLE
chore(deps): vite-plugin-react-server 3.4.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "^19.2.7",
         "tsx": "^4.22.4",
         "vite": "^6.4.3",
-        "vite-plugin-react-server": "^3.4.6",
+        "vite-plugin-react-server": "^3.4.7",
         "webpack-sources": "^3.5.0"
       }
     },
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.4.6.tgz",
-      "integrity": "sha512-4C80UZ+/gppvcaeCazEh35CrU4dZGpNZHTQDbvxPCtsRf4dtm5zZPGxdqi4cvU4a6JL1tXx/9DQStRENGrxT4A==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.4.7.tgz",
+      "integrity": "sha512-36P3HjgqXZ+9rJKSa2rz9GEO/abGqkv1FGHMEUGaaWM8BK7dQDGKC44t8evmISAJ4vILl24KrZKtQeDo9bZPww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^19.2.7",
     "tsx": "^4.22.4",
     "vite": "^6.4.3",
-    "vite-plugin-react-server": "^3.4.6",
+    "vite-plugin-react-server": "^3.4.7",
     "webpack-sources": "^3.5.0"
   }
 }


### PR DESCRIPTION
Patch release: dev HMR for server-only CSS modules (class hashes tracked
across edits without a restart), panic flag across the worker boundary,
hydrateOrRender user-abort wording.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
