### PR TITLE
feat(config): replace the hand-rolled url switch with the routes field

### DIFF
--- a/vite.react.config.ts
+++ b/vite.react.config.ts
@@ -1,32 +1,13 @@
 import type { StreamPluginOptions } from "vite-plugin-react-server/types";
 
-const createRouter = (file: "props.ts" | "page.tsx") => (url: string) => {
-  switch (url) { 
-    case "/bidoof":
-      return `src/page/bidoof/${file}`;
-    case "/404":
-      return `src/page/404/${file}`;
-    case "/error-example":
-      return `src/page/error-example/${file}`;
-    case "/":
-      return `src/page/${file}`;
-    case "/todos":
-      return `src/page/todos/${file}`;
-    default: {
-      if (process.env.NODE_ENV === "development") {
-        return `src/page/404/${file}`;
-      }
-      throw new Error(
-        `Unknown route: ${typeof url === "string" ? url : JSON.stringify(url)}`
-      );
-    }
-  }
-};
 console.log('process.env.VITE_GITHUB_PAGES', process.env.VITE_GITHUB_PAGES);
 export default {
   moduleBase: "src",
-  Page: createRouter("page.tsx"),
-  props: createRouter("props.ts"),
+  // File-based routing in one field: scans src/page/** for page.tsx (+ sibling
+  // props.ts) and derives Page / props / routePatterns / the prerender
+  // worklist. All five routes are static, so build.pages is discovered from
+  // the tree — no more hand-rolled url switch to keep in sync.
+  routes: { dir: "page" },
   Html: "src/Html.tsx",
   verbose: false,
   moduleBasePath: "/",
@@ -38,7 +19,6 @@ export default {
     inlineThreshold: 10000,
   },
   build: {
-    pages: ["/", "/bidoof", "/404", "/todos", "/error-example"],
     // The single-isolate edge bundle (dist/server-edge/render.js, server React
     // inlined) is ON by default — it's what lets /todos render flash-free per
     // request in ONE isolate, no html-worker and no runtime `--conditions


### PR DESCRIPTION
vite-plugin-react-server ships a file router: `routes: { dir: "page" }` scans `src/page/**` for `page.tsx` (+ sibling `props.ts`) and derives `Page` / `props` / `routePatterns` / `build.pages` from the tree. This deletes the `createRouter(file) => (url) => switch {…}` and the hand-maintained `build.pages` list — adding a route is now just adding a folder.

One dev-only behavior change: an unknown url errors (`no route matches`) instead of silently serving the 404 page. Production serving is unchanged (`/404` still prerenders).

Verified: prod build renders the same 5 pages from the discovered tree; e2e 3/3 green (server-action persistence, direct server-function import from a client component, flash-free dynamic SSR with zero refetch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)