### PR TITLE
chore: vite-plugin-react-server 3.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "^19.2.7",
         "tsx": "^4.22.4",
         "vite": "^8.2.0",
-        "vite-plugin-react-server": "^3.5.3",
+        "vite-plugin-react-server": "^3.6.0",
         "webpack-sources": "^3.5.0"
       }
     },
@@ -995,6 +995,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/acorn-loose": {
       "version": "8.5.2",
       "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.5.2.tgz",
@@ -1530,13 +1540,14 @@
       }
     },
     "node_modules/react-server-loader": {
-      "version": "19.2.18",
-      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.18.tgz",
-      "integrity": "sha512-grrUSq8rVeI4eBnY1Uv9pu+IgCwQiLGJkCHVyhZ6rihwfpPa7KNl8mosaJDQZGqddYWmBH9D2IRifddKxuzpFQ==",
+      "version": "19.2.19",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.19.tgz",
+      "integrity": "sha512-zwRsbVhd/xm5BO6lAVl/d0pVhq+0vlPPjIAV+RyVzMYeZ7qVErQRaR1eLY9T2R3pg+rZ0ahPPsdvibAfl506uQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
         "picocolors": "^1.1.1",
         "source-map": "^0.7.6"
       },
@@ -1544,8 +1555,8 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7"
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8"
       }
     },
     "node_modules/rolldown": {
@@ -1754,15 +1765,15 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.5.3.tgz",
-      "integrity": "sha512-40ue7B2IHhVBfxoqzSu/cy4jlBjst+vX1/G7jDkNCkS2qoFKPx9Yj9qcsKR8ZkykYEc9WzaAz4GqIzIqOERjoQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.6.0.tgz",
+      "integrity": "sha512-vsKHXmcCOw4KFC7+AvU7EGi0czRsJZMbhBope89MZndxewSDB8P4opvDlvpgI/kprQCfdfRIlw0EXoYnnYZJmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "react-server-loader": "^19.2.18 || 0.0.0-experimental-172742b4-20260716.1",
+        "react-server-loader": "^19.2.19 || 0.0.0-experimental-7dfc7ccd-20260803",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^19.2.7",
     "tsx": "^4.22.4",
     "vite": "^8.2.0",
-    "vite-plugin-react-server": "^3.5.3",
+    "vite-plugin-react-server": "^3.6.0",
     "webpack-sources": "^3.5.0"
   }
 }


### PR DESCRIPTION
Bumps ^3.5.3 → 3.6.0 on top of the in-flight `fix/v3.5.2` line (Vite 8 move). 3.6.0 highlights relevant here: rsl 19.2.19 (JSX-capable directive analysis, React ^19.2.8 peer), `transformWithOxc` on Vite 8 (no more dev deprecation warning), and the `handleServerAction` breaking change — bidoof dispatches actions through the baked `handleRouteAction` gate, so it is unaffected. Local `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)