### PR TITLE
chore: vite-plugin-react-server 3.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "^19.2.7",
         "tsx": "^4.22.4",
         "vite": "^8.2.0",
-        "vite-plugin-react-server": "^3.7.0",
+        "vite-plugin-react-server": "^3.9.0",
         "webpack-sources": "^3.5.0"
       }
     },
@@ -1765,9 +1765,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.7.0.tgz",
-      "integrity": "sha512-abzu8S4z1BetpKQEx1XGwidmfcFQGQa40yG06xgX396EOVRUZEfmcn59KPvltc9n9vaMRzZIA6jEvKEE+ng/6A==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.9.0.tgz",
+      "integrity": "sha512-MFduI5ICwUJ+g6Wrh1orTx+NmLdqg6WneiFJ81lCUZ8z4TlHaa/hU1mb67Rkp5jBAo+XpP+LRKQ0vEAGFc6xHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "^19.2.7",
         "tsx": "^4.22.4",
         "vite": "^8.2.0",
-        "vite-plugin-react-server": "^3.6.0",
+        "vite-plugin-react-server": "^3.7.0",
         "webpack-sources": "^3.5.0"
       }
     },
@@ -1765,9 +1765,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.6.0.tgz",
-      "integrity": "sha512-vsKHXmcCOw4KFC7+AvU7EGi0czRsJZMbhBope89MZndxewSDB8P4opvDlvpgI/kprQCfdfRIlw0EXoYnnYZJmQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.7.0.tgz",
+      "integrity": "sha512-abzu8S4z1BetpKQEx1XGwidmfcFQGQa40yG06xgX396EOVRUZEfmcn59KPvltc9n9vaMRzZIA6jEvKEE+ng/6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^19.2.7",
     "tsx": "^4.22.4",
     "vite": "^8.2.0",
-    "vite-plugin-react-server": "^3.6.0",
+    "vite-plugin-react-server": "^3.7.0",
     "webpack-sources": "^3.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^19.2.7",
     "tsx": "^4.22.4",
     "vite": "^8.2.0",
-    "vite-plugin-react-server": "^3.7.0",
+    "vite-plugin-react-server": "^3.9.0",
     "webpack-sources": "^3.5.0"
   }
 }


### PR DESCRIPTION
Registry bump to vite-plugin-react-server 3.7.0 (layouts-warning DX, edge-bake failure naming, html-render deadline, dead handler-layer removal — full notes on the vprs release PR #338).

No config changes needed: this template already uses `routes: { dir }`, so the new unwired-layouts warning has nothing to catch here.

Verified: full Playwright e2e against the prod build on the bumped install — 3/3 (server-action round-trip with persistence, client-imported server function, flash-free dynamic SSR with zero-refetch hydration). This mirrors the pre-release tarball validation that ran against this repo before 3.7.0 shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)