### PR TITLE
chore: vite-plugin-react-server 3.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "^19.2.7",
         "tsx": "^4.22.4",
         "vite": "^6.4.3",
-        "vite-plugin-react-server": "^3.5.0",
+        "vite-plugin-react-server": "^3.5.1",
         "webpack-sources": "^3.5.0"
       }
     },
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.5.0.tgz",
-      "integrity": "sha512-8KLnxVTgrdshfhHv9pDIAQVSqj47y5jRJq1qDhxCKKZkDxNg2v8pftbFkHlGDgcKZdgV6ogPPML1q0rLANVYLA==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.5.1.tgz",
+      "integrity": "sha512-W/DPCtFAHX0WRpBjHMgXEAy3QQ8xK9ba0pjnXHYJyD39T/qc1P4LFfwSQRRzNayuYI1+oH56rzyZYtHiMXfotg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^19.2.7",
     "tsx": "^4.22.4",
     "vite": "^6.4.3",
-    "vite-plugin-react-server": "^3.5.0",
+    "vite-plugin-react-server": "^3.5.1",
     "webpack-sources": "^3.5.0"
   }
 }


### PR DESCRIPTION
Pins the lockfile to the published 3.5.1 patch (Vite 6/7 entry-resolution fix, vite-plugin-react-server#317). `build:preview` verified green against the published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)