### PR TITLE
chore(deps): vite-plugin-react-server 3.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "^19.2.7",
         "tsx": "^4.22.4",
         "vite": "^6.4.3",
-        "vite-plugin-react-server": "^3.4.7",
+        "vite-plugin-react-server": "^3.5.0",
         "webpack-sources": "^3.5.0"
       }
     },
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.4.7.tgz",
-      "integrity": "sha512-36P3HjgqXZ+9rJKSa2rz9GEO/abGqkv1FGHMEUGaaWM8BK7dQDGKC44t8evmISAJ4vILl24KrZKtQeDo9bZPww==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.5.0.tgz",
+      "integrity": "sha512-8KLnxVTgrdshfhHv9pDIAQVSqj47y5jRJq1qDhxCKKZkDxNg2v8pftbFkHlGDgcKZdgV6ogPPML1q0rLANVYLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^19.2.7",
     "tsx": "^4.22.4",
     "vite": "^6.4.3",
-    "vite-plugin-react-server": "^3.4.7",
+    "vite-plugin-react-server": "^3.5.0",
     "webpack-sources": "^3.5.0"
   }
 }


### PR DESCRIPTION
Bumps `vite-plugin-react-server` from ^3.4.7 to ^3.5.0, the router parity release: index routes, pathless groups, error/loading boundaries, `head.ts`, and loader `redirect`/`notFound`.

## Verification

- `npm ls vite-plugin-react-server` resolves 3.5.0
- `npm run build` — production `--app` build green, 5 static pages rendered
- `npm test` (`test:e2e`) — 3/3 Playwright specs pass against the plain-Node prod server (no `--conditions` flag): server actions persist across reload, a client component directly importing a server function, and flash-free dynamic SSR with zero-refetch hydration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F24bCFmZ82fRkfH5PGgnxy