### PR TITLE
chore: vite-plugin-react-server 3.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "^19.2.7",
         "tsx": "^4.22.4",
         "vite": "^8.2.0",
-        "vite-plugin-react-server": "^3.9.0",
+        "vite-plugin-react-server": "^3.9.1",
         "webpack-sources": "^3.5.0"
       }
     },
@@ -1765,9 +1765,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.9.0.tgz",
-      "integrity": "sha512-MFduI5ICwUJ+g6Wrh1orTx+NmLdqg6WneiFJ81lCUZ8z4TlHaa/hU1mb67Rkp5jBAo+XpP+LRKQ0vEAGFc6xHg==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.9.1.tgz",
+      "integrity": "sha512-r4nD73hk9pW05HX5bHDeFOiMjeSAnY+R1a8MzDZOhAChePvz4+2yaKN/oqjJzy7izkShzd8jIAipYyHbuYawIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^19.2.7",
     "tsx": "^4.22.4",
     "vite": "^8.2.0",
-    "vite-plugin-react-server": "^3.9.0",
+    "vite-plugin-react-server": "^3.9.1",
     "webpack-sources": "^3.5.0"
   }
 }


### PR DESCRIPTION
Patch bump: the directive-driven action gate (this app's `.server.`-named actions gate identically — verified prod e2e 3/3 against the published package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHY8KAH6Taq7boWCzEB47M