### PR TITLE
feat: prerender the full dex — all 1025 species static

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ The app is small on purpose; every route exists to show one capability:
 | Route | Rendering | Shows |
 | --- | --- | --- |
 | `/` | static | server pages, layout, a client component (the walking Bidoof) |
-| `/pokedex/` | static | a 151-card grid + client-side search over the FULL roster (a vendored name index served as a static asset) — prerendered from a committed dataset, no network at build time |
-| `/pokedex/$name/` | **hybrid** | file-router dynamic params: the 151 gen-1 Pokémon are prerendered via `staticPaths`; **any other name renders per request** on the same route, fetched live from PokéAPI |
+| `/pokedex/` | static | all 1025 Pokémon as cards + client-side search over the full roster (a vendored name index served as a static asset) — prerendered from a committed dataset, no network at build time |
+| `/pokedex/$name/` | **hybrid** | file-router dynamic params: every species is prerendered via `staticPaths`; **special forms (Megas, regional variants) render per request** on the same route, fetched live from PokéAPI |
 | `/404/` | static | `notFound()` thrown from a loader |
 
-The mascot doubles as the demo: Bidoof is gen 4, so `/pokedex/bidoof/` is deliberately *not* in the static build — it only renders through the server's live path (`npm run demo`), flash-free, in a single Node isolate with no `--conditions` flag. On the static-only GitHub Pages deploy that URL answers 404, which is the honest difference between the two render modes.
+The full dex — 1025 pages — prerenders in about 17 seconds. What stays dynamic are the alternate forms (Mega evolutions, regional variants, costumes): they render through the server's live path (`npm run demo`), flash-free, in a single Node isolate with no `--conditions` flag. On the static-only GitHub Pages deploy those URLs answer 404, which is the honest difference between the two render modes.
 
 Also demonstrated:
 
@@ -22,7 +22,7 @@ Also demonstrated:
 - Client / server boundary: error boundary, `useState`, hydration from the inlined flight payload
 - Static site generation with "headless" `index.rsc` files next to fully static `index.html` files
 
-The gen-1 dataset is committed (`src/data/pokedex.json`) so builds are deterministic and offline; regenerate it with `node scripts/generate-pokedex.mjs`.
+The dataset is committed (`src/data/pokedex.json`) so builds are deterministic and offline; regenerate it with `node scripts/generate-pokedex.mjs`.
 
 Clone the repository to see the development process in action.
 

--- a/e2e/pokedex.spec.ts
+++ b/e2e/pokedex.spec.ts
@@ -20,14 +20,14 @@ test.describe("static pages (prerendered)", () => {
     await expect(page.getByRole("heading", { name: "Pokédex" })).toBeVisible();
     await page.getByRole("link", { name: "Browse the Pokédex" }).click();
     await expect(page).toHaveURL(/\/pokedex\/$/);
-    await expect(page.getByText(/151 originals/)).toBeVisible();
+    await expect(page.getByText(/All 1025 Pokémon/)).toBeVisible();
   });
 
-  test("the grid lists all 151 and navigates to a detail page", async ({
+  test("the grid lists all 1025 and navigates to a detail page", async ({
     page,
   }) => {
     await page.goto("/pokedex/");
-    await expect(page.locator("li")).toHaveCount(151);
+    await expect(page.locator("li")).toHaveCount(1025);
     await page.getByRole("link", { name: /pikachu/ }).click();
     await expect(page).toHaveURL(/\/pokedex\/pikachu\/$/);
     await expect(page.getByRole("heading", { name: /pikachu/ })).toBeVisible();
@@ -42,20 +42,24 @@ test.describe("static pages (prerendered)", () => {
 });
 
 test.describe("per-request path (not prerendered)", () => {
-  // Bidoof is gen 4 — deliberately outside the vendored dataset, so this page
+  // Alternate forms sit outside the vendored species dataset, so this page
   // only exists through the server's live render (loader fetches PokéAPI).
-  test("bidoof renders per request with the live badge", async ({ page }) => {
-    const response = await page.goto("/pokedex/bidoof/");
+  test("a special form renders per request with the live badge", async ({
+    page,
+  }) => {
+    const response = await page.goto("/pokedex/pikachu-rock-star/");
     test.skip(
       response?.status() === 404,
       "PokéAPI unreachable from this environment",
     );
-    await expect(page.getByRole("heading", { name: /bidoof/ })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /pikachu-rock-star/ }),
+    ).toBeVisible();
     await expect(page.getByText("rendered per request")).toBeVisible();
     // The document is flash-free: the name is IN the server HTML, not
     // client-rendered after the fact.
     const html = await response!.text();
-    expect(html).toContain("bidoof");
+    expect(html).toContain("pikachu-rock-star");
   });
 
   test("an unknown name answers 404 with the not-found page", async ({
@@ -85,21 +89,21 @@ test.describe("pokemon search", () => {
     await expect(page).toHaveURL(/\/pokedex\/pikachu\/$/);
   });
 
-  test("a match beyond the originals reaches the per-request route", async ({
+  test("a form match beyond the dataset reaches the per-request route", async ({
     page,
   }) => {
     await page.goto("/pokedex/");
     await page.waitForLoadState("networkidle");
     await page.waitForTimeout(1000);
 
-    await page.getByLabel("Search Pokémon by name").fill("lucario");
+    await page.getByLabel("Search Pokémon by name").fill("rock-star");
     const result = page
       .getByLabel("search results")
-      .locator('a[href="/pokedex/lucario/"]');
+      .locator('a[href="/pokedex/pikachu-rock-star/"]');
     await expect(result).toBeVisible();
     await result.click();
     await expect(
-      page.getByRole("heading", { name: /lucario/ }),
+      page.getByRole("heading", { name: /pikachu-rock-star/ }),
     ).toBeVisible({ timeout: 15000 });
     await expect(page.getByText("rendered per request")).toBeVisible();
   });
@@ -168,7 +172,7 @@ test.describe("navigation transition state", () => {
     await page.waitForLoadState("networkidle");
     await page.waitForTimeout(1000);
 
-    const link = page.getByRole("link", { name: "Bidoof" });
+    const link = page.getByRole("link", { name: "visit Bidoof" });
     await link.click();
     // The clicked link itself announces the transition…
     await expect(link).toHaveAttribute("aria-busy", "true");

--- a/scripts/generate-pokedex.mjs
+++ b/scripts/generate-pokedex.mjs
@@ -1,11 +1,11 @@
-// Regenerate the vendored gen-1 dataset: node scripts/generate-pokedex.mjs
+// Regenerate the vendored full-dex dataset: node scripts/generate-pokedex.mjs
 // Static builds read the committed JSON and never touch the network; only
-// per-request renders of non-gen-1 Pokémon fetch PokéAPI live.
+// per-request renders of special forms (ids above 10000) fetch PokéAPI live.
 import { writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 const OUT = fileURLToPath(new URL("../src/data/pokedex.json", import.meta.url));
-const COUNT = 151;
+const COUNT = 1025;
 
 const get = async (url) => {
   const res = await fetch(url);

--- a/src/components/PokemonSearch.client.tsx
+++ b/src/components/PokemonSearch.client.tsx
@@ -9,6 +9,8 @@ import styles from "../css/pokedex.module.css";
 type NameEntry = { id: number; name: string };
 
 const MAX_RESULTS = 24;
+// Species ids; alternate forms sit above 10000 and are not in the dataset.
+const MAX_SPECIES_ID = 1025;
 
 // Search over EVERY Pokémon, statically: the full name+id index is a build
 // artifact (public/names.json) fetched once on mount, matches render as the
@@ -21,8 +23,8 @@ export const PokemonSearch = ({
 }: {
   namesHref: string;
   action: string;
-  /** Static-only deploy (GitHub Pages): only the prerendered originals
-   *  exist, so search offers just those. */
+  /** Static-only deploy (GitHub Pages): only the prerendered species exist,
+   *  so search offers just those (special forms need a server). */
   staticOnly?: boolean;
 }) => {
   const router = useOptionalRouter();
@@ -43,7 +45,9 @@ export const PokemonSearch = ({
   }, [namesHref]);
 
   const q = toSlug(query);
-  const searchable = staticOnly ? index.filter((entry) => entry.id <= 151) : index;
+  const searchable = staticOnly
+    ? index.filter((entry) => entry.id <= MAX_SPECIES_ID)
+    : index;
   const results = q
     ? searchable.filter((entry) => entry.name.includes(q)).slice(0, MAX_RESULTS)
     : [];

--- a/src/data/pokedex.json
+++ b/src/data/pokedex.json
@@ -2783,5 +2783,16196 @@
    "speed": 100
   },
   "flavor": "So rare that it is still said to be a mirage by many experts. Only a few people have seen it worldwide."
+ },
+ {
+  "id": 152,
+  "name": "chikorita",
+  "types": [
+   "grass"
+  ],
+  "height": 9,
+  "weight": 64,
+  "stats": {
+   "hp": 45,
+   "attack": 49,
+   "defense": 65,
+   "special-attack": 49,
+   "special-defense": 65,
+   "speed": 45
+  },
+  "flavor": "It uses the leaf on its head to determine the temperature and humidity. It loves to sunbathe."
+ },
+ {
+  "id": 153,
+  "name": "bayleef",
+  "types": [
+   "grass"
+  ],
+  "height": 12,
+  "weight": 158,
+  "stats": {
+   "hp": 60,
+   "attack": 62,
+   "defense": 80,
+   "special-attack": 63,
+   "special-defense": 80,
+   "speed": 60
+  },
+  "flavor": "The scent of spices comes from around its neck. Somehow, sniffing it makes you want to fight."
+ },
+ {
+  "id": 154,
+  "name": "meganium",
+  "types": [
+   "grass"
+  ],
+  "height": 18,
+  "weight": 1005,
+  "stats": {
+   "hp": 80,
+   "attack": 82,
+   "defense": 100,
+   "special-attack": 83,
+   "special-defense": 100,
+   "speed": 80
+  },
+  "flavor": "The aroma that rises from its petals contains a substance that calms aggressive feelings."
+ },
+ {
+  "id": 155,
+  "name": "cyndaquil",
+  "types": [
+   "fire"
+  ],
+  "height": 5,
+  "weight": 79,
+  "stats": {
+   "hp": 39,
+   "attack": 52,
+   "defense": 43,
+   "special-attack": 60,
+   "special-defense": 50,
+   "speed": 65
+  },
+  "flavor": "It is timid, and always curls it­ self up in a ball. If attacked, it flares up its back for protection."
+ },
+ {
+  "id": 156,
+  "name": "quilava",
+  "types": [
+   "fire"
+  ],
+  "height": 9,
+  "weight": 190,
+  "stats": {
+   "hp": 58,
+   "attack": 64,
+   "defense": 58,
+   "special-attack": 80,
+   "special-defense": 65,
+   "speed": 80
+  },
+  "flavor": "Be careful if it turns its back during battle. It means that it will attack with the fire on its back."
+ },
+ {
+  "id": 157,
+  "name": "typhlosion",
+  "types": [
+   "fire"
+  ],
+  "height": 17,
+  "weight": 795,
+  "stats": {
+   "hp": 78,
+   "attack": 84,
+   "defense": 78,
+   "special-attack": 109,
+   "special-defense": 85,
+   "speed": 100
+  },
+  "flavor": "If its rage peaks, it becomes so hot that anything that touches it will instantly go up in flames."
+ },
+ {
+  "id": 158,
+  "name": "totodile",
+  "types": [
+   "water"
+  ],
+  "height": 6,
+  "weight": 95,
+  "stats": {
+   "hp": 50,
+   "attack": 65,
+   "defense": 64,
+   "special-attack": 44,
+   "special-defense": 48,
+   "speed": 43
+  },
+  "flavor": "Its well-developed jaws are powerful and capable of crushing anything. Even its trainer must be careful."
+ },
+ {
+  "id": 159,
+  "name": "croconaw",
+  "types": [
+   "water"
+  ],
+  "height": 11,
+  "weight": 250,
+  "stats": {
+   "hp": 65,
+   "attack": 80,
+   "defense": 80,
+   "special-attack": 59,
+   "special-defense": 63,
+   "speed": 58
+  },
+  "flavor": "If it loses a fang, a new one grows back in its place. There are always 48 fangs lining its mouth."
+ },
+ {
+  "id": 160,
+  "name": "feraligatr",
+  "types": [
+   "water"
+  ],
+  "height": 23,
+  "weight": 888,
+  "stats": {
+   "hp": 85,
+   "attack": 105,
+   "defense": 100,
+   "special-attack": 79,
+   "special-defense": 83,
+   "speed": 78
+  },
+  "flavor": "When it bites with its massive and powerful jaws, it shakes its head and savagely tears its victim up."
+ },
+ {
+  "id": 161,
+  "name": "sentret",
+  "types": [
+   "normal"
+  ],
+  "height": 8,
+  "weight": 60,
+  "stats": {
+   "hp": 35,
+   "attack": 46,
+   "defense": 34,
+   "special-attack": 35,
+   "special-defense": 45,
+   "speed": 20
+  },
+  "flavor": "It has a very nervous nature. It stands up high on its tail so it can scan wide areas."
+ },
+ {
+  "id": 162,
+  "name": "furret",
+  "types": [
+   "normal"
+  ],
+  "height": 18,
+  "weight": 325,
+  "stats": {
+   "hp": 85,
+   "attack": 76,
+   "defense": 64,
+   "special-attack": 45,
+   "special-defense": 55,
+   "speed": 90
+  },
+  "flavor": "It makes a nest to suit its long and skinny body. The nest is impossible for other POKéMON to enter."
+ },
+ {
+  "id": 163,
+  "name": "hoothoot",
+  "types": [
+   "normal",
+   "flying"
+  ],
+  "height": 7,
+  "weight": 212,
+  "stats": {
+   "hp": 60,
+   "attack": 30,
+   "defense": 30,
+   "special-attack": 36,
+   "special-defense": 56,
+   "speed": 50
+  },
+  "flavor": "It always stands on one foot. It changes feet so fast, the movement can rarely be seen."
+ },
+ {
+  "id": 164,
+  "name": "noctowl",
+  "types": [
+   "normal",
+   "flying"
+  ],
+  "height": 16,
+  "weight": 408,
+  "stats": {
+   "hp": 100,
+   "attack": 50,
+   "defense": 50,
+   "special-attack": 86,
+   "special-defense": 96,
+   "speed": 70
+  },
+  "flavor": "Its eyes are specially adapted. They concentrate even faint light and enable it to see in the dark."
+ },
+ {
+  "id": 165,
+  "name": "ledyba",
+  "types": [
+   "bug",
+   "flying"
+  ],
+  "height": 10,
+  "weight": 108,
+  "stats": {
+   "hp": 40,
+   "attack": 20,
+   "defense": 30,
+   "special-attack": 40,
+   "special-defense": 80,
+   "speed": 55
+  },
+  "flavor": "It is very timid. It will be afraid to move if it is alone. But it will be active if it is in a group."
+ },
+ {
+  "id": 166,
+  "name": "ledian",
+  "types": [
+   "bug",
+   "flying"
+  ],
+  "height": 14,
+  "weight": 356,
+  "stats": {
+   "hp": 55,
+   "attack": 35,
+   "defense": 50,
+   "special-attack": 55,
+   "special-defense": 110,
+   "speed": 85
+  },
+  "flavor": "When the stars flicker in the night sky, it flutters about, scattering a glowing powder."
+ },
+ {
+  "id": 167,
+  "name": "spinarak",
+  "types": [
+   "bug",
+   "poison"
+  ],
+  "height": 5,
+  "weight": 85,
+  "stats": {
+   "hp": 40,
+   "attack": 60,
+   "defense": 40,
+   "special-attack": 40,
+   "special-defense": 40,
+   "speed": 30
+  },
+  "flavor": "It lies still in the same pose for days in its web, waiting for its unsuspecting prey to wander close."
+ },
+ {
+  "id": 168,
+  "name": "ariados",
+  "types": [
+   "bug",
+   "poison"
+  ],
+  "height": 11,
+  "weight": 335,
+  "stats": {
+   "hp": 70,
+   "attack": 90,
+   "defense": 70,
+   "special-attack": 60,
+   "special-defense": 70,
+   "speed": 40
+  },
+  "flavor": "It spins string not only from its rear but also from its mouth. It is hard to tell which end is which."
+ },
+ {
+  "id": 169,
+  "name": "crobat",
+  "types": [
+   "poison",
+   "flying"
+  ],
+  "height": 18,
+  "weight": 750,
+  "stats": {
+   "hp": 85,
+   "attack": 90,
+   "defense": 80,
+   "special-attack": 70,
+   "special-defense": 80,
+   "speed": 130
+  },
+  "flavor": "Having four wings allows it to fly more quickly and quietly so it can sneak up on prey without its noticing."
+ },
+ {
+  "id": 170,
+  "name": "chinchou",
+  "types": [
+   "water",
+   "electric"
+  ],
+  "height": 5,
+  "weight": 120,
+  "stats": {
+   "hp": 75,
+   "attack": 38,
+   "defense": 38,
+   "special-attack": 56,
+   "special-defense": 56,
+   "speed": 67
+  },
+  "flavor": "It shoots positive and negative elec­ tricity between the tips of its two antennae and zaps its enemies."
+ },
+ {
+  "id": 171,
+  "name": "lanturn",
+  "types": [
+   "water",
+   "electric"
+  ],
+  "height": 12,
+  "weight": 225,
+  "stats": {
+   "hp": 125,
+   "attack": 58,
+   "defense": 58,
+   "special-attack": 76,
+   "special-defense": 76,
+   "speed": 67
+  },
+  "flavor": "The light it emits is so bright that it can illuminate the sea's surface from a depth of over three miles."
+ },
+ {
+  "id": 172,
+  "name": "pichu",
+  "types": [
+   "electric"
+  ],
+  "height": 3,
+  "weight": 20,
+  "stats": {
+   "hp": 20,
+   "attack": 40,
+   "defense": 15,
+   "special-attack": 35,
+   "special-defense": 35,
+   "speed": 60
+  },
+  "flavor": "It is not yet skilled at storing electricity. It may send out a jolt if amused or startled."
+ },
+ {
+  "id": 173,
+  "name": "cleffa",
+  "types": [
+   "fairy"
+  ],
+  "height": 3,
+  "weight": 30,
+  "stats": {
+   "hp": 50,
+   "attack": 25,
+   "defense": 28,
+   "special-attack": 45,
+   "special-defense": 55,
+   "speed": 15
+  },
+  "flavor": "Because of its unusual, star-like silhouette, people believe that it came here on a meteor."
+ },
+ {
+  "id": 174,
+  "name": "igglybuff",
+  "types": [
+   "normal",
+   "fairy"
+  ],
+  "height": 3,
+  "weight": 10,
+  "stats": {
+   "hp": 90,
+   "attack": 30,
+   "defense": 15,
+   "special-attack": 40,
+   "special-defense": 20,
+   "speed": 15
+  },
+  "flavor": "It has a very soft body. If it starts to roll, it will bounce all over and be impossible to stop."
+ },
+ {
+  "id": 175,
+  "name": "togepi",
+  "types": [
+   "fairy"
+  ],
+  "height": 3,
+  "weight": 15,
+  "stats": {
+   "hp": 35,
+   "attack": 20,
+   "defense": 65,
+   "special-attack": 40,
+   "special-defense": 65,
+   "speed": 20
+  },
+  "flavor": "The shell seems to be filled with joy. It is said that it will share good luck when treated kindly."
+ },
+ {
+  "id": 176,
+  "name": "togetic",
+  "types": [
+   "fairy",
+   "flying"
+  ],
+  "height": 6,
+  "weight": 32,
+  "stats": {
+   "hp": 55,
+   "attack": 40,
+   "defense": 85,
+   "special-attack": 80,
+   "special-defense": 105,
+   "speed": 40
+  },
+  "flavor": "To share its happiness, it flies around the world seeking kind- hearted people."
+ },
+ {
+  "id": 177,
+  "name": "natu",
+  "types": [
+   "psychic",
+   "flying"
+  ],
+  "height": 2,
+  "weight": 20,
+  "stats": {
+   "hp": 40,
+   "attack": 50,
+   "defense": 45,
+   "special-attack": 70,
+   "special-defense": 45,
+   "speed": 70
+  },
+  "flavor": "Because its wings aren't yet fully grown, it has to hop to get around. It is always star­ ing at something."
+ },
+ {
+  "id": 178,
+  "name": "xatu",
+  "types": [
+   "psychic",
+   "flying"
+  ],
+  "height": 15,
+  "weight": 150,
+  "stats": {
+   "hp": 65,
+   "attack": 75,
+   "defense": 70,
+   "special-attack": 95,
+   "special-defense": 70,
+   "speed": 95
+  },
+  "flavor": "They say that it stays still and quiet because it is seeing both the past and future at the same time."
+ },
+ {
+  "id": 179,
+  "name": "mareep",
+  "types": [
+   "electric"
+  ],
+  "height": 6,
+  "weight": 78,
+  "stats": {
+   "hp": 55,
+   "attack": 40,
+   "defense": 40,
+   "special-attack": 65,
+   "special-defense": 45,
+   "speed": 35
+  },
+  "flavor": "If static elec­ tricity builds in its body, its fleece doubles in volume. Touching it will shock you."
+ },
+ {
+  "id": 180,
+  "name": "flaaffy",
+  "types": [
+   "electric"
+  ],
+  "height": 8,
+  "weight": 133,
+  "stats": {
+   "hp": 70,
+   "attack": 55,
+   "defense": 55,
+   "special-attack": 80,
+   "special-defense": 60,
+   "speed": 45
+  },
+  "flavor": "As a result of storing too much electricity, it developed patches where even downy wool won't grow."
+ },
+ {
+  "id": 181,
+  "name": "ampharos",
+  "types": [
+   "electric"
+  ],
+  "height": 14,
+  "weight": 615,
+  "stats": {
+   "hp": 90,
+   "attack": 75,
+   "defense": 85,
+   "special-attack": 115,
+   "special-defense": 90,
+   "speed": 55
+  },
+  "flavor": "The tail's tip shines brightly and can be seen from far away. It acts as a beacon for lost people."
+ },
+ {
+  "id": 182,
+  "name": "bellossom",
+  "types": [
+   "grass"
+  ],
+  "height": 4,
+  "weight": 58,
+  "stats": {
+   "hp": 75,
+   "attack": 80,
+   "defense": 95,
+   "special-attack": 90,
+   "special-defense": 100,
+   "speed": 50
+  },
+  "flavor": "BELLOSSOM gather at times and appear to dance. They say that the dance is a ritual to summon the sun."
+ },
+ {
+  "id": 183,
+  "name": "marill",
+  "types": [
+   "water",
+   "fairy"
+  ],
+  "height": 4,
+  "weight": 85,
+  "stats": {
+   "hp": 70,
+   "attack": 20,
+   "defense": 50,
+   "special-attack": 20,
+   "special-defense": 50,
+   "speed": 40
+  },
+  "flavor": "The tip of its tail, which con­ tains oil that is lighter than wa­ ter, lets it swim without drowning."
+ },
+ {
+  "id": 184,
+  "name": "azumarill",
+  "types": [
+   "water",
+   "fairy"
+  ],
+  "height": 8,
+  "weight": 285,
+  "stats": {
+   "hp": 100,
+   "attack": 50,
+   "defense": 80,
+   "special-attack": 60,
+   "special-defense": 80,
+   "speed": 50
+  },
+  "flavor": "By keeping still and listening in­ tently, it can tell what is in even wild, fast- moving rivers."
+ },
+ {
+  "id": 185,
+  "name": "sudowoodo",
+  "types": [
+   "rock"
+  ],
+  "height": 12,
+  "weight": 380,
+  "stats": {
+   "hp": 70,
+   "attack": 100,
+   "defense": 115,
+   "special-attack": 30,
+   "special-defense": 65,
+   "speed": 30
+  },
+  "flavor": "Despite appearing to be a tree, its body is closer to rocks and stones. It is very weak to water."
+ },
+ {
+  "id": 186,
+  "name": "politoed",
+  "types": [
+   "water"
+  ],
+  "height": 11,
+  "weight": 339,
+  "stats": {
+   "hp": 90,
+   "attack": 75,
+   "defense": 75,
+   "special-attack": 90,
+   "special-defense": 100,
+   "speed": 70
+  },
+  "flavor": "If POLIWAG and POLIWHIRL hear its echoing cry, they respond by gather­ ing from far and wide."
+ },
+ {
+  "id": 187,
+  "name": "hoppip",
+  "types": [
+   "grass",
+   "flying"
+  ],
+  "height": 4,
+  "weight": 5,
+  "stats": {
+   "hp": 35,
+   "attack": 35,
+   "defense": 40,
+   "special-attack": 35,
+   "special-defense": 55,
+   "speed": 50
+  },
+  "flavor": "To keep from being blown away by the wind, they gather in clusters. They do enjoy gentle breezes, though."
+ },
+ {
+  "id": 188,
+  "name": "skiploom",
+  "types": [
+   "grass",
+   "flying"
+  ],
+  "height": 6,
+  "weight": 10,
+  "stats": {
+   "hp": 55,
+   "attack": 45,
+   "defense": 50,
+   "special-attack": 45,
+   "special-defense": 65,
+   "speed": 80
+  },
+  "flavor": "The bloom on top of its head opens and closes as the temperature fluc­ tuates up and down."
+ },
+ {
+  "id": 189,
+  "name": "jumpluff",
+  "types": [
+   "grass",
+   "flying"
+  ],
+  "height": 8,
+  "weight": 30,
+  "stats": {
+   "hp": 75,
+   "attack": 55,
+   "defense": 70,
+   "special-attack": 55,
+   "special-defense": 95,
+   "speed": 110
+  },
+  "flavor": "Blown by seasonal winds, it circles the globe, scattering cotton spores as it goes."
+ },
+ {
+  "id": 190,
+  "name": "aipom",
+  "types": [
+   "normal"
+  ],
+  "height": 8,
+  "weight": 115,
+  "stats": {
+   "hp": 55,
+   "attack": 70,
+   "defense": 55,
+   "special-attack": 40,
+   "special-defense": 55,
+   "speed": 85
+  },
+  "flavor": "Its tail is so powerful that it can use it to grab a tree branch and hold itself up in the air."
+ },
+ {
+  "id": 191,
+  "name": "sunkern",
+  "types": [
+   "grass"
+  ],
+  "height": 3,
+  "weight": 18,
+  "stats": {
+   "hp": 30,
+   "attack": 30,
+   "defense": 30,
+   "special-attack": 30,
+   "special-defense": 30,
+   "speed": 30
+  },
+  "flavor": "It may drop out of the sky suddenly. If attacked by a SPEAROW, it will violently shake its leaves."
+ },
+ {
+  "id": 192,
+  "name": "sunflora",
+  "types": [
+   "grass"
+  ],
+  "height": 8,
+  "weight": 85,
+  "stats": {
+   "hp": 75,
+   "attack": 75,
+   "defense": 55,
+   "special-attack": 105,
+   "special-defense": 85,
+   "speed": 30
+  },
+  "flavor": "It converts sun­ light into energy. In the darkness after sunset, it closes its petals and becomes still."
+ },
+ {
+  "id": 193,
+  "name": "yanma",
+  "types": [
+   "bug",
+   "flying"
+  ],
+  "height": 12,
+  "weight": 380,
+  "stats": {
+   "hp": 65,
+   "attack": 65,
+   "defense": 45,
+   "special-attack": 75,
+   "special-defense": 45,
+   "speed": 95
+  },
+  "flavor": "If it flaps its wings really fast, it can generate shock waves that will shatter win­ dows in the area."
+ },
+ {
+  "id": 194,
+  "name": "wooper",
+  "types": [
+   "water",
+   "ground"
+  ],
+  "height": 4,
+  "weight": 85,
+  "stats": {
+   "hp": 55,
+   "attack": 45,
+   "defense": 45,
+   "special-attack": 25,
+   "special-defense": 25,
+   "speed": 15
+  },
+  "flavor": "This POKéMON lives in cold water. It will leave the water to search for food when it gets cold outside."
+ },
+ {
+  "id": 195,
+  "name": "quagsire",
+  "types": [
+   "water",
+   "ground"
+  ],
+  "height": 14,
+  "weight": 750,
+  "stats": {
+   "hp": 95,
+   "attack": 85,
+   "defense": 85,
+   "special-attack": 65,
+   "special-defense": 65,
+   "speed": 35
+  },
+  "flavor": "This carefree POKéMON has an easy-going nature. While swimming, it always bumps into boat hulls."
+ },
+ {
+  "id": 196,
+  "name": "espeon",
+  "types": [
+   "psychic"
+  ],
+  "height": 9,
+  "weight": 265,
+  "stats": {
+   "hp": 65,
+   "attack": 65,
+   "defense": 60,
+   "special-attack": 130,
+   "special-defense": 95,
+   "speed": 110
+  },
+  "flavor": "Its fur is so sensitive, it can sense minute shifts in the air and predict the weather."
+ },
+ {
+  "id": 197,
+  "name": "umbreon",
+  "types": [
+   "dark"
+  ],
+  "height": 10,
+  "weight": 270,
+  "stats": {
+   "hp": 95,
+   "attack": 65,
+   "defense": 110,
+   "special-attack": 60,
+   "special-defense": 130,
+   "speed": 65
+  },
+  "flavor": "When agitated, this POKéMON pro­ tects itself by spraying poisonous sweat from its pores."
+ },
+ {
+  "id": 198,
+  "name": "murkrow",
+  "types": [
+   "dark",
+   "flying"
+  ],
+  "height": 5,
+  "weight": 21,
+  "stats": {
+   "hp": 60,
+   "attack": 85,
+   "defense": 42,
+   "special-attack": 85,
+   "special-defense": 42,
+   "speed": 91
+  },
+  "flavor": "Feared and loathed by many, it is believed to bring misfortune to all those who see it at night."
+ },
+ {
+  "id": 199,
+  "name": "slowking",
+  "types": [
+   "water",
+   "psychic"
+  ],
+  "height": 20,
+  "weight": 795,
+  "stats": {
+   "hp": 95,
+   "attack": 75,
+   "defense": 80,
+   "special-attack": 100,
+   "special-defense": 110,
+   "speed": 30
+  },
+  "flavor": "It has incredible intellect and in­ tuition. Whatever the situation, it remains calm and collected."
+ },
+ {
+  "id": 200,
+  "name": "misdreavus",
+  "types": [
+   "ghost"
+  ],
+  "height": 7,
+  "weight": 10,
+  "stats": {
+   "hp": 60,
+   "attack": 60,
+   "defense": 60,
+   "special-attack": 85,
+   "special-defense": 85,
+   "speed": 85
+  },
+  "flavor": "It likes playing mischievous tricks such as screaming and wailing to startle people at night."
+ },
+ {
+  "id": 201,
+  "name": "unown",
+  "types": [
+   "psychic"
+  ],
+  "height": 5,
+  "weight": 50,
+  "stats": {
+   "hp": 48,
+   "attack": 72,
+   "defense": 48,
+   "special-attack": 72,
+   "special-defense": 48,
+   "speed": 48
+  },
+  "flavor": "Their shapes look like hieroglyphs on ancient tab­ lets. It is said that the two are somehow related."
+ },
+ {
+  "id": 202,
+  "name": "wobbuffet",
+  "types": [
+   "psychic"
+  ],
+  "height": 13,
+  "weight": 285,
+  "stats": {
+   "hp": 190,
+   "attack": 33,
+   "defense": 58,
+   "special-attack": 33,
+   "special-defense": 58,
+   "speed": 33
+  },
+  "flavor": "It hates light and shock. If attack­ ed, it inflates its body to pump up its counter­ strike."
+ },
+ {
+  "id": 203,
+  "name": "girafarig",
+  "types": [
+   "normal",
+   "psychic"
+  ],
+  "height": 15,
+  "weight": 415,
+  "stats": {
+   "hp": 70,
+   "attack": 80,
+   "defense": 65,
+   "special-attack": 90,
+   "special-defense": 65,
+   "speed": 85
+  },
+  "flavor": "Its tail has a small brain of its own. Beware! If you get close, it may react to your scent and bite."
+ },
+ {
+  "id": 204,
+  "name": "pineco",
+  "types": [
+   "bug"
+  ],
+  "height": 6,
+  "weight": 72,
+  "stats": {
+   "hp": 50,
+   "attack": 65,
+   "defense": 90,
+   "special-attack": 35,
+   "special-defense": 35,
+   "speed": 15
+  },
+  "flavor": "It likes to make its shell thicker by adding layers of tree bark. The additional weight doesn't bother it."
+ },
+ {
+  "id": 205,
+  "name": "forretress",
+  "types": [
+   "bug",
+   "steel"
+  ],
+  "height": 12,
+  "weight": 1258,
+  "stats": {
+   "hp": 75,
+   "attack": 90,
+   "defense": 140,
+   "special-attack": 60,
+   "special-defense": 60,
+   "speed": 40
+  },
+  "flavor": "Its entire body is shielded by a steel-hard shell. What lurks inside the armor is a total mystery."
+ },
+ {
+  "id": 206,
+  "name": "dunsparce",
+  "types": [
+   "normal"
+  ],
+  "height": 15,
+  "weight": 140,
+  "stats": {
+   "hp": 100,
+   "attack": 70,
+   "defense": 70,
+   "special-attack": 65,
+   "special-defense": 65,
+   "speed": 45
+  },
+  "flavor": "When spotted, this POKéMON escapes backward by furi­ ously boring into the ground with its tail."
+ },
+ {
+  "id": 207,
+  "name": "gligar",
+  "types": [
+   "ground",
+   "flying"
+  ],
+  "height": 11,
+  "weight": 648,
+  "stats": {
+   "hp": 65,
+   "attack": 75,
+   "defense": 105,
+   "special-attack": 35,
+   "special-defense": 65,
+   "speed": 85
+  },
+  "flavor": "It flies straight at its target's face then clamps down on the star­ tled victim to inject poison."
+ },
+ {
+  "id": 208,
+  "name": "steelix",
+  "types": [
+   "steel",
+   "ground"
+  ],
+  "height": 92,
+  "weight": 4000,
+  "stats": {
+   "hp": 75,
+   "attack": 85,
+   "defense": 200,
+   "special-attack": 55,
+   "special-defense": 65,
+   "speed": 30
+  },
+  "flavor": "Its body has been compressed deep under the ground. As a result, it is even harder than a diamond."
+ },
+ {
+  "id": 209,
+  "name": "snubbull",
+  "types": [
+   "fairy"
+  ],
+  "height": 6,
+  "weight": 78,
+  "stats": {
+   "hp": 60,
+   "attack": 80,
+   "defense": 50,
+   "special-attack": 40,
+   "special-defense": 40,
+   "speed": 30
+  },
+  "flavor": "Although it looks frightening, it is actually kind and affectionate. It is very popular among women."
+ },
+ {
+  "id": 210,
+  "name": "granbull",
+  "types": [
+   "fairy"
+  ],
+  "height": 14,
+  "weight": 487,
+  "stats": {
+   "hp": 90,
+   "attack": 120,
+   "defense": 75,
+   "special-attack": 60,
+   "special-defense": 60,
+   "speed": 45
+  },
+  "flavor": "It is actually timid and easily spooked. If at­ tacked, it flails about to fend off its attacker."
+ },
+ {
+  "id": 211,
+  "name": "qwilfish",
+  "types": [
+   "water",
+   "poison"
+  ],
+  "height": 5,
+  "weight": 39,
+  "stats": {
+   "hp": 65,
+   "attack": 95,
+   "defense": 85,
+   "special-attack": 55,
+   "special-defense": 55,
+   "speed": 85
+  },
+  "flavor": "To fire its poison spikes, it must inflate its body by drinking over 2.6 gallons of water all at once."
+ },
+ {
+  "id": 212,
+  "name": "scizor",
+  "types": [
+   "bug",
+   "steel"
+  ],
+  "height": 18,
+  "weight": 1180,
+  "stats": {
+   "hp": 70,
+   "attack": 130,
+   "defense": 100,
+   "special-attack": 55,
+   "special-defense": 80,
+   "speed": 65
+  },
+  "flavor": "It swings its eye- patterned pincers up to scare its foes. This makes it look like it has three heads."
+ },
+ {
+  "id": 213,
+  "name": "shuckle",
+  "types": [
+   "bug",
+   "rock"
+  ],
+  "height": 6,
+  "weight": 205,
+  "stats": {
+   "hp": 20,
+   "attack": 10,
+   "defense": 230,
+   "special-attack": 10,
+   "special-defense": 230,
+   "speed": 5
+  },
+  "flavor": "The BERRIES it stores in its vase-like shell decompose and become a gooey liquid."
+ },
+ {
+  "id": 214,
+  "name": "heracross",
+  "types": [
+   "bug",
+   "fighting"
+  ],
+  "height": 15,
+  "weight": 540,
+  "stats": {
+   "hp": 80,
+   "attack": 125,
+   "defense": 75,
+   "special-attack": 40,
+   "special-defense": 95,
+   "speed": 85
+  },
+  "flavor": "This powerful POKéMON thrusts its prized horn under its enemies’ bellies then lifts and throws them."
+ },
+ {
+  "id": 215,
+  "name": "sneasel",
+  "types": [
+   "dark",
+   "ice"
+  ],
+  "height": 9,
+  "weight": 280,
+  "stats": {
+   "hp": 55,
+   "attack": 95,
+   "defense": 55,
+   "special-attack": 35,
+   "special-defense": 75,
+   "speed": 115
+  },
+  "flavor": "Its paws conceal sharp claws. If attacked, it sud­ denly extends the claws and startles its enemy."
+ },
+ {
+  "id": 216,
+  "name": "teddiursa",
+  "types": [
+   "normal"
+  ],
+  "height": 6,
+  "weight": 88,
+  "stats": {
+   "hp": 60,
+   "attack": 80,
+   "defense": 50,
+   "special-attack": 50,
+   "special-defense": 50,
+   "speed": 40
+  },
+  "flavor": "If it finds honey, its crescent mark glows. It always licks its paws because they are soaked with honey."
+ },
+ {
+  "id": 217,
+  "name": "ursaring",
+  "types": [
+   "normal"
+  ],
+  "height": 18,
+  "weight": 1258,
+  "stats": {
+   "hp": 90,
+   "attack": 130,
+   "defense": 75,
+   "special-attack": 75,
+   "special-defense": 75,
+   "speed": 55
+  },
+  "flavor": "Although it is a good climber, it prefers to snap trees with its forelegs and eat fallen BERRIES."
+ },
+ {
+  "id": 218,
+  "name": "slugma",
+  "types": [
+   "fire"
+  ],
+  "height": 7,
+  "weight": 350,
+  "stats": {
+   "hp": 40,
+   "attack": 40,
+   "defense": 40,
+   "special-attack": 70,
+   "special-defense": 40,
+   "speed": 20
+  },
+  "flavor": "Its body is made of magma. If it doesn’t keep moving, its body will cool and harden."
+ },
+ {
+  "id": 219,
+  "name": "magcargo",
+  "types": [
+   "fire",
+   "rock"
+  ],
+  "height": 8,
+  "weight": 550,
+  "stats": {
+   "hp": 60,
+   "attack": 50,
+   "defense": 120,
+   "special-attack": 90,
+   "special-defense": 80,
+   "speed": 30
+  },
+  "flavor": "The shell on its back is just skin that has cooled and hardened. It breaks easily with a slight touch."
+ },
+ {
+  "id": 220,
+  "name": "swinub",
+  "types": [
+   "ice",
+   "ground"
+  ],
+  "height": 4,
+  "weight": 65,
+  "stats": {
+   "hp": 50,
+   "attack": 50,
+   "defense": 40,
+   "special-attack": 30,
+   "special-defense": 30,
+   "speed": 50
+  },
+  "flavor": "It rubs its snout on the ground to find and dig up food. It sometimes discovers hot springs."
+ },
+ {
+  "id": 221,
+  "name": "piloswine",
+  "types": [
+   "ice",
+   "ground"
+  ],
+  "height": 11,
+  "weight": 558,
+  "stats": {
+   "hp": 100,
+   "attack": 100,
+   "defense": 80,
+   "special-attack": 60,
+   "special-defense": 60,
+   "speed": 50
+  },
+  "flavor": "Although its legs are short, its rugged hooves prevent it from slipping, even on icy ground."
+ },
+ {
+  "id": 222,
+  "name": "corsola",
+  "types": [
+   "water",
+   "rock"
+  ],
+  "height": 6,
+  "weight": 50,
+  "stats": {
+   "hp": 65,
+   "attack": 55,
+   "defense": 95,
+   "special-attack": 65,
+   "special-defense": 95,
+   "speed": 35
+  },
+  "flavor": "It continuously sheds and grows. The tip of its head is prized as a treasure for its beauty."
+ },
+ {
+  "id": 223,
+  "name": "remoraid",
+  "types": [
+   "water"
+  ],
+  "height": 6,
+  "weight": 120,
+  "stats": {
+   "hp": 35,
+   "attack": 65,
+   "defense": 35,
+   "special-attack": 65,
+   "special-defense": 35,
+   "speed": 65
+  },
+  "flavor": "It has superb ac­ curacy. The water it shoots out can strike even moving prey from more than 300 feet."
+ },
+ {
+  "id": 224,
+  "name": "octillery",
+  "types": [
+   "water"
+  ],
+  "height": 9,
+  "weight": 285,
+  "stats": {
+   "hp": 75,
+   "attack": 105,
+   "defense": 75,
+   "special-attack": 105,
+   "special-defense": 75,
+   "speed": 45
+  },
+  "flavor": "It traps enemies with its suction- cupped tentacles then smashes them with its rock-hard head."
+ },
+ {
+  "id": 225,
+  "name": "delibird",
+  "types": [
+   "ice",
+   "flying"
+  ],
+  "height": 9,
+  "weight": 160,
+  "stats": {
+   "hp": 45,
+   "attack": 55,
+   "defense": 45,
+   "special-attack": 65,
+   "special-defense": 45,
+   "speed": 75
+  },
+  "flavor": "It carries food all day long. There are tales about lost people who were saved by the food it had."
+ },
+ {
+  "id": 226,
+  "name": "mantine",
+  "types": [
+   "water",
+   "flying"
+  ],
+  "height": 21,
+  "weight": 2200,
+  "stats": {
+   "hp": 85,
+   "attack": 40,
+   "defense": 70,
+   "special-attack": 80,
+   "special-defense": 140,
+   "speed": 70
+  },
+  "flavor": "As it majestically swims, it doesn't care if REMORAID attach to it for scavenging its leftovers."
+ },
+ {
+  "id": 227,
+  "name": "skarmory",
+  "types": [
+   "steel",
+   "flying"
+  ],
+  "height": 17,
+  "weight": 505,
+  "stats": {
+   "hp": 65,
+   "attack": 80,
+   "defense": 140,
+   "special-attack": 40,
+   "special-defense": 70,
+   "speed": 70
+  },
+  "flavor": "Its sturdy wings look heavy, but they are actually hollow and light, allowing it to fly freely in the sky."
+ },
+ {
+  "id": 228,
+  "name": "houndour",
+  "types": [
+   "dark",
+   "fire"
+  ],
+  "height": 6,
+  "weight": 108,
+  "stats": {
+   "hp": 45,
+   "attack": 60,
+   "defense": 30,
+   "special-attack": 80,
+   "special-defense": 50,
+   "speed": 65
+  },
+  "flavor": "It uses different kinds of cries for communicating with others of its kind and for pursuing its prey."
+ },
+ {
+  "id": 229,
+  "name": "houndoom",
+  "types": [
+   "dark",
+   "fire"
+  ],
+  "height": 14,
+  "weight": 350,
+  "stats": {
+   "hp": 75,
+   "attack": 90,
+   "defense": 50,
+   "special-attack": 110,
+   "special-defense": 80,
+   "speed": 95
+  },
+  "flavor": "If you are burned by the flames it shoots from its mouth, the pain will never go away."
+ },
+ {
+  "id": 230,
+  "name": "kingdra",
+  "types": [
+   "water",
+   "dragon"
+  ],
+  "height": 18,
+  "weight": 1520,
+  "stats": {
+   "hp": 75,
+   "attack": 95,
+   "defense": 95,
+   "special-attack": 95,
+   "special-defense": 95,
+   "speed": 85
+  },
+  "flavor": "It is said that it usually hides in underwater caves. It can create whirlpools by yawning."
+ },
+ {
+  "id": 231,
+  "name": "phanpy",
+  "types": [
+   "ground"
+  ],
+  "height": 5,
+  "weight": 335,
+  "stats": {
+   "hp": 90,
+   "attack": 60,
+   "defense": 60,
+   "special-attack": 40,
+   "special-defense": 40,
+   "speed": 40
+  },
+  "flavor": "It swings its long snout around play­ fully, but because it is so strong, that can be dan­ gerous."
+ },
+ {
+  "id": 232,
+  "name": "donphan",
+  "types": [
+   "ground"
+  ],
+  "height": 11,
+  "weight": 1200,
+  "stats": {
+   "hp": 90,
+   "attack": 120,
+   "defense": 120,
+   "special-attack": 60,
+   "special-defense": 60,
+   "speed": 50
+  },
+  "flavor": "It has sharp, hard tusks and a rugged hide. Its TACKLE is strong enough to knock down a house."
+ },
+ {
+  "id": 233,
+  "name": "porygon2",
+  "types": [
+   "normal"
+  ],
+  "height": 6,
+  "weight": 325,
+  "stats": {
+   "hp": 85,
+   "attack": 80,
+   "defense": 90,
+   "special-attack": 105,
+   "special-defense": 95,
+   "speed": 60
+  },
+  "flavor": "This upgraded version of PORYGON is designed for space exploration. It can't fly, though."
+ },
+ {
+  "id": 234,
+  "name": "stantler",
+  "types": [
+   "normal"
+  ],
+  "height": 14,
+  "weight": 712,
+  "stats": {
+   "hp": 73,
+   "attack": 95,
+   "defense": 62,
+   "special-attack": 85,
+   "special-defense": 65,
+   "speed": 85
+  },
+  "flavor": "The curved antlers subtly change the flow of air to create a strange space where real­ ity is distorted."
+ },
+ {
+  "id": 235,
+  "name": "smeargle",
+  "types": [
+   "normal"
+  ],
+  "height": 12,
+  "weight": 580,
+  "stats": {
+   "hp": 55,
+   "attack": 20,
+   "defense": 35,
+   "special-attack": 20,
+   "special-defense": 45,
+   "speed": 75
+  },
+  "flavor": "A special fluid oozes from the tip of its tail. It paints the fluid everywhere to mark its territory."
+ },
+ {
+  "id": 236,
+  "name": "tyrogue",
+  "types": [
+   "fighting"
+  ],
+  "height": 7,
+  "weight": 210,
+  "stats": {
+   "hp": 35,
+   "attack": 35,
+   "defense": 35,
+   "special-attack": 35,
+   "special-defense": 35,
+   "speed": 35
+  },
+  "flavor": "It is always bursting with en­ ergy. To make it­ self stronger, it keeps on fighting even if it loses."
+ },
+ {
+  "id": 237,
+  "name": "hitmontop",
+  "types": [
+   "fighting"
+  ],
+  "height": 14,
+  "weight": 480,
+  "stats": {
+   "hp": 50,
+   "attack": 95,
+   "defense": 95,
+   "special-attack": 35,
+   "special-defense": 110,
+   "speed": 70
+  },
+  "flavor": "If you become enchanted by its smooth, elegant, dance-like kicks, you may get drilled hard."
+ },
+ {
+  "id": 238,
+  "name": "smoochum",
+  "types": [
+   "ice",
+   "psychic"
+  ],
+  "height": 4,
+  "weight": 60,
+  "stats": {
+   "hp": 45,
+   "attack": 30,
+   "defense": 15,
+   "special-attack": 85,
+   "special-defense": 65,
+   "speed": 65
+  },
+  "flavor": "Its lips are the most sensitive parts on its body. It always uses its lips first to examine things."
+ },
+ {
+  "id": 239,
+  "name": "elekid",
+  "types": [
+   "electric"
+  ],
+  "height": 6,
+  "weight": 235,
+  "stats": {
+   "hp": 45,
+   "attack": 63,
+   "defense": 37,
+   "special-attack": 65,
+   "special-defense": 55,
+   "speed": 95
+  },
+  "flavor": "It rotates its arms to generate electricity, but it tires easily, so it charges up only a little bit."
+ },
+ {
+  "id": 240,
+  "name": "magby",
+  "types": [
+   "fire"
+  ],
+  "height": 7,
+  "weight": 214,
+  "stats": {
+   "hp": 45,
+   "attack": 75,
+   "defense": 37,
+   "special-attack": 70,
+   "special-defense": 55,
+   "speed": 83
+  },
+  "flavor": "Each and every time it inhales and exhales, hot embers dribble out of its mouth and nostrils."
+ },
+ {
+  "id": 241,
+  "name": "miltank",
+  "types": [
+   "normal"
+  ],
+  "height": 12,
+  "weight": 755,
+  "stats": {
+   "hp": 95,
+   "attack": 80,
+   "defense": 105,
+   "special-attack": 40,
+   "special-defense": 70,
+   "speed": 100
+  },
+  "flavor": "Its milk is packed with nutrition, making it the ultimate beverage for the sick or weary."
+ },
+ {
+  "id": 242,
+  "name": "blissey",
+  "types": [
+   "normal"
+  ],
+  "height": 15,
+  "weight": 468,
+  "stats": {
+   "hp": 255,
+   "attack": 10,
+   "defense": 10,
+   "special-attack": 75,
+   "special-defense": 135,
+   "speed": 55
+  },
+  "flavor": "Anyone who takes even one bite of BLISSEY's egg be­ comes unfailingly caring and pleas­ ant to everyone."
+ },
+ {
+  "id": 243,
+  "name": "raikou",
+  "types": [
+   "electric"
+  ],
+  "height": 19,
+  "weight": 1780,
+  "stats": {
+   "hp": 90,
+   "attack": 85,
+   "defense": 75,
+   "special-attack": 115,
+   "special-defense": 100,
+   "speed": 115
+  },
+  "flavor": "The rain clouds it carries let it fire thunderbolts at will. They say that it descended with lightning."
+ },
+ {
+  "id": 244,
+  "name": "entei",
+  "types": [
+   "fire"
+  ],
+  "height": 21,
+  "weight": 1980,
+  "stats": {
+   "hp": 115,
+   "attack": 115,
+   "defense": 85,
+   "special-attack": 90,
+   "special-defense": 75,
+   "speed": 100
+  },
+  "flavor": "Volcanoes erupt when it barks. Un­ able to restrain its extreme power, it races headlong around the land."
+ },
+ {
+  "id": 245,
+  "name": "suicune",
+  "types": [
+   "water"
+  ],
+  "height": 20,
+  "weight": 1870,
+  "stats": {
+   "hp": 100,
+   "attack": 75,
+   "defense": 115,
+   "special-attack": 90,
+   "special-defense": 115,
+   "speed": 85
+  },
+  "flavor": "Said to be the reincarnation of north winds, it can instantly purify filthy, murky water."
+ },
+ {
+  "id": 246,
+  "name": "larvitar",
+  "types": [
+   "rock",
+   "ground"
+  ],
+  "height": 6,
+  "weight": 720,
+  "stats": {
+   "hp": 50,
+   "attack": 64,
+   "defense": 50,
+   "special-attack": 45,
+   "special-defense": 50,
+   "speed": 41
+  },
+  "flavor": "It feeds on soil. After it has eaten a large mountain, it will fall asleep so it can grow."
+ },
+ {
+  "id": 247,
+  "name": "pupitar",
+  "types": [
+   "rock",
+   "ground"
+  ],
+  "height": 12,
+  "weight": 1520,
+  "stats": {
+   "hp": 70,
+   "attack": 84,
+   "defense": 70,
+   "special-attack": 65,
+   "special-defense": 70,
+   "speed": 51
+  },
+  "flavor": "Its shell is as hard as sheet rock, and it is also very strong. Its THRASHING can topple a mountain."
+ },
+ {
+  "id": 248,
+  "name": "tyranitar",
+  "types": [
+   "rock",
+   "dark"
+  ],
+  "height": 20,
+  "weight": 2020,
+  "stats": {
+   "hp": 100,
+   "attack": 134,
+   "defense": 110,
+   "special-attack": 95,
+   "special-defense": 100,
+   "speed": 61
+  },
+  "flavor": "Its body can't be harmed by any sort of attack, so it is very eager to make challenges against enemies."
+ },
+ {
+  "id": 249,
+  "name": "lugia",
+  "types": [
+   "psychic",
+   "flying"
+  ],
+  "height": 52,
+  "weight": 2160,
+  "stats": {
+   "hp": 106,
+   "attack": 90,
+   "defense": 130,
+   "special-attack": 90,
+   "special-defense": 154,
+   "speed": 110
+  },
+  "flavor": "It is said that it quietly spends its time deep at the bottom of the sea because its powers are too strong."
+ },
+ {
+  "id": 250,
+  "name": "ho-oh",
+  "types": [
+   "fire",
+   "flying"
+  ],
+  "height": 38,
+  "weight": 1990,
+  "stats": {
+   "hp": 106,
+   "attack": 130,
+   "defense": 90,
+   "special-attack": 110,
+   "special-defense": 154,
+   "speed": 90
+  },
+  "flavor": "Legends claim this POKéMON flies the world's skies con­ tinuously on its magnificent seven- colored wings."
+ },
+ {
+  "id": 251,
+  "name": "celebi",
+  "types": [
+   "psychic",
+   "grass"
+  ],
+  "height": 6,
+  "weight": 50,
+  "stats": {
+   "hp": 100,
+   "attack": 100,
+   "defense": 100,
+   "special-attack": 100,
+   "special-defense": 100,
+   "speed": 100
+  },
+  "flavor": "This POKéMON wan­ ders across time. Grass and trees flourish in the forests in which it has appeared."
+ },
+ {
+  "id": 252,
+  "name": "treecko",
+  "types": [
+   "grass"
+  ],
+  "height": 5,
+  "weight": 50,
+  "stats": {
+   "hp": 40,
+   "attack": 45,
+   "defense": 35,
+   "special-attack": 65,
+   "special-defense": 55,
+   "speed": 70
+  },
+  "flavor": "TREECKO has small hooks on the bottom of its feet that enable it to scale vertical walls. This POKéMON attacks by slamming foes with its thick tail."
+ },
+ {
+  "id": 253,
+  "name": "grovyle",
+  "types": [
+   "grass"
+  ],
+  "height": 9,
+  "weight": 216,
+  "stats": {
+   "hp": 50,
+   "attack": 65,
+   "defense": 45,
+   "special-attack": 85,
+   "special-defense": 65,
+   "speed": 95
+  },
+  "flavor": "The leaves growing out of GROVYLE’s body are convenient for camouflaging it from enemies in the forest. This POKéMON is a master at climbing trees in jungles."
+ },
+ {
+  "id": 254,
+  "name": "sceptile",
+  "types": [
+   "grass"
+  ],
+  "height": 17,
+  "weight": 522,
+  "stats": {
+   "hp": 70,
+   "attack": 85,
+   "defense": 65,
+   "special-attack": 105,
+   "special-defense": 85,
+   "speed": 120
+  },
+  "flavor": "The leaves growing on SCEPTILE’s body are very sharp edged. This POKéMON is very agile - it leaps all over the branches of trees and jumps on its foe from above or behind."
+ },
+ {
+  "id": 255,
+  "name": "torchic",
+  "types": [
+   "fire"
+  ],
+  "height": 4,
+  "weight": 25,
+  "stats": {
+   "hp": 45,
+   "attack": 60,
+   "defense": 40,
+   "special-attack": 70,
+   "special-defense": 50,
+   "speed": 45
+  },
+  "flavor": "TORCHIC sticks with its TRAINER, following behind with unsteady steps. This POKéMON breathes fire of over 1,800 degrees F, including fireballs that leave the foe scorched black."
+ },
+ {
+  "id": 256,
+  "name": "combusken",
+  "types": [
+   "fire",
+   "fighting"
+  ],
+  "height": 9,
+  "weight": 195,
+  "stats": {
+   "hp": 60,
+   "attack": 85,
+   "defense": 60,
+   "special-attack": 85,
+   "special-defense": 60,
+   "speed": 55
+  },
+  "flavor": "COMBUSKEN toughens up its legs and thighs by running through fields and mountains. This POKéMON’s legs possess both speed and power, enabling it to dole out ten kicks in one second."
+ },
+ {
+  "id": 257,
+  "name": "blaziken",
+  "types": [
+   "fire",
+   "fighting"
+  ],
+  "height": 19,
+  "weight": 520,
+  "stats": {
+   "hp": 80,
+   "attack": 120,
+   "defense": 70,
+   "special-attack": 110,
+   "special-defense": 70,
+   "speed": 80
+  },
+  "flavor": "Flames spout from its wrists, enveloping its knuckles. Its punches scorch its foes."
+ },
+ {
+  "id": 258,
+  "name": "mudkip",
+  "types": [
+   "water"
+  ],
+  "height": 4,
+  "weight": 76,
+  "stats": {
+   "hp": 50,
+   "attack": 70,
+   "defense": 50,
+   "special-attack": 50,
+   "special-defense": 50,
+   "speed": 40
+  },
+  "flavor": "The fin on MUDKIP’s head acts as highly sensitive radar. Using this fin to sense movements of water and air, this POKéMON can determine what is taking place around it without using its eyes."
+ },
+ {
+  "id": 259,
+  "name": "marshtomp",
+  "types": [
+   "water",
+   "ground"
+  ],
+  "height": 7,
+  "weight": 280,
+  "stats": {
+   "hp": 70,
+   "attack": 85,
+   "defense": 70,
+   "special-attack": 60,
+   "special-defense": 70,
+   "speed": 50
+  },
+  "flavor": "The surface of MARSHTOMP’s body is enveloped by a thin, sticky film that enables it to live on land. This POKéMON plays in mud on beaches when the ocean tide is low."
+ },
+ {
+  "id": 260,
+  "name": "swampert",
+  "types": [
+   "water",
+   "ground"
+  ],
+  "height": 15,
+  "weight": 819,
+  "stats": {
+   "hp": 100,
+   "attack": 110,
+   "defense": 90,
+   "special-attack": 85,
+   "special-defense": 90,
+   "speed": 60
+  },
+  "flavor": "SWAMPERT is very strong. It has enough power to easily drag a boulder weighing more than a ton. This POKéMON also has powerful vision that lets it see even in murky water."
+ },
+ {
+  "id": 261,
+  "name": "poochyena",
+  "types": [
+   "dark"
+  ],
+  "height": 5,
+  "weight": 136,
+  "stats": {
+   "hp": 35,
+   "attack": 55,
+   "defense": 35,
+   "special-attack": 30,
+   "special-defense": 30,
+   "speed": 35
+  },
+  "flavor": "At first sight, POOCHYENA takes a bite at anything that moves. This POKéMON chases after prey until the victim becomes exhausted. However, it may turn tail if the prey strikes back."
+ },
+ {
+  "id": 262,
+  "name": "mightyena",
+  "types": [
+   "dark"
+  ],
+  "height": 10,
+  "weight": 370,
+  "stats": {
+   "hp": 70,
+   "attack": 90,
+   "defense": 70,
+   "special-attack": 60,
+   "special-defense": 60,
+   "speed": 70
+  },
+  "flavor": "It chases down prey in a pack. It will never disobey the commands of a skilled Trainer."
+ },
+ {
+  "id": 263,
+  "name": "zigzagoon",
+  "types": [
+   "normal"
+  ],
+  "height": 4,
+  "weight": 175,
+  "stats": {
+   "hp": 38,
+   "attack": 30,
+   "defense": 41,
+   "special-attack": 30,
+   "special-defense": 41,
+   "speed": 60
+  },
+  "flavor": "ZIGZAGOON restlessly wanders everywhere at all times. This POKéMON does so because it is very curious. It becomes interested in anything that it happens to see."
+ },
+ {
+  "id": 264,
+  "name": "linoone",
+  "types": [
+   "normal"
+  ],
+  "height": 5,
+  "weight": 325,
+  "stats": {
+   "hp": 78,
+   "attack": 70,
+   "defense": 61,
+   "special-attack": 50,
+   "special-defense": 61,
+   "speed": 100
+  },
+  "flavor": "LINOONE always runs full speed and only in straight lines. If facing an obstacle, it makes a right-angle turn to evade it. This POKéMON is very challenged by gently curving roads."
+ },
+ {
+  "id": 265,
+  "name": "wurmple",
+  "types": [
+   "bug"
+  ],
+  "height": 3,
+  "weight": 36,
+  "stats": {
+   "hp": 45,
+   "attack": 45,
+   "defense": 35,
+   "special-attack": 20,
+   "special-defense": 30,
+   "speed": 20
+  },
+  "flavor": "Using the spikes on its rear end, WURMPLE peels the bark off trees and feeds on the sap that oozes out. This POKéMON’s feet are tipped with suction pads that allow it to cling to glass without slipping."
+ },
+ {
+  "id": 266,
+  "name": "silcoon",
+  "types": [
+   "bug"
+  ],
+  "height": 6,
+  "weight": 100,
+  "stats": {
+   "hp": 50,
+   "attack": 35,
+   "defense": 55,
+   "special-attack": 25,
+   "special-defense": 25,
+   "speed": 15
+  },
+  "flavor": "SILCOON tethers itself to a tree branch using silk to keep from falling. There, this POKéMON hangs quietly while it awaits evolution. It peers out of the silk cocoon through a small hole."
+ },
+ {
+  "id": 267,
+  "name": "beautifly",
+  "types": [
+   "bug",
+   "flying"
+  ],
+  "height": 10,
+  "weight": 284,
+  "stats": {
+   "hp": 60,
+   "attack": 70,
+   "defense": 50,
+   "special-attack": 100,
+   "special-defense": 50,
+   "speed": 65
+  },
+  "flavor": "BEAUTIFLY’s favorite food is the sweet pollen of flowers. If you want to see this POKéMON, just leave a potted flower by an open window. BEAUTIFLY is sure to come looking for pollen."
+ },
+ {
+  "id": 268,
+  "name": "cascoon",
+  "types": [
+   "bug"
+  ],
+  "height": 7,
+  "weight": 115,
+  "stats": {
+   "hp": 50,
+   "attack": 35,
+   "defense": 55,
+   "special-attack": 25,
+   "special-defense": 25,
+   "speed": 15
+  },
+  "flavor": "CASCOON makes its protective cocoon by wrapping its body entirely with a fine silk from its mouth. Once the silk goes around its body, it hardens. This POKéMON prepares for its evolution inside the cocoon."
+ },
+ {
+  "id": 269,
+  "name": "dustox",
+  "types": [
+   "bug",
+   "poison"
+  ],
+  "height": 12,
+  "weight": 316,
+  "stats": {
+   "hp": 60,
+   "attack": 50,
+   "defense": 70,
+   "special-attack": 50,
+   "special-defense": 90,
+   "speed": 65
+  },
+  "flavor": "DUSTOX is instinctively drawn to light. Swarms of this POKéMON are attracted by the bright lights of cities, where they wreak havoc by stripping the leaves off roadside trees for food."
+ },
+ {
+  "id": 270,
+  "name": "lotad",
+  "types": [
+   "water",
+   "grass"
+  ],
+  "height": 5,
+  "weight": 26,
+  "stats": {
+   "hp": 40,
+   "attack": 30,
+   "defense": 30,
+   "special-attack": 40,
+   "special-defense": 50,
+   "speed": 30
+  },
+  "flavor": "LOTAD live in ponds and lakes, where they float on the surface. It grows weak if its broad leaf dies. On rare occasions, this POKéMON travels on land in search of clean water."
+ },
+ {
+  "id": 271,
+  "name": "lombre",
+  "types": [
+   "water",
+   "grass"
+  ],
+  "height": 12,
+  "weight": 325,
+  "stats": {
+   "hp": 60,
+   "attack": 50,
+   "defense": 50,
+   "special-attack": 60,
+   "special-defense": 70,
+   "speed": 50
+  },
+  "flavor": "LOMBRE is nocturnal - it will get active after dusk. It is also a mischief-maker. When this POKéMON spots anglers, it tugs on their fishing lines from beneath the surface and enjoys their consternation."
+ },
+ {
+  "id": 272,
+  "name": "ludicolo",
+  "types": [
+   "water",
+   "grass"
+  ],
+  "height": 15,
+  "weight": 550,
+  "stats": {
+   "hp": 80,
+   "attack": 70,
+   "defense": 70,
+   "special-attack": 90,
+   "special-defense": 100,
+   "speed": 70
+  },
+  "flavor": "LUDICOLO begins dancing as soon as it hears cheerful, festive music. This POKéMON is said to appear when it hears the singing of children on hiking outings."
+ },
+ {
+  "id": 273,
+  "name": "seedot",
+  "types": [
+   "grass"
+  ],
+  "height": 5,
+  "weight": 40,
+  "stats": {
+   "hp": 40,
+   "attack": 40,
+   "defense": 50,
+   "special-attack": 30,
+   "special-defense": 30,
+   "speed": 30
+  },
+  "flavor": "SEEDOT attaches itself to a tree branch using the top of its head. It sucks moisture from the tree while hanging off the branch. The more water it drinks, the glossier this POKéMON’s body becomes."
+ },
+ {
+  "id": 274,
+  "name": "nuzleaf",
+  "types": [
+   "grass",
+   "dark"
+  ],
+  "height": 10,
+  "weight": 280,
+  "stats": {
+   "hp": 70,
+   "attack": 70,
+   "defense": 40,
+   "special-attack": 60,
+   "special-defense": 40,
+   "speed": 60
+  },
+  "flavor": "NUZLEAF live in densely overgrown forests. They occasionally venture out of the forest to startle people. This POKéMON dislikes having its long nose pinched."
+ },
+ {
+  "id": 275,
+  "name": "shiftry",
+  "types": [
+   "grass",
+   "dark"
+  ],
+  "height": 13,
+  "weight": 596,
+  "stats": {
+   "hp": 90,
+   "attack": 100,
+   "defense": 60,
+   "special-attack": 90,
+   "special-defense": 60,
+   "speed": 80
+  },
+  "flavor": "SHIFTRY is a mysterious POKéMON that is said to live atop towering trees dating back over a thousand years. It creates terrific windstorms with the fans it holds."
+ },
+ {
+  "id": 276,
+  "name": "taillow",
+  "types": [
+   "normal",
+   "flying"
+  ],
+  "height": 3,
+  "weight": 23,
+  "stats": {
+   "hp": 40,
+   "attack": 55,
+   "defense": 30,
+   "special-attack": 30,
+   "special-defense": 30,
+   "speed": 85
+  },
+  "flavor": "TAILLOW courageously stands its ground against foes, however strong they may be. This gutsy POKéMON will remain defiant even after a loss. On the other hand, it cries loudly if it becomes hungry."
+ },
+ {
+  "id": 277,
+  "name": "swellow",
+  "types": [
+   "normal",
+   "flying"
+  ],
+  "height": 7,
+  "weight": 198,
+  "stats": {
+   "hp": 60,
+   "attack": 85,
+   "defense": 60,
+   "special-attack": 75,
+   "special-defense": 50,
+   "speed": 125
+  },
+  "flavor": "SWELLOW flies high above our heads, making graceful arcs in the sky. This POKéMON dives at a steep angle as soon as it spots its prey. The hapless prey is tightly grasped by SWELLOW’s clawed feet, preventing escape."
+ },
+ {
+  "id": 278,
+  "name": "wingull",
+  "types": [
+   "water",
+   "flying"
+  ],
+  "height": 6,
+  "weight": 95,
+  "stats": {
+   "hp": 40,
+   "attack": 30,
+   "defense": 30,
+   "special-attack": 55,
+   "special-defense": 30,
+   "speed": 85
+  },
+  "flavor": "WINGULL has the habit of carrying prey and valuables in its beak and hiding them in all sorts of locations. This POKéMON rides the winds and flies as if it were skating across the sky."
+ },
+ {
+  "id": 279,
+  "name": "pelipper",
+  "types": [
+   "water",
+   "flying"
+  ],
+  "height": 12,
+  "weight": 280,
+  "stats": {
+   "hp": 60,
+   "attack": 50,
+   "defense": 100,
+   "special-attack": 95,
+   "special-defense": 70,
+   "speed": 65
+  },
+  "flavor": "PELIPPER is a flying transporter that carries small POKéMON and eggs inside its massive bill. This POKéMON builds its nest on steep cliffs facing the sea."
+ },
+ {
+  "id": 280,
+  "name": "ralts",
+  "types": [
+   "psychic",
+   "fairy"
+  ],
+  "height": 4,
+  "weight": 66,
+  "stats": {
+   "hp": 28,
+   "attack": 25,
+   "defense": 25,
+   "special-attack": 45,
+   "special-defense": 35,
+   "speed": 40
+  },
+  "flavor": "RALTS senses the emotions of people using the horns on its head. This POKéMON rarely appears before people. But when it does, it draws closer if it senses that the person has a positive disposition."
+ },
+ {
+  "id": 281,
+  "name": "kirlia",
+  "types": [
+   "psychic",
+   "fairy"
+  ],
+  "height": 8,
+  "weight": 202,
+  "stats": {
+   "hp": 38,
+   "attack": 35,
+   "defense": 35,
+   "special-attack": 65,
+   "special-defense": 55,
+   "speed": 50
+  },
+  "flavor": "It is said that a KIRLIA that is exposed to the positive emotions of its TRAINER grows beautiful. This POKéMON controls psychokinetic powers with its highly developed brain."
+ },
+ {
+  "id": 282,
+  "name": "gardevoir",
+  "types": [
+   "psychic",
+   "fairy"
+  ],
+  "height": 16,
+  "weight": 484,
+  "stats": {
+   "hp": 68,
+   "attack": 65,
+   "defense": 65,
+   "special-attack": 125,
+   "special-defense": 115,
+   "speed": 80
+  },
+  "flavor": "It unleashes psychokinetic energy at full power when protecting a Trainer it has bonded closely with."
+ },
+ {
+  "id": 283,
+  "name": "surskit",
+  "types": [
+   "bug",
+   "water"
+  ],
+  "height": 5,
+  "weight": 17,
+  "stats": {
+   "hp": 40,
+   "attack": 30,
+   "defense": 32,
+   "special-attack": 50,
+   "special-defense": 52,
+   "speed": 65
+  },
+  "flavor": "From the tips of its feet, SURSKIT secretes an oil that enables it to walk on water as if it were skating. This POKéMON feeds on microscopic organisms in ponds and lakes."
+ },
+ {
+  "id": 284,
+  "name": "masquerain",
+  "types": [
+   "bug",
+   "flying"
+  ],
+  "height": 8,
+  "weight": 36,
+  "stats": {
+   "hp": 70,
+   "attack": 60,
+   "defense": 62,
+   "special-attack": 100,
+   "special-defense": 82,
+   "speed": 80
+  },
+  "flavor": "MASQUERAIN intimidates enemies with the eyelike patterns on its antennas. This POKéMON flaps its four wings to freely fly in any direction - even sideways and backwards - as if it were a helicopter."
+ },
+ {
+  "id": 285,
+  "name": "shroomish",
+  "types": [
+   "grass"
+  ],
+  "height": 4,
+  "weight": 45,
+  "stats": {
+   "hp": 60,
+   "attack": 40,
+   "defense": 60,
+   "special-attack": 40,
+   "special-defense": 60,
+   "speed": 35
+  },
+  "flavor": "SHROOMISH live in damp soil in the dark depths of forests. They are often found keeping still under fallen leaves. This POKéMON feeds on compost that is made up of fallen, rotted leaves."
+ },
+ {
+  "id": 286,
+  "name": "breloom",
+  "types": [
+   "grass",
+   "fighting"
+  ],
+  "height": 12,
+  "weight": 392,
+  "stats": {
+   "hp": 60,
+   "attack": 130,
+   "defense": 80,
+   "special-attack": 60,
+   "special-defense": 60,
+   "speed": 70
+  },
+  "flavor": "BRELOOM closes in on its foe with light and sprightly footwork, then throws punches with its stretchy arms. This POKéMON’s fighting technique puts boxers to shame."
+ },
+ {
+  "id": 287,
+  "name": "slakoth",
+  "types": [
+   "normal"
+  ],
+  "height": 8,
+  "weight": 240,
+  "stats": {
+   "hp": 60,
+   "attack": 60,
+   "defense": 60,
+   "special-attack": 35,
+   "special-defense": 35,
+   "speed": 30
+  },
+  "flavor": "SLAKOTH lolls around for over twenty hours every day. Because it moves so little, it does not need much food. This POKéMON’s sole daily meal consists of just three leaves."
+ },
+ {
+  "id": 288,
+  "name": "vigoroth",
+  "types": [
+   "normal"
+  ],
+  "height": 14,
+  "weight": 465,
+  "stats": {
+   "hp": 80,
+   "attack": 80,
+   "defense": 80,
+   "special-attack": 55,
+   "special-defense": 55,
+   "speed": 90
+  },
+  "flavor": "VIGOROTH is always itching and agitated to go on a wild rampage. It simply can’t tolerate sitting still for even a minute. This POKéMON’s stress level rises if it can’t be moving constantly."
+ },
+ {
+  "id": 289,
+  "name": "slaking",
+  "types": [
+   "normal"
+  ],
+  "height": 20,
+  "weight": 1305,
+  "stats": {
+   "hp": 150,
+   "attack": 160,
+   "defense": 100,
+   "special-attack": 95,
+   "special-defense": 65,
+   "speed": 100
+  },
+  "flavor": "SLAKING spends all day lying down and lolling about. It eats grass growing within its reach. If it eats all the grass it can reach, this POKéMON reluctantly moves to another spot."
+ },
+ {
+  "id": 290,
+  "name": "nincada",
+  "types": [
+   "bug",
+   "ground"
+  ],
+  "height": 5,
+  "weight": 55,
+  "stats": {
+   "hp": 31,
+   "attack": 45,
+   "defense": 90,
+   "special-attack": 30,
+   "special-defense": 30,
+   "speed": 40
+  },
+  "flavor": "NINCADA lives underground for many years in complete darkness. This POKéMON absorbs nutrients from the roots of trees. It stays motionless as it waits for evolution."
+ },
+ {
+  "id": 291,
+  "name": "ninjask",
+  "types": [
+   "bug",
+   "flying"
+  ],
+  "height": 8,
+  "weight": 120,
+  "stats": {
+   "hp": 61,
+   "attack": 90,
+   "defense": 45,
+   "special-attack": 50,
+   "special-defense": 50,
+   "speed": 160
+  },
+  "flavor": "NINJASK moves around at such a high speed that it cannot be seen, even while its crying can be clearly heard. For that reason, this POKéMON was long believed to be invisible."
+ },
+ {
+  "id": 292,
+  "name": "shedinja",
+  "types": [
+   "bug",
+   "ghost"
+  ],
+  "height": 8,
+  "weight": 12,
+  "stats": {
+   "hp": 1,
+   "attack": 90,
+   "defense": 45,
+   "special-attack": 30,
+   "special-defense": 30,
+   "speed": 40
+  },
+  "flavor": "SHEDINJA’s hard body doesn’t move - not even a twitch. In fact, its body appears to be merely a hollow shell. It is believed that this POKéMON will steal the spirit of anyone peering into its hollow body from its back."
+ },
+ {
+  "id": 293,
+  "name": "whismur",
+  "types": [
+   "normal"
+  ],
+  "height": 6,
+  "weight": 163,
+  "stats": {
+   "hp": 64,
+   "attack": 51,
+   "defense": 23,
+   "special-attack": 51,
+   "special-defense": 23,
+   "speed": 28
+  },
+  "flavor": "Normally, WHISMUR’s voice is very quiet - it is barely audible even if one is paying close attention. However, if this POKéMON senses danger, it starts crying at an earsplitting volume."
+ },
+ {
+  "id": 294,
+  "name": "loudred",
+  "types": [
+   "normal"
+  ],
+  "height": 10,
+  "weight": 405,
+  "stats": {
+   "hp": 84,
+   "attack": 71,
+   "defense": 43,
+   "special-attack": 71,
+   "special-defense": 43,
+   "speed": 48
+  },
+  "flavor": "LOUDRED’s bellowing can completely decimate a wood-frame house. It uses its voice to punish its foes. This POKéMON’s round ears serve as loudspeakers."
+ },
+ {
+  "id": 295,
+  "name": "exploud",
+  "types": [
+   "normal"
+  ],
+  "height": 15,
+  "weight": 840,
+  "stats": {
+   "hp": 104,
+   "attack": 91,
+   "defense": 63,
+   "special-attack": 91,
+   "special-defense": 73,
+   "speed": 68
+  },
+  "flavor": "EXPLOUD triggers earthquakes with the tremors it creates by bellowing. If this POKéMON violently inhales from the ports on its body, it’s a sign that it is preparing to let loose a huge bellow."
+ },
+ {
+  "id": 296,
+  "name": "makuhita",
+  "types": [
+   "fighting"
+  ],
+  "height": 10,
+  "weight": 864,
+  "stats": {
+   "hp": 72,
+   "attack": 60,
+   "defense": 30,
+   "special-attack": 20,
+   "special-defense": 30,
+   "speed": 25
+  },
+  "flavor": "MAKUHITA is tenacious - it will keep getting up and attacking its foe however many times it is knocked down. Every time it gets back up, this POKéMON stores more energy in its body for evolving."
+ },
+ {
+  "id": 297,
+  "name": "hariyama",
+  "types": [
+   "fighting"
+  ],
+  "height": 23,
+  "weight": 2538,
+  "stats": {
+   "hp": 144,
+   "attack": 120,
+   "defense": 60,
+   "special-attack": 40,
+   "special-defense": 60,
+   "speed": 50
+  },
+  "flavor": "HARIYAMA practices its straight-arm slaps in any number of locations. One hit of this POKéMON’s powerful, openhanded, straight-arm punches could snap a telephone pole in two."
+ },
+ {
+  "id": 298,
+  "name": "azurill",
+  "types": [
+   "normal",
+   "fairy"
+  ],
+  "height": 2,
+  "weight": 20,
+  "stats": {
+   "hp": 50,
+   "attack": 20,
+   "defense": 40,
+   "special-attack": 20,
+   "special-defense": 40,
+   "speed": 20
+  },
+  "flavor": "AZURILL spins its tail as if it were a lasso, then hurls it far. The momentum of the throw sends its body flying, too. Using this unique action, one of these POKéMON managed to hurl itself a record 33 feet."
+ },
+ {
+  "id": 299,
+  "name": "nosepass",
+  "types": [
+   "rock"
+  ],
+  "height": 10,
+  "weight": 970,
+  "stats": {
+   "hp": 30,
+   "attack": 45,
+   "defense": 135,
+   "special-attack": 45,
+   "special-defense": 90,
+   "speed": 30
+  },
+  "flavor": "NOSEPASS’s magnetic nose is always pointed to the north. If two of these POKéMON meet, they cannot turn their faces to each other when they are close because their magnetic noses repel one another."
+ },
+ {
+  "id": 300,
+  "name": "skitty",
+  "types": [
+   "normal"
+  ],
+  "height": 6,
+  "weight": 110,
+  "stats": {
+   "hp": 50,
+   "attack": 45,
+   "defense": 45,
+   "special-attack": 35,
+   "special-defense": 35,
+   "speed": 50
+  },
+  "flavor": "SKITTY has the habit of becoming fascinated by moving objects and chasing them around. This POKéMON is known to chase after its own tail and become dizzy."
+ },
+ {
+  "id": 301,
+  "name": "delcatty",
+  "types": [
+   "normal"
+  ],
+  "height": 11,
+  "weight": 326,
+  "stats": {
+   "hp": 70,
+   "attack": 65,
+   "defense": 65,
+   "special-attack": 55,
+   "special-defense": 55,
+   "speed": 90
+  },
+  "flavor": "DELCATTY prefers to live an unfettered existence in which it can do as it pleases at its own pace. Because this POKéMON eats and sleeps whenever it decides, its daily routines are completely random."
+ },
+ {
+  "id": 302,
+  "name": "sableye",
+  "types": [
+   "dark",
+   "ghost"
+  ],
+  "height": 5,
+  "weight": 110,
+  "stats": {
+   "hp": 50,
+   "attack": 75,
+   "defense": 75,
+   "special-attack": 65,
+   "special-defense": 65,
+   "speed": 50
+  },
+  "flavor": "SABLEYE lead quiet lives deep inside caverns. They are feared, however, because these POKéMON are thought to steal the spirits of people when their eyes burn with a sinister glow in the darkness."
+ },
+ {
+  "id": 303,
+  "name": "mawile",
+  "types": [
+   "steel",
+   "fairy"
+  ],
+  "height": 6,
+  "weight": 115,
+  "stats": {
+   "hp": 50,
+   "attack": 85,
+   "defense": 85,
+   "special-attack": 55,
+   "special-defense": 55,
+   "speed": 50
+  },
+  "flavor": "MAWHILE’s huge jaws are actually steel horns that have been transformed. Its docile-looking face serves to lull its foe into letting down its guard. When the foe least expects it, MAWHILE chomps it with its gaping jaws."
+ },
+ {
+  "id": 304,
+  "name": "aron",
+  "types": [
+   "steel",
+   "rock"
+  ],
+  "height": 4,
+  "weight": 600,
+  "stats": {
+   "hp": 50,
+   "attack": 70,
+   "defense": 100,
+   "special-attack": 40,
+   "special-defense": 40,
+   "speed": 30
+  },
+  "flavor": "This POKéMON has a body of steel. To make its body, ARON feeds on iron ore that it digs from mountains. Occasionally, it causes major trouble by eating bridges and rails."
+ },
+ {
+  "id": 305,
+  "name": "lairon",
+  "types": [
+   "steel",
+   "rock"
+  ],
+  "height": 9,
+  "weight": 1200,
+  "stats": {
+   "hp": 60,
+   "attack": 90,
+   "defense": 140,
+   "special-attack": 50,
+   "special-defense": 50,
+   "speed": 40
+  },
+  "flavor": "LAIRON tempers its steel body by drinking highly nutritious mineral springwater until it is bloated. This POKéMON makes its nest close to springs of delicious water."
+ },
+ {
+  "id": 306,
+  "name": "aggron",
+  "types": [
+   "steel",
+   "rock"
+  ],
+  "height": 21,
+  "weight": 3600,
+  "stats": {
+   "hp": 70,
+   "attack": 110,
+   "defense": 180,
+   "special-attack": 60,
+   "special-defense": 60,
+   "speed": 50
+  },
+  "flavor": "AGGRON claims an entire mountain as its own territory. It mercilessly beats up anything that violates its environment. This POKéMON vigilantly patrols its territory at all times."
+ },
+ {
+  "id": 307,
+  "name": "meditite",
+  "types": [
+   "fighting",
+   "psychic"
+  ],
+  "height": 6,
+  "weight": 112,
+  "stats": {
+   "hp": 30,
+   "attack": 40,
+   "defense": 55,
+   "special-attack": 40,
+   "special-defense": 55,
+   "speed": 60
+  },
+  "flavor": "MEDITITE undertakes rigorous mental training deep in the mountains. However, whenever it meditates, this POKéMON always loses its concentration and focus. As a result, its training never ends."
+ },
+ {
+  "id": 308,
+  "name": "medicham",
+  "types": [
+   "fighting",
+   "psychic"
+  ],
+  "height": 13,
+  "weight": 315,
+  "stats": {
+   "hp": 60,
+   "attack": 60,
+   "defense": 75,
+   "special-attack": 60,
+   "special-defense": 75,
+   "speed": 80
+  },
+  "flavor": "It is said that through meditation, MEDICHAM heightens energy inside its body and sharpens its sixth sense. This POKéMON hides its presence by merging itself with fields and mountains."
+ },
+ {
+  "id": 309,
+  "name": "electrike",
+  "types": [
+   "electric"
+  ],
+  "height": 6,
+  "weight": 152,
+  "stats": {
+   "hp": 40,
+   "attack": 45,
+   "defense": 40,
+   "special-attack": 65,
+   "special-defense": 40,
+   "speed": 65
+  },
+  "flavor": "ELECTRIKE stores electricity in its long body hair. This POKéMON stimulates its leg muscles with electric charges. These jolts of power give its legs explosive acceleration performance."
+ },
+ {
+  "id": 310,
+  "name": "manectric",
+  "types": [
+   "electric"
+  ],
+  "height": 15,
+  "weight": 402,
+  "stats": {
+   "hp": 70,
+   "attack": 75,
+   "defense": 60,
+   "special-attack": 105,
+   "special-defense": 60,
+   "speed": 105
+  },
+  "flavor": "MANECTRIC is constantly discharging electricity from its mane. The sparks sometimes ignite forest fires. When it enters a battle, this POKéMON creates thunderclouds."
+ },
+ {
+  "id": 311,
+  "name": "plusle",
+  "types": [
+   "electric"
+  ],
+  "height": 4,
+  "weight": 42,
+  "stats": {
+   "hp": 60,
+   "attack": 50,
+   "defense": 40,
+   "special-attack": 85,
+   "special-defense": 75,
+   "speed": 95
+  },
+  "flavor": "PLUSLE always acts as a cheerleader for its partners. Whenever a teammate puts out a good effort in battle, this POKéMON shorts out its body to create the crackling noises of sparks to show its joy."
+ },
+ {
+  "id": 312,
+  "name": "minun",
+  "types": [
+   "electric"
+  ],
+  "height": 4,
+  "weight": 42,
+  "stats": {
+   "hp": 60,
+   "attack": 40,
+   "defense": 50,
+   "special-attack": 75,
+   "special-defense": 85,
+   "speed": 95
+  },
+  "flavor": "MINUN is more concerned about cheering on its partners than its own safety. It shorts out the electricity in its body to create brilliant showers of sparks to cheer on its teammates."
+ },
+ {
+  "id": 313,
+  "name": "volbeat",
+  "types": [
+   "bug"
+  ],
+  "height": 7,
+  "weight": 177,
+  "stats": {
+   "hp": 65,
+   "attack": 73,
+   "defense": 75,
+   "special-attack": 47,
+   "special-defense": 85,
+   "speed": 85
+  },
+  "flavor": "With the arrival of night, VOLBEAT emits light from its tail. It communicates with others by adjusting the intensity and flashing of its light. This POKéMON is attracted by the sweet aroma of ILLUMISE."
+ },
+ {
+  "id": 314,
+  "name": "illumise",
+  "types": [
+   "bug"
+  ],
+  "height": 6,
+  "weight": 177,
+  "stats": {
+   "hp": 65,
+   "attack": 47,
+   "defense": 75,
+   "special-attack": 73,
+   "special-defense": 85,
+   "speed": 85
+  },
+  "flavor": "ILLUMISE attracts a swarm of VOLBEAT using a sweet fragrance. Once the VOLBEAT have gathered, this POKéMON leads the lit-up swarm in drawing geometric designs on the canvas of the night sky."
+ },
+ {
+  "id": 315,
+  "name": "roselia",
+  "types": [
+   "grass",
+   "poison"
+  ],
+  "height": 3,
+  "weight": 20,
+  "stats": {
+   "hp": 50,
+   "attack": 60,
+   "defense": 45,
+   "special-attack": 100,
+   "special-defense": 80,
+   "speed": 65
+  },
+  "flavor": "ROSELIA shoots sharp thorns as projectiles at any opponent that tries to steal the flowers on its arms. The aroma of this POKéMON brings serenity to living things."
+ },
+ {
+  "id": 316,
+  "name": "gulpin",
+  "types": [
+   "poison"
+  ],
+  "height": 4,
+  "weight": 103,
+  "stats": {
+   "hp": 70,
+   "attack": 43,
+   "defense": 53,
+   "special-attack": 43,
+   "special-defense": 53,
+   "speed": 40
+  },
+  "flavor": "It has a small heart and brain. Its stomach comprises most of its body, with enzymes to dissolve anything."
+ },
+ {
+  "id": 317,
+  "name": "swalot",
+  "types": [
+   "poison"
+  ],
+  "height": 17,
+  "weight": 800,
+  "stats": {
+   "hp": 100,
+   "attack": 73,
+   "defense": 83,
+   "special-attack": 73,
+   "special-defense": 83,
+   "speed": 55
+  },
+  "flavor": "When SWALOT spots prey, it spurts out a hideously toxic fluid from its pores and sprays the target. Once the prey has weakened, this POKéMON gulps it down whole with its cavernous mouth."
+ },
+ {
+  "id": 318,
+  "name": "carvanha",
+  "types": [
+   "water",
+   "dark"
+  ],
+  "height": 8,
+  "weight": 208,
+  "stats": {
+   "hp": 45,
+   "attack": 90,
+   "defense": 20,
+   "special-attack": 65,
+   "special-defense": 20,
+   "speed": 65
+  },
+  "flavor": "CARVANHA’s strongly developed jaws and its sharply pointed fangs pack the destructive power to rip out boat hulls. Many boats have been attacked and sunk by this POKéMON."
+ },
+ {
+  "id": 319,
+  "name": "sharpedo",
+  "types": [
+   "water",
+   "dark"
+  ],
+  "height": 18,
+  "weight": 888,
+  "stats": {
+   "hp": 70,
+   "attack": 120,
+   "defense": 40,
+   "special-attack": 95,
+   "special-defense": 40,
+   "speed": 95
+  },
+  "flavor": "Nicknamed “the bully of the sea,” SHARPEDO is widely feared. Its cruel fangs grow back immediately if they snap off. Just one of these POKéMON can thoroughly tear apart a supertanker."
+ },
+ {
+  "id": 320,
+  "name": "wailmer",
+  "types": [
+   "water"
+  ],
+  "height": 20,
+  "weight": 1300,
+  "stats": {
+   "hp": 130,
+   "attack": 70,
+   "defense": 35,
+   "special-attack": 70,
+   "special-defense": 35,
+   "speed": 60
+  },
+  "flavor": "WAILMER’s nostrils are located above its eyes. This playful POKéMON loves to startle people by forcefully snorting out seawater it stores inside its body out of its nostrils."
+ },
+ {
+  "id": 321,
+  "name": "wailord",
+  "types": [
+   "water"
+  ],
+  "height": 145,
+  "weight": 3980,
+  "stats": {
+   "hp": 170,
+   "attack": 90,
+   "defense": 45,
+   "special-attack": 90,
+   "special-defense": 45,
+   "speed": 60
+  },
+  "flavor": "WAILORD is the largest of all identified POKéMON up to now. This giant POKéMON swims languorously in the vast open sea, eating massive amounts of food at once with its enormous mouth."
+ },
+ {
+  "id": 322,
+  "name": "numel",
+  "types": [
+   "fire",
+   "ground"
+  ],
+  "height": 7,
+  "weight": 240,
+  "stats": {
+   "hp": 60,
+   "attack": 60,
+   "defense": 40,
+   "special-attack": 65,
+   "special-defense": 45,
+   "speed": 35
+  },
+  "flavor": "NUMEL is extremely dull witted - it doesn’t notice being hit. However, it can’t stand hunger for even a second. This POKéMON’s body is a seething cauldron of boiling magma."
+ },
+ {
+  "id": 323,
+  "name": "camerupt",
+  "types": [
+   "fire",
+   "ground"
+  ],
+  "height": 19,
+  "weight": 2200,
+  "stats": {
+   "hp": 70,
+   "attack": 100,
+   "defense": 70,
+   "special-attack": 105,
+   "special-defense": 75,
+   "speed": 40
+  },
+  "flavor": "CAMERUPT has a volcano inside its body. Magma of 18,000 degrees F courses through its body. Occasionally, the humps on this POKéMON’s back erupt, spewing the superheated magma."
+ },
+ {
+  "id": 324,
+  "name": "torkoal",
+  "types": [
+   "fire"
+  ],
+  "height": 5,
+  "weight": 804,
+  "stats": {
+   "hp": 70,
+   "attack": 85,
+   "defense": 140,
+   "special-attack": 85,
+   "special-defense": 70,
+   "speed": 20
+  },
+  "flavor": "TORKOAL digs through mountains in search of coal. If it finds some, it fills hollow spaces on its shell with the coal and burns it. If it is attacked, this POKéMON spouts thick black smoke to beat a retreat."
+ },
+ {
+  "id": 325,
+  "name": "spoink",
+  "types": [
+   "psychic"
+  ],
+  "height": 7,
+  "weight": 306,
+  "stats": {
+   "hp": 60,
+   "attack": 25,
+   "defense": 35,
+   "special-attack": 70,
+   "special-defense": 80,
+   "speed": 60
+  },
+  "flavor": "SPOINK bounces around on its tail. The shock of its bouncing makes its heart pump. As a result, this POKéMON cannot afford to stop bouncing - if it stops, its heart will stop."
+ },
+ {
+  "id": 326,
+  "name": "grumpig",
+  "types": [
+   "psychic"
+  ],
+  "height": 9,
+  "weight": 715,
+  "stats": {
+   "hp": 80,
+   "attack": 45,
+   "defense": 65,
+   "special-attack": 90,
+   "special-defense": 110,
+   "speed": 80
+  },
+  "flavor": "GRUMPIG uses the black pearls on its body to amplify its psychic power waves for gaining total control over its foe. When this POKéMON uses its special power, its snorting breath grows labored."
+ },
+ {
+  "id": 327,
+  "name": "spinda",
+  "types": [
+   "normal"
+  ],
+  "height": 11,
+  "weight": 50,
+  "stats": {
+   "hp": 60,
+   "attack": 60,
+   "defense": 60,
+   "special-attack": 60,
+   "special-defense": 60,
+   "speed": 60
+  },
+  "flavor": "All the SPINDA that exist in the world are said to have utterly unique spot patterns. The shaky, tottering steps of this POKéMON give it the appearance of dancing."
+ },
+ {
+  "id": 328,
+  "name": "trapinch",
+  "types": [
+   "ground"
+  ],
+  "height": 7,
+  "weight": 150,
+  "stats": {
+   "hp": 45,
+   "attack": 100,
+   "defense": 45,
+   "special-attack": 45,
+   "special-defense": 45,
+   "speed": 10
+  },
+  "flavor": "TRAPINCH’s nest is a sloped, bowl-like pit dug in sand. This POKéMON patiently waits for prey to tumble down the pit. Its giant jaws have enough strength to crush even boulders."
+ },
+ {
+  "id": 329,
+  "name": "vibrava",
+  "types": [
+   "ground",
+   "dragon"
+  ],
+  "height": 11,
+  "weight": 153,
+  "stats": {
+   "hp": 50,
+   "attack": 70,
+   "defense": 50,
+   "special-attack": 50,
+   "special-defense": 50,
+   "speed": 70
+  },
+  "flavor": "To make prey faint, VIBRAVA generates ultrasonic waves by vigorously making its two wings vibrate. This POKéMON’s ultrasonic waves are so powerful, they can bring on headaches in people."
+ },
+ {
+  "id": 330,
+  "name": "flygon",
+  "types": [
+   "ground",
+   "dragon"
+  ],
+  "height": 20,
+  "weight": 820,
+  "stats": {
+   "hp": 80,
+   "attack": 100,
+   "defense": 80,
+   "special-attack": 80,
+   "special-defense": 80,
+   "speed": 100
+  },
+  "flavor": "FLYGON is nicknamed “the elemental spirit of the desert.” Because its flapping wings whip up a cloud of sand, this POKéMON is always enveloped in a sandstorm while flying."
+ },
+ {
+  "id": 331,
+  "name": "cacnea",
+  "types": [
+   "grass"
+  ],
+  "height": 4,
+  "weight": 513,
+  "stats": {
+   "hp": 50,
+   "attack": 85,
+   "defense": 40,
+   "special-attack": 85,
+   "special-defense": 40,
+   "speed": 35
+  },
+  "flavor": "CACNEA lives in arid locations such as deserts. It releases a strong aroma from its flower to attract prey. When prey comes near, this POKéMON shoots sharp thorns from its body to bring the victim down."
+ },
+ {
+  "id": 332,
+  "name": "cacturne",
+  "types": [
+   "grass",
+   "dark"
+  ],
+  "height": 13,
+  "weight": 774,
+  "stats": {
+   "hp": 70,
+   "attack": 115,
+   "defense": 60,
+   "special-attack": 115,
+   "special-defense": 60,
+   "speed": 55
+  },
+  "flavor": "During the daytime, CACTURNE remains unmoving so that it does not lose any moisture to the harsh desert sun. This POKéMON becomes active at night when the temperature drops."
+ },
+ {
+  "id": 333,
+  "name": "swablu",
+  "types": [
+   "normal",
+   "flying"
+  ],
+  "height": 4,
+  "weight": 12,
+  "stats": {
+   "hp": 45,
+   "attack": 40,
+   "defense": 60,
+   "special-attack": 40,
+   "special-defense": 75,
+   "speed": 50
+  },
+  "flavor": "SWABLU has light and fluffy wings that are like cottony clouds. This POKéMON is not frightened of people. It lands on the heads of people and sits there like a cotton-fluff hat."
+ },
+ {
+  "id": 334,
+  "name": "altaria",
+  "types": [
+   "dragon",
+   "flying"
+  ],
+  "height": 11,
+  "weight": 206,
+  "stats": {
+   "hp": 75,
+   "attack": 70,
+   "defense": 90,
+   "special-attack": 70,
+   "special-defense": 105,
+   "speed": 80
+  },
+  "flavor": "ALTARIA dances and wheels through the sky among billowing, cotton-like clouds. By singing melodies in its crystal-clear voice, this POKéMON makes its listeners experience dreamy wonderment."
+ },
+ {
+  "id": 335,
+  "name": "zangoose",
+  "types": [
+   "normal"
+  ],
+  "height": 13,
+  "weight": 403,
+  "stats": {
+   "hp": 73,
+   "attack": 115,
+   "defense": 60,
+   "special-attack": 60,
+   "special-defense": 60,
+   "speed": 90
+  },
+  "flavor": "It has feuded with Seviper for many generations. Its sharp claws are its biggest weapons."
+ },
+ {
+  "id": 336,
+  "name": "seviper",
+  "types": [
+   "poison"
+  ],
+  "height": 27,
+  "weight": 525,
+  "stats": {
+   "hp": 73,
+   "attack": 100,
+   "defense": 60,
+   "special-attack": 100,
+   "special-defense": 60,
+   "speed": 65
+  },
+  "flavor": "SEVIPER shares a generations-long feud with ZANGOOSE. The scars on its body are evidence of vicious battles. This POKéMON attacks using its sword- edged tail."
+ },
+ {
+  "id": 337,
+  "name": "lunatone",
+  "types": [
+   "rock",
+   "psychic"
+  ],
+  "height": 10,
+  "weight": 1680,
+  "stats": {
+   "hp": 90,
+   "attack": 55,
+   "defense": 65,
+   "special-attack": 95,
+   "special-defense": 85,
+   "speed": 70
+  },
+  "flavor": "LUNATONE was discovered at a location where a meteorite fell. As a result, some people theorize that this POKéMON came from space. However, no one has been able to prove this theory so far."
+ },
+ {
+  "id": 338,
+  "name": "solrock",
+  "types": [
+   "rock",
+   "psychic"
+  ],
+  "height": 12,
+  "weight": 1540,
+  "stats": {
+   "hp": 90,
+   "attack": 95,
+   "defense": 85,
+   "special-attack": 55,
+   "special-defense": 65,
+   "speed": 70
+  },
+  "flavor": "SOLROCK is a new species of POKéMON that is said to have fallen from space. It floats in air and moves silently. In battle, this POKéMON releases intensely bright light."
+ },
+ {
+  "id": 339,
+  "name": "barboach",
+  "types": [
+   "water",
+   "ground"
+  ],
+  "height": 4,
+  "weight": 19,
+  "stats": {
+   "hp": 50,
+   "attack": 48,
+   "defense": 43,
+   "special-attack": 46,
+   "special-defense": 41,
+   "speed": 60
+  },
+  "flavor": "BARBOACH’s sensitive whiskers serve as a superb radar system. This POKéMON hides in mud, leaving only its two whiskers exposed while it waits for prey to come along."
+ },
+ {
+  "id": 340,
+  "name": "whiscash",
+  "types": [
+   "water",
+   "ground"
+  ],
+  "height": 9,
+  "weight": 236,
+  "stats": {
+   "hp": 110,
+   "attack": 78,
+   "defense": 73,
+   "special-attack": 76,
+   "special-defense": 71,
+   "speed": 60
+  },
+  "flavor": "WHISCASH is extremely territorial. Just one of these POKéMON will claim a large pond as its exclusive territory. If a foe approaches it, it thrashes about and triggers a massive earthquake."
+ },
+ {
+  "id": 341,
+  "name": "corphish",
+  "types": [
+   "water"
+  ],
+  "height": 6,
+  "weight": 115,
+  "stats": {
+   "hp": 43,
+   "attack": 80,
+   "defense": 65,
+   "special-attack": 50,
+   "special-defense": 35,
+   "speed": 35
+  },
+  "flavor": "CORPHISH were originally foreign POKéMON that were imported as pets. They eventually turned up in the wild. This POKéMON is very hardy and has greatly increased its population."
+ },
+ {
+  "id": 342,
+  "name": "crawdaunt",
+  "types": [
+   "water",
+   "dark"
+  ],
+  "height": 11,
+  "weight": 328,
+  "stats": {
+   "hp": 63,
+   "attack": 120,
+   "defense": 85,
+   "special-attack": 90,
+   "special-defense": 55,
+   "speed": 55
+  },
+  "flavor": "CRAWDAUNT has an extremely violent nature that compels it to challenge other living things to battle. Other life-forms refuse to live in ponds inhabited by this POKéMON, making them desolate places."
+ },
+ {
+  "id": 343,
+  "name": "baltoy",
+  "types": [
+   "ground",
+   "psychic"
+  ],
+  "height": 5,
+  "weight": 215,
+  "stats": {
+   "hp": 40,
+   "attack": 40,
+   "defense": 55,
+   "special-attack": 40,
+   "special-defense": 70,
+   "speed": 55
+  },
+  "flavor": "BALTOY moves while spinning around on its one foot. Primitive wall paintings depicting this POKéMON living among people were discovered in some ancient ruins."
+ },
+ {
+  "id": 344,
+  "name": "claydol",
+  "types": [
+   "ground",
+   "psychic"
+  ],
+  "height": 15,
+  "weight": 1080,
+  "stats": {
+   "hp": 60,
+   "attack": 70,
+   "defense": 105,
+   "special-attack": 70,
+   "special-defense": 120,
+   "speed": 75
+  },
+  "flavor": "CLAYDOL are said to be dolls of mud made by primitive humans and brought to life by exposure to a mysterious ray. This POKéMON moves about while levitating."
+ },
+ {
+  "id": 345,
+  "name": "lileep",
+  "types": [
+   "rock",
+   "grass"
+  ],
+  "height": 10,
+  "weight": 238,
+  "stats": {
+   "hp": 66,
+   "attack": 41,
+   "defense": 77,
+   "special-attack": 61,
+   "special-defense": 87,
+   "speed": 23
+  },
+  "flavor": "It lived on the seafloor 100 million years ago and was reanimated scientifically."
+ },
+ {
+  "id": 346,
+  "name": "cradily",
+  "types": [
+   "rock",
+   "grass"
+  ],
+  "height": 15,
+  "weight": 604,
+  "stats": {
+   "hp": 86,
+   "attack": 81,
+   "defense": 97,
+   "special-attack": 81,
+   "special-defense": 107,
+   "speed": 43
+  },
+  "flavor": "CRADILY roams around the ocean floor in search of food. This POKéMON freely extends its tree trunk-like neck and captures unwary prey using its eight tentacles."
+ },
+ {
+  "id": 347,
+  "name": "anorith",
+  "types": [
+   "rock",
+   "bug"
+  ],
+  "height": 7,
+  "weight": 125,
+  "stats": {
+   "hp": 45,
+   "attack": 95,
+   "defense": 50,
+   "special-attack": 40,
+   "special-defense": 50,
+   "speed": 75
+  },
+  "flavor": "ANORITH was regenerated from a prehistoric fossil. This primitive POKéMON once lived in warm seas. It grips its prey firmly between its two large claws."
+ },
+ {
+  "id": 348,
+  "name": "armaldo",
+  "types": [
+   "rock",
+   "bug"
+  ],
+  "height": 15,
+  "weight": 682,
+  "stats": {
+   "hp": 75,
+   "attack": 125,
+   "defense": 100,
+   "special-attack": 70,
+   "special-defense": 80,
+   "speed": 45
+  },
+  "flavor": "ARMALDO’s tough armor makes all attacks bounce off. This POKéMON’s two enormous claws can be freely extended or contracted. They have the power to punch right through a steel slab."
+ },
+ {
+  "id": 349,
+  "name": "feebas",
+  "types": [
+   "water"
+  ],
+  "height": 6,
+  "weight": 74,
+  "stats": {
+   "hp": 20,
+   "attack": 15,
+   "defense": 20,
+   "special-attack": 10,
+   "special-defense": 55,
+   "speed": 80
+  },
+  "flavor": "FEEBAS’s fins are ragged and tattered from the start of its life. Because of its shoddy appearance, this POKéMON is largely ignored. It is capable of living in both the sea and in rivers."
+ },
+ {
+  "id": 350,
+  "name": "milotic",
+  "types": [
+   "water"
+  ],
+  "height": 62,
+  "weight": 1620,
+  "stats": {
+   "hp": 95,
+   "attack": 60,
+   "defense": 79,
+   "special-attack": 100,
+   "special-defense": 125,
+   "speed": 81
+  },
+  "flavor": "MILOTIC is breathtakingly beautiful. Those that see it are said to forget their combative spirits."
+ },
+ {
+  "id": 351,
+  "name": "castform",
+  "types": [
+   "normal"
+  ],
+  "height": 3,
+  "weight": 8,
+  "stats": {
+   "hp": 70,
+   "attack": 70,
+   "defense": 70,
+   "special-attack": 70,
+   "special-defense": 70,
+   "speed": 70
+  },
+  "flavor": "CASTFORM’s appearance changes with the weather. This POKéMON gained the ability to use the vast power of nature to protect its tiny body."
+ },
+ {
+  "id": 352,
+  "name": "kecleon",
+  "types": [
+   "normal"
+  ],
+  "height": 10,
+  "weight": 220,
+  "stats": {
+   "hp": 60,
+   "attack": 90,
+   "defense": 70,
+   "special-attack": 60,
+   "special-defense": 120,
+   "speed": 40
+  },
+  "flavor": "KECLEON is capable of changing its body colors at will to blend in with its surroundings. There is one exception - this POKéMON can’t change the zigzag pattern on its belly."
+ },
+ {
+  "id": 353,
+  "name": "shuppet",
+  "types": [
+   "ghost"
+  ],
+  "height": 6,
+  "weight": 23,
+  "stats": {
+   "hp": 44,
+   "attack": 75,
+   "defense": 35,
+   "special-attack": 63,
+   "special-defense": 33,
+   "speed": 45
+  },
+  "flavor": "SHUPPET is attracted by feelings of jealousy and vindictiveness. If someone develops strong feelings of vengeance, this POKéMON will appear in a swarm and line up beneath the eaves of that person’s home."
+ },
+ {
+  "id": 354,
+  "name": "banette",
+  "types": [
+   "ghost"
+  ],
+  "height": 11,
+  "weight": 125,
+  "stats": {
+   "hp": 64,
+   "attack": 115,
+   "defense": 65,
+   "special-attack": 83,
+   "special-defense": 63,
+   "speed": 65
+  },
+  "flavor": "A doll that became a Pokémon over its grudge from being junked. It seeks the child that disowned it."
+ },
+ {
+  "id": 355,
+  "name": "duskull",
+  "types": [
+   "ghost"
+  ],
+  "height": 8,
+  "weight": 150,
+  "stats": {
+   "hp": 20,
+   "attack": 40,
+   "defense": 90,
+   "special-attack": 30,
+   "special-defense": 90,
+   "speed": 25
+  },
+  "flavor": "DUSKULL can pass through any wall no matter how thick it may be. Once this POKéMON chooses a target, it will doggedly pursue the intended victim until the break of dawn."
+ },
+ {
+  "id": 356,
+  "name": "dusclops",
+  "types": [
+   "ghost"
+  ],
+  "height": 16,
+  "weight": 306,
+  "stats": {
+   "hp": 40,
+   "attack": 70,
+   "defense": 130,
+   "special-attack": 60,
+   "special-defense": 130,
+   "speed": 25
+  },
+  "flavor": "DUSCLOPS’s body is completely hollow - there is nothing at all inside. It is said that its body is like a black hole. This POKéMON will absorb anything into its body, but nothing will ever come back out."
+ },
+ {
+  "id": 357,
+  "name": "tropius",
+  "types": [
+   "grass",
+   "flying"
+  ],
+  "height": 20,
+  "weight": 1000,
+  "stats": {
+   "hp": 99,
+   "attack": 68,
+   "defense": 83,
+   "special-attack": 72,
+   "special-defense": 87,
+   "speed": 51
+  },
+  "flavor": "It lives in tropical jungles. The bunch of fruit around its neck is delicious. The fruit grows twice a year."
+ },
+ {
+  "id": 358,
+  "name": "chimecho",
+  "types": [
+   "psychic"
+  ],
+  "height": 6,
+  "weight": 10,
+  "stats": {
+   "hp": 75,
+   "attack": 50,
+   "defense": 80,
+   "special-attack": 95,
+   "special-defense": 90,
+   "speed": 65
+  },
+  "flavor": "CHIMECHO makes its cries echo inside its hollow body. When this POKéMON becomes enraged, its cries result in ultrasonic waves that have the power to knock foes flying."
+ },
+ {
+  "id": 359,
+  "name": "absol",
+  "types": [
+   "dark"
+  ],
+  "height": 12,
+  "weight": 470,
+  "stats": {
+   "hp": 65,
+   "attack": 130,
+   "defense": 60,
+   "special-attack": 75,
+   "special-defense": 60,
+   "speed": 75
+  },
+  "flavor": "Every time ABSOL appears before people, it is followed by a disaster such as an earthquake or a tidal wave. As a result, it came to be known as the disaster POKéMON."
+ },
+ {
+  "id": 360,
+  "name": "wynaut",
+  "types": [
+   "psychic"
+  ],
+  "height": 6,
+  "weight": 140,
+  "stats": {
+   "hp": 95,
+   "attack": 23,
+   "defense": 48,
+   "special-attack": 23,
+   "special-defense": 48,
+   "speed": 23
+  },
+  "flavor": "WYNAUT can always be seen with a big, happy smile on its face. Look at its tail to determine if it is angry. When angered, this POKéMON will be slapping the ground with its tail."
+ },
+ {
+  "id": 361,
+  "name": "snorunt",
+  "types": [
+   "ice"
+  ],
+  "height": 7,
+  "weight": 168,
+  "stats": {
+   "hp": 50,
+   "attack": 50,
+   "defense": 50,
+   "special-attack": 50,
+   "special-defense": 50,
+   "speed": 50
+  },
+  "flavor": "SNORUNT live in regions with heavy snowfall. In seasons without snow, such as spring and summer, this POKéMON steals away to live quietly among stalactites and stalagmites deep in caverns."
+ },
+ {
+  "id": 362,
+  "name": "glalie",
+  "types": [
+   "ice"
+  ],
+  "height": 15,
+  "weight": 2565,
+  "stats": {
+   "hp": 80,
+   "attack": 80,
+   "defense": 80,
+   "special-attack": 80,
+   "special-defense": 80,
+   "speed": 80
+  },
+  "flavor": "GLALIE has a body made of rock, which it hardens with an armor of ice. This POKéMON has the ability to freeze moisture in the atmosphere into any shape it desires."
+ },
+ {
+  "id": 363,
+  "name": "spheal",
+  "types": [
+   "ice",
+   "water"
+  ],
+  "height": 8,
+  "weight": 395,
+  "stats": {
+   "hp": 70,
+   "attack": 40,
+   "defense": 50,
+   "special-attack": 55,
+   "special-defense": 50,
+   "speed": 25
+  },
+  "flavor": "SPHEAL is much faster rolling than walking to get around. When groups of this POKéMON eat, they all clap at once to show their pleasure. Because of this, their mealtimes are noisy."
+ },
+ {
+  "id": 364,
+  "name": "sealeo",
+  "types": [
+   "ice",
+   "water"
+  ],
+  "height": 11,
+  "weight": 876,
+  "stats": {
+   "hp": 90,
+   "attack": 60,
+   "defense": 70,
+   "special-attack": 75,
+   "special-defense": 70,
+   "speed": 45
+  },
+  "flavor": "It has a very sensitive nose. It touches new things with its nose to examine them."
+ },
+ {
+  "id": 365,
+  "name": "walrein",
+  "types": [
+   "ice",
+   "water"
+  ],
+  "height": 14,
+  "weight": 1506,
+  "stats": {
+   "hp": 110,
+   "attack": 80,
+   "defense": 90,
+   "special-attack": 95,
+   "special-defense": 90,
+   "speed": 65
+  },
+  "flavor": "WALREIN’s two massively developed tusks can totally shatter blocks of ice weighing ten tons with one blow. This POKéMON’s thick coat of blubber insulates it from subzero temperatures."
+ },
+ {
+  "id": 366,
+  "name": "clamperl",
+  "types": [
+   "water"
+  ],
+  "height": 4,
+  "weight": 525,
+  "stats": {
+   "hp": 35,
+   "attack": 64,
+   "defense": 85,
+   "special-attack": 74,
+   "special-defense": 55,
+   "speed": 32
+  },
+  "flavor": "CLAMPERL’s sturdy shell is not only good for protection - it is also used for clamping and catching prey. A fully grown CLAMPERL’s shell will be scored with nicks and scratches all over."
+ },
+ {
+  "id": 367,
+  "name": "huntail",
+  "types": [
+   "water"
+  ],
+  "height": 17,
+  "weight": 270,
+  "stats": {
+   "hp": 55,
+   "attack": 104,
+   "defense": 105,
+   "special-attack": 94,
+   "special-defense": 75,
+   "speed": 52
+  },
+  "flavor": "HUNTAIL’s presence went unnoticed by people for a long time because it lives at extreme depths in the sea. This POKéMON’s eyes can see clearly even in the murky dark depths of the ocean."
+ },
+ {
+  "id": 368,
+  "name": "gorebyss",
+  "types": [
+   "water"
+  ],
+  "height": 18,
+  "weight": 226,
+  "stats": {
+   "hp": 55,
+   "attack": 84,
+   "defense": 105,
+   "special-attack": 114,
+   "special-defense": 75,
+   "speed": 52
+  },
+  "flavor": "GOREBYSS lives in the southern seas at extreme depths. Its body is built to withstand the enormous pressure of water at incredible depths. Because of this, this POKéMON’s body is unharmed by ordinary attacks."
+ },
+ {
+  "id": 369,
+  "name": "relicanth",
+  "types": [
+   "water",
+   "rock"
+  ],
+  "height": 10,
+  "weight": 234,
+  "stats": {
+   "hp": 100,
+   "attack": 90,
+   "defense": 130,
+   "special-attack": 45,
+   "special-defense": 65,
+   "speed": 55
+  },
+  "flavor": "RELICANTH is a POKéMON species that existed for a hundred million years without ever changing its form. This ancient POKéMON feeds on microscopic organisms with its toothless mouth."
+ },
+ {
+  "id": 370,
+  "name": "luvdisc",
+  "types": [
+   "water"
+  ],
+  "height": 6,
+  "weight": 87,
+  "stats": {
+   "hp": 43,
+   "attack": 30,
+   "defense": 55,
+   "special-attack": 40,
+   "special-defense": 65,
+   "speed": 97
+  },
+  "flavor": "LUVDISC live in shallow seas in the tropics. This heart-shaped POKéMON earned its name by swimming after loving couples it spotted in the ocean’s waves."
+ },
+ {
+  "id": 371,
+  "name": "bagon",
+  "types": [
+   "dragon"
+  ],
+  "height": 6,
+  "weight": 421,
+  "stats": {
+   "hp": 45,
+   "attack": 75,
+   "defense": 60,
+   "special-attack": 40,
+   "special-defense": 30,
+   "speed": 50
+  },
+  "flavor": "BAGON has a dream of one day soaring in the sky. In doomed efforts to fly, this POKéMON hurls itself off cliffs. As a result of its dives, its head has grown tough and as hard as tempered steel."
+ },
+ {
+  "id": 372,
+  "name": "shelgon",
+  "types": [
+   "dragon"
+  ],
+  "height": 11,
+  "weight": 1105,
+  "stats": {
+   "hp": 65,
+   "attack": 95,
+   "defense": 100,
+   "special-attack": 60,
+   "special-defense": 50,
+   "speed": 50
+  },
+  "flavor": "Inside SHELGON’s armor-like shell, cells are in the midst of transformation to create an entirely new body. This POKéMON’s shell is extremely heavy, making its movements sluggish."
+ },
+ {
+  "id": 373,
+  "name": "salamence",
+  "types": [
+   "dragon",
+   "flying"
+  ],
+  "height": 15,
+  "weight": 1026,
+  "stats": {
+   "hp": 95,
+   "attack": 135,
+   "defense": 80,
+   "special-attack": 110,
+   "special-defense": 80,
+   "speed": 100
+  },
+  "flavor": "SALAMENCE came about as a result of a strong, long-held dream of growing wings. It is said that this powerful desire triggered a sudden mutation in this POKéMON’s cells, causing it to sprout its magnificent wings."
+ },
+ {
+  "id": 374,
+  "name": "beldum",
+  "types": [
+   "steel",
+   "psychic"
+  ],
+  "height": 6,
+  "weight": 952,
+  "stats": {
+   "hp": 40,
+   "attack": 55,
+   "defense": 80,
+   "special-attack": 35,
+   "special-defense": 60,
+   "speed": 30
+  },
+  "flavor": "It converses with others by using magnetic pulses. In a swarm, they move in perfect unison."
+ },
+ {
+  "id": 375,
+  "name": "metang",
+  "types": [
+   "steel",
+   "psychic"
+  ],
+  "height": 12,
+  "weight": 2025,
+  "stats": {
+   "hp": 60,
+   "attack": 75,
+   "defense": 100,
+   "special-attack": 55,
+   "special-defense": 80,
+   "speed": 50
+  },
+  "flavor": "When two BELDUM fuse together, METANG is formed. The brains of the BELDUM are joined by a magnetic nervous system. By linking its brains magnetically, this POKéMON generates strong psychokinetic power."
+ },
+ {
+  "id": 376,
+  "name": "metagross",
+  "types": [
+   "steel",
+   "psychic"
+  ],
+  "height": 16,
+  "weight": 5500,
+  "stats": {
+   "hp": 80,
+   "attack": 135,
+   "defense": 130,
+   "special-attack": 95,
+   "special-defense": 90,
+   "speed": 70
+  },
+  "flavor": "METAGROSS has four brains in total. Combined, the four brains can breeze through difficult calculations faster than a supercomputer. This POKéMON can float in the air by tucking in its four legs."
+ },
+ {
+  "id": 377,
+  "name": "regirock",
+  "types": [
+   "rock"
+  ],
+  "height": 17,
+  "weight": 2300,
+  "stats": {
+   "hp": 80,
+   "attack": 100,
+   "defense": 200,
+   "special-attack": 50,
+   "special-defense": 100,
+   "speed": 50
+  },
+  "flavor": "REGIROCK was sealed away by people long ago. If this POKéMON’s body is damaged in battle, it is said to seek out suitable rocks on its own to repair itself."
+ },
+ {
+  "id": 378,
+  "name": "regice",
+  "types": [
+   "ice"
+  ],
+  "height": 18,
+  "weight": 1750,
+  "stats": {
+   "hp": 80,
+   "attack": 50,
+   "defense": 100,
+   "special-attack": 100,
+   "special-defense": 200,
+   "speed": 50
+  },
+  "flavor": "REGICE’s body was made during an ice age. The deep-frozen body can’t be melted, even by fire. This POKéMON controls frigid air of minus 328 degrees F."
+ },
+ {
+  "id": 379,
+  "name": "registeel",
+  "types": [
+   "steel"
+  ],
+  "height": 19,
+  "weight": 2050,
+  "stats": {
+   "hp": 80,
+   "attack": 75,
+   "defense": 150,
+   "special-attack": 75,
+   "special-defense": 150,
+   "speed": 50
+  },
+  "flavor": "REGISTEEL has a body that is harder than any kind of metal. Its body is apparently hollow. No one has any idea what this POKéMON eats."
+ },
+ {
+  "id": 380,
+  "name": "latias",
+  "types": [
+   "dragon",
+   "psychic"
+  ],
+  "height": 14,
+  "weight": 400,
+  "stats": {
+   "hp": 80,
+   "attack": 80,
+   "defense": 90,
+   "special-attack": 110,
+   "special-defense": 130,
+   "speed": 110
+  },
+  "flavor": "LATIAS is highly sensitive to the emotions of people. If it senses any hostility, this POKéMON ruffles the feathers all over its body and cries shrilly to intimidate the foe."
+ },
+ {
+  "id": 381,
+  "name": "latios",
+  "types": [
+   "dragon",
+   "psychic"
+  ],
+  "height": 20,
+  "weight": 600,
+  "stats": {
+   "hp": 80,
+   "attack": 90,
+   "defense": 80,
+   "special-attack": 130,
+   "special-defense": 110,
+   "speed": 110
+  },
+  "flavor": "LATIOS has the ability to make its foe see an image of what it has seen or imagines in its head. This POKéMON is intelligent and understands human speech."
+ },
+ {
+  "id": 382,
+  "name": "kyogre",
+  "types": [
+   "water"
+  ],
+  "height": 45,
+  "weight": 3520,
+  "stats": {
+   "hp": 100,
+   "attack": 100,
+   "defense": 90,
+   "special-attack": 150,
+   "special-defense": 140,
+   "speed": 90
+  },
+  "flavor": "KYOGRE has the power to create massive rain clouds that cover the entire sky and bring about torrential downpours. This POKéMON saved people who were suffering from droughts."
+ },
+ {
+  "id": 383,
+  "name": "groudon",
+  "types": [
+   "ground"
+  ],
+  "height": 35,
+  "weight": 9500,
+  "stats": {
+   "hp": 100,
+   "attack": 150,
+   "defense": 140,
+   "special-attack": 100,
+   "special-defense": 90,
+   "speed": 90
+  },
+  "flavor": "GROUDON has long been described in mythology as the POKéMON that raised lands and expanded continents. This POKéMON took to sleep after a cataclysmic battle with KYOGRE."
+ },
+ {
+  "id": 384,
+  "name": "rayquaza",
+  "types": [
+   "dragon",
+   "flying"
+  ],
+  "height": 70,
+  "weight": 2065,
+  "stats": {
+   "hp": 105,
+   "attack": 150,
+   "defense": 90,
+   "special-attack": 150,
+   "special-defense": 90,
+   "speed": 95
+  },
+  "flavor": "RAYQUAZA lived for hundreds of millions of years in the earth’s ozone layer, never descending to the ground. This POKéMON appears to feed on water and particles in the atmosphere."
+ },
+ {
+  "id": 385,
+  "name": "jirachi",
+  "types": [
+   "steel",
+   "psychic"
+  ],
+  "height": 3,
+  "weight": 11,
+  "stats": {
+   "hp": 100,
+   "attack": 100,
+   "defense": 100,
+   "special-attack": 100,
+   "special-defense": 100,
+   "speed": 100
+  },
+  "flavor": "A legend states that JIRACHI will make true any wish that is written on notes attached to its head when it awakens. If this POKéMON senses danger, it will fight without awakening."
+ },
+ {
+  "id": 386,
+  "name": "deoxys-normal",
+  "types": [
+   "psychic"
+  ],
+  "height": 17,
+  "weight": 608,
+  "stats": {
+   "hp": 50,
+   "attack": 150,
+   "defense": 50,
+   "special-attack": 150,
+   "special-defense": 50,
+   "speed": 150
+  },
+  "flavor": "The DNA of a space virus underwent a sudden mutation upon exposure to a laser beam and resulted in DEOXYS. The crystalline organ on this POKéMON’s chest appears to be its brain."
+ },
+ {
+  "id": 387,
+  "name": "turtwig",
+  "types": [
+   "grass"
+  ],
+  "height": 4,
+  "weight": 102,
+  "stats": {
+   "hp": 55,
+   "attack": 68,
+   "defense": 64,
+   "special-attack": 45,
+   "special-defense": 55,
+   "speed": 31
+  },
+  "flavor": "Made from soil, the shell on its back hardens when it drinks water. It lives along lakes."
+ },
+ {
+  "id": 388,
+  "name": "grotle",
+  "types": [
+   "grass"
+  ],
+  "height": 11,
+  "weight": 970,
+  "stats": {
+   "hp": 75,
+   "attack": 89,
+   "defense": 85,
+   "special-attack": 55,
+   "special-defense": 65,
+   "speed": 36
+  },
+  "flavor": "A GROTLE that lives in the forest is said to have its own secret springwater."
+ },
+ {
+  "id": 389,
+  "name": "torterra",
+  "types": [
+   "grass",
+   "ground"
+  ],
+  "height": 22,
+  "weight": 3100,
+  "stats": {
+   "hp": 95,
+   "attack": 109,
+   "defense": 105,
+   "special-attack": 75,
+   "special-defense": 85,
+   "speed": 56
+  },
+  "flavor": "Some Pokémon are born on a Torterra’s back and spend their entire life there."
+ },
+ {
+  "id": 390,
+  "name": "chimchar",
+  "types": [
+   "fire"
+  ],
+  "height": 5,
+  "weight": 62,
+  "stats": {
+   "hp": 44,
+   "attack": 58,
+   "defense": 44,
+   "special-attack": 58,
+   "special-defense": 44,
+   "speed": 61
+  },
+  "flavor": "It agilely scales sheer cliffs to live atop craggy mountains. Its fire is put out when it sleeps."
+ },
+ {
+  "id": 391,
+  "name": "monferno",
+  "types": [
+   "fire",
+   "fighting"
+  ],
+  "height": 9,
+  "weight": 220,
+  "stats": {
+   "hp": 64,
+   "attack": 78,
+   "defense": 52,
+   "special-attack": 78,
+   "special-defense": 52,
+   "speed": 81
+  },
+  "flavor": "To intimidate attackers, it stretches the fire on its tail to make itself appear bigger."
+ },
+ {
+  "id": 392,
+  "name": "infernape",
+  "types": [
+   "fire",
+   "fighting"
+  ],
+  "height": 12,
+  "weight": 550,
+  "stats": {
+   "hp": 76,
+   "attack": 104,
+   "defense": 71,
+   "special-attack": 104,
+   "special-defense": 71,
+   "speed": 108
+  },
+  "flavor": "It uses a special kind of martial arts involving all its limbs. Its fire never goes out."
+ },
+ {
+  "id": 393,
+  "name": "piplup",
+  "types": [
+   "water"
+  ],
+  "height": 4,
+  "weight": 52,
+  "stats": {
+   "hp": 53,
+   "attack": 51,
+   "defense": 53,
+   "special-attack": 61,
+   "special-defense": 56,
+   "speed": 40
+  },
+  "flavor": "Because it is very proud, it hates accepting food from people. Its thick down guards it from cold."
+ },
+ {
+  "id": 394,
+  "name": "prinplup",
+  "types": [
+   "water"
+  ],
+  "height": 8,
+  "weight": 230,
+  "stats": {
+   "hp": 64,
+   "attack": 66,
+   "defense": 68,
+   "special-attack": 81,
+   "special-defense": 76,
+   "speed": 50
+  },
+  "flavor": "It lives alone, away from others. Apparently, every one of them believes it is the most important."
+ },
+ {
+  "id": 395,
+  "name": "empoleon",
+  "types": [
+   "water",
+   "steel"
+  ],
+  "height": 17,
+  "weight": 845,
+  "stats": {
+   "hp": 84,
+   "attack": 86,
+   "defense": 88,
+   "special-attack": 111,
+   "special-defense": 101,
+   "speed": 60
+  },
+  "flavor": "The three horns that extend from its beak attest to its power. The leader has the biggest horns."
+ },
+ {
+  "id": 396,
+  "name": "starly",
+  "types": [
+   "normal",
+   "flying"
+  ],
+  "height": 3,
+  "weight": 20,
+  "stats": {
+   "hp": 40,
+   "attack": 55,
+   "defense": 30,
+   "special-attack": 30,
+   "special-defense": 30,
+   "speed": 60
+  },
+  "flavor": "They flock in great numbers. Though small, they flap their wings with great power."
+ },
+ {
+  "id": 397,
+  "name": "staravia",
+  "types": [
+   "normal",
+   "flying"
+  ],
+  "height": 6,
+  "weight": 155,
+  "stats": {
+   "hp": 55,
+   "attack": 75,
+   "defense": 50,
+   "special-attack": 40,
+   "special-defense": 40,
+   "speed": 80
+  },
+  "flavor": "It flies around forests and fields in search of bug Pokémon. It stays within a huge flock."
+ },
+ {
+  "id": 398,
+  "name": "staraptor",
+  "types": [
+   "normal",
+   "flying"
+  ],
+  "height": 12,
+  "weight": 249,
+  "stats": {
+   "hp": 85,
+   "attack": 120,
+   "defense": 70,
+   "special-attack": 50,
+   "special-defense": 60,
+   "speed": 100
+  },
+  "flavor": "It has a savage nature. It will courageously challenge foes that are much larger."
+ },
+ {
+  "id": 399,
+  "name": "bidoof",
+  "types": [
+   "normal"
+  ],
+  "height": 5,
+  "weight": 200,
+  "stats": {
+   "hp": 59,
+   "attack": 45,
+   "defense": 40,
+   "special-attack": 35,
+   "special-defense": 40,
+   "speed": 31
+  },
+  "flavor": "A comparison revealed that Bidoof’s front teeth grow at the same rate as Rattata’s."
+ },
+ {
+  "id": 400,
+  "name": "bibarel",
+  "types": [
+   "normal",
+   "water"
+  ],
+  "height": 10,
+  "weight": 315,
+  "stats": {
+   "hp": 79,
+   "attack": 85,
+   "defense": 60,
+   "special-attack": 55,
+   "special-defense": 60,
+   "speed": 71
+  },
+  "flavor": "It makes its nest by damming streams with bark and mud. It is known as an industrious worker."
+ },
+ {
+  "id": 401,
+  "name": "kricketot",
+  "types": [
+   "bug"
+  ],
+  "height": 3,
+  "weight": 22,
+  "stats": {
+   "hp": 37,
+   "attack": 25,
+   "defense": 41,
+   "special-attack": 25,
+   "special-defense": 41,
+   "speed": 25
+  },
+  "flavor": "It shakes its head back to front, causing its antennae to hit each other and sound like a xylophone."
+ },
+ {
+  "id": 402,
+  "name": "kricketune",
+  "types": [
+   "bug"
+  ],
+  "height": 10,
+  "weight": 255,
+  "stats": {
+   "hp": 77,
+   "attack": 85,
+   "defense": 51,
+   "special-attack": 55,
+   "special-defense": 51,
+   "speed": 65
+  },
+  "flavor": "It crosses its knifelike arms in front of its chest when it cries. It can compose melodies ad lib."
+ },
+ {
+  "id": 403,
+  "name": "shinx",
+  "types": [
+   "electric"
+  ],
+  "height": 5,
+  "weight": 95,
+  "stats": {
+   "hp": 45,
+   "attack": 65,
+   "defense": 34,
+   "special-attack": 40,
+   "special-defense": 34,
+   "speed": 45
+  },
+  "flavor": "All of its fur dazzles if danger is sensed. It flees while the foe is momentarily blinded."
+ },
+ {
+  "id": 404,
+  "name": "luxio",
+  "types": [
+   "electric"
+  ],
+  "height": 9,
+  "weight": 305,
+  "stats": {
+   "hp": 60,
+   "attack": 85,
+   "defense": 49,
+   "special-attack": 60,
+   "special-defense": 49,
+   "speed": 60
+  },
+  "flavor": "Its claws loose electricity with enough amperage to cause fainting. They live in small groups."
+ },
+ {
+  "id": 405,
+  "name": "luxray",
+  "types": [
+   "electric"
+  ],
+  "height": 14,
+  "weight": 420,
+  "stats": {
+   "hp": 80,
+   "attack": 120,
+   "defense": 79,
+   "special-attack": 95,
+   "special-defense": 79,
+   "speed": 70
+  },
+  "flavor": "It has eyes that can see through anything. It spots and captures prey hiding behind objects."
+ },
+ {
+  "id": 406,
+  "name": "budew",
+  "types": [
+   "grass",
+   "poison"
+  ],
+  "height": 2,
+  "weight": 12,
+  "stats": {
+   "hp": 40,
+   "attack": 30,
+   "defense": 35,
+   "special-attack": 50,
+   "special-defense": 70,
+   "speed": 55
+  },
+  "flavor": "Over the winter, it closes its bud and endures the cold. In spring, the bud opens and releases pollen."
+ },
+ {
+  "id": 407,
+  "name": "roserade",
+  "types": [
+   "grass",
+   "poison"
+  ],
+  "height": 9,
+  "weight": 145,
+  "stats": {
+   "hp": 60,
+   "attack": 70,
+   "defense": 65,
+   "special-attack": 125,
+   "special-defense": 105,
+   "speed": 90
+  },
+  "flavor": "It attracts prey with a sweet aroma, then downs it with thorny whips hidden in its arms."
+ },
+ {
+  "id": 408,
+  "name": "cranidos",
+  "types": [
+   "rock"
+  ],
+  "height": 9,
+  "weight": 315,
+  "stats": {
+   "hp": 67,
+   "attack": 125,
+   "defense": 40,
+   "special-attack": 30,
+   "special-defense": 30,
+   "speed": 58
+  },
+  "flavor": "It lived in jungles around 100 million years ago. Its skull is as hard as iron."
+ },
+ {
+  "id": 409,
+  "name": "rampardos",
+  "types": [
+   "rock"
+  ],
+  "height": 16,
+  "weight": 1025,
+  "stats": {
+   "hp": 97,
+   "attack": 165,
+   "defense": 60,
+   "special-attack": 65,
+   "special-defense": 50,
+   "speed": 58
+  },
+  "flavor": "Its powerful head butt has enough power to shatter even the most durable things upon impact."
+ },
+ {
+  "id": 410,
+  "name": "shieldon",
+  "types": [
+   "rock",
+   "steel"
+  ],
+  "height": 5,
+  "weight": 570,
+  "stats": {
+   "hp": 30,
+   "attack": 42,
+   "defense": 118,
+   "special-attack": 42,
+   "special-defense": 88,
+   "speed": 30
+  },
+  "flavor": "A Pokémon that lived in jungles around 100 million years ago. Its facial hide is extremely hard."
+ },
+ {
+  "id": 411,
+  "name": "bastiodon",
+  "types": [
+   "rock",
+   "steel"
+  ],
+  "height": 13,
+  "weight": 1495,
+  "stats": {
+   "hp": 60,
+   "attack": 52,
+   "defense": 168,
+   "special-attack": 47,
+   "special-defense": 138,
+   "speed": 30
+  },
+  "flavor": "Any frontal attack is repulsed. It is a docile Pokémon that feeds on grass and berries."
+ },
+ {
+  "id": 412,
+  "name": "burmy",
+  "types": [
+   "bug"
+  ],
+  "height": 2,
+  "weight": 34,
+  "stats": {
+   "hp": 40,
+   "attack": 29,
+   "defense": 45,
+   "special-attack": 29,
+   "special-defense": 45,
+   "speed": 36
+  },
+  "flavor": "To shelter itself from cold, wintry winds, it covers itself with a cloak made of twigs and leaves."
+ },
+ {
+  "id": 413,
+  "name": "wormadam-plant",
+  "types": [
+   "bug",
+   "grass"
+  ],
+  "height": 5,
+  "weight": 65,
+  "stats": {
+   "hp": 60,
+   "attack": 59,
+   "defense": 85,
+   "special-attack": 79,
+   "special-defense": 105,
+   "speed": 36
+  },
+  "flavor": "When BURMY evolved, its cloak became a part of this Pokémon’s body. The cloak is never shed."
+ },
+ {
+  "id": 414,
+  "name": "mothim",
+  "types": [
+   "bug",
+   "flying"
+  ],
+  "height": 9,
+  "weight": 233,
+  "stats": {
+   "hp": 70,
+   "attack": 94,
+   "defense": 50,
+   "special-attack": 94,
+   "special-defense": 50,
+   "speed": 66
+  },
+  "flavor": "It loves the honey of flowers and steals honey collected by COMBEE."
+ },
+ {
+  "id": 415,
+  "name": "combee",
+  "types": [
+   "bug",
+   "flying"
+  ],
+  "height": 3,
+  "weight": 55,
+  "stats": {
+   "hp": 30,
+   "attack": 30,
+   "defense": 42,
+   "special-attack": 30,
+   "special-defense": 42,
+   "speed": 70
+  },
+  "flavor": "A Pokémon formed by three others. It busily carries sweet floral honey to VESPIQUEN."
+ },
+ {
+  "id": 416,
+  "name": "vespiquen",
+  "types": [
+   "bug",
+   "flying"
+  ],
+  "height": 12,
+  "weight": 385,
+  "stats": {
+   "hp": 70,
+   "attack": 80,
+   "defense": 102,
+   "special-attack": 80,
+   "special-defense": 102,
+   "speed": 40
+  },
+  "flavor": "Its abdomen is a honeycomb for grubs. It raises its grubs on honey collected by COMBEE."
+ },
+ {
+  "id": 417,
+  "name": "pachirisu",
+  "types": [
+   "electric"
+  ],
+  "height": 4,
+  "weight": 39,
+  "stats": {
+   "hp": 60,
+   "attack": 45,
+   "defense": 70,
+   "special-attack": 45,
+   "special-defense": 90,
+   "speed": 95
+  },
+  "flavor": "It makes fur balls that crackle with static electricity. It stores them with berries in tree holes."
+ },
+ {
+  "id": 418,
+  "name": "buizel",
+  "types": [
+   "water"
+  ],
+  "height": 7,
+  "weight": 295,
+  "stats": {
+   "hp": 55,
+   "attack": 65,
+   "defense": 35,
+   "special-attack": 60,
+   "special-defense": 30,
+   "speed": 85
+  },
+  "flavor": "It has a flotation sac that is like an inflatable collar. It floats on water with its head out."
+ },
+ {
+  "id": 419,
+  "name": "floatzel",
+  "types": [
+   "water"
+  ],
+  "height": 11,
+  "weight": 335,
+  "stats": {
+   "hp": 85,
+   "attack": 105,
+   "defense": 55,
+   "special-attack": 85,
+   "special-defense": 50,
+   "speed": 115
+  },
+  "flavor": "It floats using its well-developed flotation sac. It assists in the rescues of drowning people."
+ },
+ {
+  "id": 420,
+  "name": "cherubi",
+  "types": [
+   "grass"
+  ],
+  "height": 4,
+  "weight": 33,
+  "stats": {
+   "hp": 45,
+   "attack": 35,
+   "defense": 45,
+   "special-attack": 62,
+   "special-defense": 53,
+   "speed": 35
+  },
+  "flavor": "The small ball holds the nutrients needed for evolution. Apparently, it is very sweet and tasty."
+ },
+ {
+  "id": 421,
+  "name": "cherrim",
+  "types": [
+   "grass"
+  ],
+  "height": 5,
+  "weight": 93,
+  "stats": {
+   "hp": 70,
+   "attack": 60,
+   "defense": 70,
+   "special-attack": 87,
+   "special-defense": 78,
+   "speed": 85
+  },
+  "flavor": "It blooms during times of strong sunlight. It tries to make up for everything it endured as a bud."
+ },
+ {
+  "id": 422,
+  "name": "shellos",
+  "types": [
+   "water"
+  ],
+  "height": 3,
+  "weight": 63,
+  "stats": {
+   "hp": 76,
+   "attack": 48,
+   "defense": 48,
+   "special-attack": 57,
+   "special-defense": 62,
+   "speed": 34
+  },
+  "flavor": "Its colors and shapes differ from region to region. In the Sinnoh region, two types are confirmed."
+ },
+ {
+  "id": 423,
+  "name": "gastrodon",
+  "types": [
+   "water",
+   "ground"
+  ],
+  "height": 9,
+  "weight": 299,
+  "stats": {
+   "hp": 111,
+   "attack": 83,
+   "defense": 68,
+   "special-attack": 92,
+   "special-defense": 82,
+   "speed": 39
+  },
+  "flavor": "It has a pliable body without any bones. If any part of its body is torn off, it grows right back."
+ },
+ {
+  "id": 424,
+  "name": "ambipom",
+  "types": [
+   "normal"
+  ],
+  "height": 12,
+  "weight": 203,
+  "stats": {
+   "hp": 75,
+   "attack": 100,
+   "defense": 66,
+   "special-attack": 60,
+   "special-defense": 66,
+   "speed": 115
+  },
+  "flavor": "To eat, it deftly shucks nuts with its two tails. It rarely uses its arms now."
+ },
+ {
+  "id": 425,
+  "name": "drifloon",
+  "types": [
+   "ghost",
+   "flying"
+  ],
+  "height": 4,
+  "weight": 12,
+  "stats": {
+   "hp": 90,
+   "attack": 50,
+   "defense": 34,
+   "special-attack": 60,
+   "special-defense": 44,
+   "speed": 70
+  },
+  "flavor": "A Pokémon formed by the spirits of people and Pokémon. It loves damp, humid seasons."
+ },
+ {
+  "id": 426,
+  "name": "drifblim",
+  "types": [
+   "ghost",
+   "flying"
+  ],
+  "height": 12,
+  "weight": 150,
+  "stats": {
+   "hp": 150,
+   "attack": 80,
+   "defense": 44,
+   "special-attack": 90,
+   "special-defense": 54,
+   "speed": 80
+  },
+  "flavor": "It’s drowzy in daytime, but flies off in the evening in big groups. No one knows where they go."
+ },
+ {
+  "id": 427,
+  "name": "buneary",
+  "types": [
+   "normal"
+  ],
+  "height": 4,
+  "weight": 55,
+  "stats": {
+   "hp": 55,
+   "attack": 66,
+   "defense": 44,
+   "special-attack": 44,
+   "special-defense": 56,
+   "speed": 85
+  },
+  "flavor": "It slams foes by sharply uncoiling its rolled ears. It stings enough to make a grown-up cry in pain."
+ },
+ {
+  "id": 428,
+  "name": "lopunny",
+  "types": [
+   "normal"
+  ],
+  "height": 12,
+  "weight": 333,
+  "stats": {
+   "hp": 65,
+   "attack": 76,
+   "defense": 84,
+   "special-attack": 54,
+   "special-defense": 96,
+   "speed": 105
+  },
+  "flavor": "An extremely cautious Pokémon. It cloaks its body with its fluffy ear fur when it senses danger."
+ },
+ {
+  "id": 429,
+  "name": "mismagius",
+  "types": [
+   "ghost"
+  ],
+  "height": 9,
+  "weight": 44,
+  "stats": {
+   "hp": 60,
+   "attack": 60,
+   "defense": 60,
+   "special-attack": 105,
+   "special-defense": 105,
+   "speed": 105
+  },
+  "flavor": "Its cries sound like incantations. Those hearing it are tormented by headaches and hallucinations."
+ },
+ {
+  "id": 430,
+  "name": "honchkrow",
+  "types": [
+   "dark",
+   "flying"
+  ],
+  "height": 9,
+  "weight": 273,
+  "stats": {
+   "hp": 100,
+   "attack": 125,
+   "defense": 52,
+   "special-attack": 105,
+   "special-defense": 52,
+   "speed": 71
+  },
+  "flavor": "Becoming active at night, it is known to swarm with numerous MURKROW in tow."
+ },
+ {
+  "id": 431,
+  "name": "glameow",
+  "types": [
+   "normal"
+  ],
+  "height": 5,
+  "weight": 39,
+  "stats": {
+   "hp": 49,
+   "attack": 55,
+   "defense": 42,
+   "special-attack": 42,
+   "special-defense": 37,
+   "speed": 85
+  },
+  "flavor": "It claws if displeased and purrs when affectionate. Its fickleness is very popular among some."
+ },
+ {
+  "id": 432,
+  "name": "purugly",
+  "types": [
+   "normal"
+  ],
+  "height": 10,
+  "weight": 438,
+  "stats": {
+   "hp": 71,
+   "attack": 82,
+   "defense": 64,
+   "special-attack": 64,
+   "special-defense": 59,
+   "speed": 112
+  },
+  "flavor": "It is a brazen brute that barges its way into another Pokémon’s nest and claims it as its own."
+ },
+ {
+  "id": 433,
+  "name": "chingling",
+  "types": [
+   "psychic"
+  ],
+  "height": 2,
+  "weight": 6,
+  "stats": {
+   "hp": 45,
+   "attack": 30,
+   "defense": 50,
+   "special-attack": 65,
+   "special-defense": 50,
+   "speed": 45
+  },
+  "flavor": "It emits cries by agitating an orb at the back of its throat. It moves with flouncing hops."
+ },
+ {
+  "id": 434,
+  "name": "stunky",
+  "types": [
+   "poison",
+   "dark"
+  ],
+  "height": 4,
+  "weight": 192,
+  "stats": {
+   "hp": 63,
+   "attack": 63,
+   "defense": 47,
+   "special-attack": 41,
+   "special-defense": 41,
+   "speed": 74
+  },
+  "flavor": "It protects itself by spraying a noxious fluid from its rear. The stench lingers for 24 hours."
+ },
+ {
+  "id": 435,
+  "name": "skuntank",
+  "types": [
+   "poison",
+   "dark"
+  ],
+  "height": 10,
+  "weight": 380,
+  "stats": {
+   "hp": 103,
+   "attack": 93,
+   "defense": 67,
+   "special-attack": 71,
+   "special-defense": 61,
+   "speed": 84
+  },
+  "flavor": "It sprays a vile-smelling fluid from the tip of its tail to attack. Its range is over 160 feet."
+ },
+ {
+  "id": 436,
+  "name": "bronzor",
+  "types": [
+   "steel",
+   "psychic"
+  ],
+  "height": 5,
+  "weight": 605,
+  "stats": {
+   "hp": 57,
+   "attack": 24,
+   "defense": 86,
+   "special-attack": 24,
+   "special-defense": 86,
+   "speed": 23
+  },
+  "flavor": "Implements shaped like it were discovered in ancient tombs. It is unknown if they are related."
+ },
+ {
+  "id": 437,
+  "name": "bronzong",
+  "types": [
+   "steel",
+   "psychic"
+  ],
+  "height": 13,
+  "weight": 1870,
+  "stats": {
+   "hp": 67,
+   "attack": 89,
+   "defense": 116,
+   "special-attack": 79,
+   "special-defense": 116,
+   "speed": 33
+  },
+  "flavor": "One caused a news sensation when it was dug up at a construction site after a 2,000-year sleep."
+ },
+ {
+  "id": 438,
+  "name": "bonsly",
+  "types": [
+   "rock"
+  ],
+  "height": 5,
+  "weight": 150,
+  "stats": {
+   "hp": 50,
+   "attack": 80,
+   "defense": 95,
+   "special-attack": 10,
+   "special-defense": 45,
+   "speed": 10
+  },
+  "flavor": "It looks as if it is always crying. It is actually adjusting its body’s fluid levels by eliminating excess."
+ },
+ {
+  "id": 439,
+  "name": "mime-jr",
+  "types": [
+   "psychic",
+   "fairy"
+  ],
+  "height": 6,
+  "weight": 130,
+  "stats": {
+   "hp": 20,
+   "attack": 25,
+   "defense": 45,
+   "special-attack": 70,
+   "special-defense": 90,
+   "speed": 60
+  },
+  "flavor": "In an attempt to confuse its enemy, it mimics the enemy’s movements. Then it wastes no time in making itself scarce!"
+ },
+ {
+  "id": 440,
+  "name": "happiny",
+  "types": [
+   "normal"
+  ],
+  "height": 6,
+  "weight": 244,
+  "stats": {
+   "hp": 100,
+   "attack": 5,
+   "defense": 5,
+   "special-attack": 15,
+   "special-defense": 65,
+   "speed": 30
+  },
+  "flavor": "It loves round white things. It carries an egg-shaped rock in imitation of CHANSEY."
+ },
+ {
+  "id": 441,
+  "name": "chatot",
+  "types": [
+   "normal",
+   "flying"
+  ],
+  "height": 5,
+  "weight": 19,
+  "stats": {
+   "hp": 76,
+   "attack": 65,
+   "defense": 45,
+   "special-attack": 92,
+   "special-defense": 42,
+   "speed": 91
+  },
+  "flavor": "It can learn and speak human words. If they gather, they all learn the same saying."
+ },
+ {
+  "id": 442,
+  "name": "spiritomb",
+  "types": [
+   "ghost",
+   "dark"
+  ],
+  "height": 10,
+  "weight": 1080,
+  "stats": {
+   "hp": 50,
+   "attack": 92,
+   "defense": 108,
+   "special-attack": 92,
+   "special-defense": 108,
+   "speed": 35
+  },
+  "flavor": "A Pokémon that was formed by 108 spirits. It is bound to a fissure in an odd keystone."
+ },
+ {
+  "id": 443,
+  "name": "gible",
+  "types": [
+   "dragon",
+   "ground"
+  ],
+  "height": 7,
+  "weight": 205,
+  "stats": {
+   "hp": 58,
+   "attack": 70,
+   "defense": 45,
+   "special-attack": 40,
+   "special-defense": 45,
+   "speed": 42
+  },
+  "flavor": "It nests in small, horizontal holes in cave walls. It pounces to catch prey that stray too close."
+ },
+ {
+  "id": 444,
+  "name": "gabite",
+  "types": [
+   "dragon",
+   "ground"
+  ],
+  "height": 14,
+  "weight": 560,
+  "stats": {
+   "hp": 68,
+   "attack": 90,
+   "defense": 65,
+   "special-attack": 50,
+   "special-defense": 55,
+   "speed": 82
+  },
+  "flavor": "There is a long-held belief that medicine made from its scales will heal even incurable illnesses."
+ },
+ {
+  "id": 445,
+  "name": "garchomp",
+  "types": [
+   "dragon",
+   "ground"
+  ],
+  "height": 19,
+  "weight": 950,
+  "stats": {
+   "hp": 108,
+   "attack": 130,
+   "defense": 95,
+   "special-attack": 80,
+   "special-defense": 85,
+   "speed": 102
+  },
+  "flavor": "When it folds up its body and extends its wings, it looks like a jet plane. It flies at sonic speed."
+ },
+ {
+  "id": 446,
+  "name": "munchlax",
+  "types": [
+   "normal"
+  ],
+  "height": 6,
+  "weight": 1050,
+  "stats": {
+   "hp": 135,
+   "attack": 85,
+   "defense": 40,
+   "special-attack": 40,
+   "special-defense": 85,
+   "speed": 5
+  },
+  "flavor": "It wolfs down its weight in food once a day, swallowing food whole with almost no chewing."
+ },
+ {
+  "id": 447,
+  "name": "riolu",
+  "types": [
+   "fighting"
+  ],
+  "height": 7,
+  "weight": 202,
+  "stats": {
+   "hp": 40,
+   "attack": 70,
+   "defense": 40,
+   "special-attack": 35,
+   "special-defense": 40,
+   "speed": 60
+  },
+  "flavor": "The aura that emanates from its body intensifies to alert others if it is afraid or sad."
+ },
+ {
+  "id": 448,
+  "name": "lucario",
+  "types": [
+   "fighting",
+   "steel"
+  ],
+  "height": 12,
+  "weight": 540,
+  "stats": {
+   "hp": 70,
+   "attack": 110,
+   "defense": 70,
+   "special-attack": 115,
+   "special-defense": 70,
+   "speed": 90
+  },
+  "flavor": "It has the ability to sense the auras of all things. It understands human speech."
+ },
+ {
+  "id": 449,
+  "name": "hippopotas",
+  "types": [
+   "ground"
+  ],
+  "height": 8,
+  "weight": 495,
+  "stats": {
+   "hp": 68,
+   "attack": 72,
+   "defense": 78,
+   "special-attack": 38,
+   "special-defense": 42,
+   "speed": 32
+  },
+  "flavor": "It lives in arid places. Instead of perspiration, it expels grainy sand from its body."
+ },
+ {
+  "id": 450,
+  "name": "hippowdon",
+  "types": [
+   "ground"
+  ],
+  "height": 20,
+  "weight": 3000,
+  "stats": {
+   "hp": 108,
+   "attack": 112,
+   "defense": 118,
+   "special-attack": 68,
+   "special-defense": 72,
+   "speed": 47
+  },
+  "flavor": "It blasts internally stored sand from ports on its body to create a towering twister for attack."
+ },
+ {
+  "id": 451,
+  "name": "skorupi",
+  "types": [
+   "poison",
+   "bug"
+  ],
+  "height": 8,
+  "weight": 120,
+  "stats": {
+   "hp": 40,
+   "attack": 50,
+   "defense": 90,
+   "special-attack": 30,
+   "special-defense": 55,
+   "speed": 65
+  },
+  "flavor": "It grips prey with its tail claws and injects poison. It tenaciously hangs on until the poison takes."
+ },
+ {
+  "id": 452,
+  "name": "drapion",
+  "types": [
+   "poison",
+   "dark"
+  ],
+  "height": 13,
+  "weight": 615,
+  "stats": {
+   "hp": 70,
+   "attack": 90,
+   "defense": 110,
+   "special-attack": 60,
+   "special-defense": 75,
+   "speed": 95
+  },
+  "flavor": "It has the power in its clawed arms to make scrap of a car. The tips of its claws release poison."
+ },
+ {
+  "id": 453,
+  "name": "croagunk",
+  "types": [
+   "poison",
+   "fighting"
+  ],
+  "height": 7,
+  "weight": 230,
+  "stats": {
+   "hp": 48,
+   "attack": 61,
+   "defense": 40,
+   "special-attack": 61,
+   "special-defense": 40,
+   "speed": 50
+  },
+  "flavor": "Its cheeks hold poison sacs. It tries to catch foes off guard to jab them with toxic fingers."
+ },
+ {
+  "id": 454,
+  "name": "toxicroak",
+  "types": [
+   "poison",
+   "fighting"
+  ],
+  "height": 13,
+  "weight": 444,
+  "stats": {
+   "hp": 83,
+   "attack": 106,
+   "defense": 65,
+   "special-attack": 86,
+   "special-defense": 65,
+   "speed": 85
+  },
+  "flavor": "Its knuckle claws secrete a toxin so vile that even a scratch could prove fatal."
+ },
+ {
+  "id": 455,
+  "name": "carnivine",
+  "types": [
+   "grass"
+  ],
+  "height": 14,
+  "weight": 270,
+  "stats": {
+   "hp": 74,
+   "attack": 100,
+   "defense": 72,
+   "special-attack": 90,
+   "special-defense": 72,
+   "speed": 46
+  },
+  "flavor": "It attracts prey with its sweet- smelling saliva, then chomps down. It takes a whole day to eat prey."
+ },
+ {
+  "id": 456,
+  "name": "finneon",
+  "types": [
+   "water"
+  ],
+  "height": 4,
+  "weight": 70,
+  "stats": {
+   "hp": 49,
+   "attack": 49,
+   "defense": 56,
+   "special-attack": 49,
+   "special-defense": 61,
+   "speed": 66
+  },
+  "flavor": "After long exposure to sunlight, the patterns on its tail fins shine vividly when darkness arrives."
+ },
+ {
+  "id": 457,
+  "name": "lumineon",
+  "types": [
+   "water"
+  ],
+  "height": 12,
+  "weight": 240,
+  "stats": {
+   "hp": 69,
+   "attack": 69,
+   "defense": 76,
+   "special-attack": 69,
+   "special-defense": 86,
+   "speed": 91
+  },
+  "flavor": "It lives on the deep-sea floor. It attracts prey by flashing the patterns on its four tail fins."
+ },
+ {
+  "id": 458,
+  "name": "mantyke",
+  "types": [
+   "water",
+   "flying"
+  ],
+  "height": 10,
+  "weight": 650,
+  "stats": {
+   "hp": 45,
+   "attack": 20,
+   "defense": 50,
+   "special-attack": 60,
+   "special-defense": 120,
+   "speed": 50
+  },
+  "flavor": "A friendly Pokémon that captures the subtle flows of seawater using its two antennae."
+ },
+ {
+  "id": 459,
+  "name": "snover",
+  "types": [
+   "grass",
+   "ice"
+  ],
+  "height": 10,
+  "weight": 505,
+  "stats": {
+   "hp": 60,
+   "attack": 62,
+   "defense": 50,
+   "special-attack": 62,
+   "special-defense": 60,
+   "speed": 40
+  },
+  "flavor": "It lives on snowy mountains. Having had little contact with humans, it is boldly inquisitive."
+ },
+ {
+  "id": 460,
+  "name": "abomasnow",
+  "types": [
+   "grass",
+   "ice"
+  ],
+  "height": 22,
+  "weight": 1355,
+  "stats": {
+   "hp": 90,
+   "attack": 92,
+   "defense": 75,
+   "special-attack": 92,
+   "special-defense": 85,
+   "speed": 60
+  },
+  "flavor": "It whips up blizzards in mountains that are always buried in snow. It is the abominable snowman."
+ },
+ {
+  "id": 461,
+  "name": "weavile",
+  "types": [
+   "dark",
+   "ice"
+  ],
+  "height": 11,
+  "weight": 340,
+  "stats": {
+   "hp": 70,
+   "attack": 120,
+   "defense": 65,
+   "special-attack": 45,
+   "special-defense": 85,
+   "speed": 125
+  },
+  "flavor": "They communicate by clawing signs in boulders and work together to surround enemies."
+ },
+ {
+  "id": 462,
+  "name": "magnezone",
+  "types": [
+   "electric",
+   "steel"
+  ],
+  "height": 12,
+  "weight": 1800,
+  "stats": {
+   "hp": 70,
+   "attack": 70,
+   "defense": 115,
+   "special-attack": 130,
+   "special-defense": 90,
+   "speed": 60
+  },
+  "flavor": "It evolved from exposure to a special magnetic field. Three units generate magnetism."
+ },
+ {
+  "id": 463,
+  "name": "lickilicky",
+  "types": [
+   "normal"
+  ],
+  "height": 17,
+  "weight": 1400,
+  "stats": {
+   "hp": 110,
+   "attack": 85,
+   "defense": 95,
+   "special-attack": 80,
+   "special-defense": 95,
+   "speed": 50
+  },
+  "flavor": "It wraps things with its extensible tongue. Getting too close to it will leave you soaked with drool."
+ },
+ {
+  "id": 464,
+  "name": "rhyperior",
+  "types": [
+   "ground",
+   "rock"
+  ],
+  "height": 24,
+  "weight": 2828,
+  "stats": {
+   "hp": 115,
+   "attack": 140,
+   "defense": 130,
+   "special-attack": 55,
+   "special-defense": 55,
+   "speed": 40
+  },
+  "flavor": "It puts rocks in holes in its palms and uses its muscles to shoot them. GEODUDE are shot at rare times."
+ },
+ {
+  "id": 465,
+  "name": "tangrowth",
+  "types": [
+   "grass"
+  ],
+  "height": 20,
+  "weight": 1286,
+  "stats": {
+   "hp": 100,
+   "attack": 100,
+   "defense": 125,
+   "special-attack": 110,
+   "special-defense": 50,
+   "speed": 50
+  },
+  "flavor": "It ensnares prey by extending arms made of vines. Losing arms to predators does not trouble it."
+ },
+ {
+  "id": 466,
+  "name": "electivire",
+  "types": [
+   "electric"
+  ],
+  "height": 18,
+  "weight": 1386,
+  "stats": {
+   "hp": 75,
+   "attack": 123,
+   "defense": 67,
+   "special-attack": 95,
+   "special-defense": 85,
+   "speed": 95
+  },
+  "flavor": "It pushes the tips of its two tails against the foe, then lets loose with over 20,000 volts of power."
+ },
+ {
+  "id": 467,
+  "name": "magmortar",
+  "types": [
+   "fire"
+  ],
+  "height": 16,
+  "weight": 680,
+  "stats": {
+   "hp": 75,
+   "attack": 95,
+   "defense": 67,
+   "special-attack": 125,
+   "special-defense": 95,
+   "speed": 83
+  },
+  "flavor": "It blasts fireballs of over 3,600 degrees F from the ends of its arms. It lives in volcanic craters."
+ },
+ {
+  "id": 468,
+  "name": "togekiss",
+  "types": [
+   "fairy",
+   "flying"
+  ],
+  "height": 15,
+  "weight": 380,
+  "stats": {
+   "hp": 85,
+   "attack": 50,
+   "defense": 95,
+   "special-attack": 120,
+   "special-defense": 115,
+   "speed": 80
+  },
+  "flavor": "It will never appear where there is strife. Its sightings have become rare recently."
+ },
+ {
+  "id": 469,
+  "name": "yanmega",
+  "types": [
+   "bug",
+   "flying"
+  ],
+  "height": 19,
+  "weight": 515,
+  "stats": {
+   "hp": 86,
+   "attack": 76,
+   "defense": 86,
+   "special-attack": 116,
+   "special-defense": 56,
+   "speed": 95
+  },
+  "flavor": "By churning its wings, it creates shock waves that inflict critical internal injuries to foes."
+ },
+ {
+  "id": 470,
+  "name": "leafeon",
+  "types": [
+   "grass"
+  ],
+  "height": 10,
+  "weight": 255,
+  "stats": {
+   "hp": 65,
+   "attack": 110,
+   "defense": 130,
+   "special-attack": 60,
+   "special-defense": 65,
+   "speed": 95
+  },
+  "flavor": "Just like a plant, it uses photosynthesis. As a result, it is always enveloped in clear air."
+ },
+ {
+  "id": 471,
+  "name": "glaceon",
+  "types": [
+   "ice"
+  ],
+  "height": 8,
+  "weight": 259,
+  "stats": {
+   "hp": 65,
+   "attack": 60,
+   "defense": 110,
+   "special-attack": 130,
+   "special-defense": 95,
+   "speed": 65
+  },
+  "flavor": "As a protective technique, it can completely freeze its fur to make its hairs stand like needles."
+ },
+ {
+  "id": 472,
+  "name": "gliscor",
+  "types": [
+   "ground",
+   "flying"
+  ],
+  "height": 20,
+  "weight": 425,
+  "stats": {
+   "hp": 75,
+   "attack": 95,
+   "defense": 125,
+   "special-attack": 45,
+   "special-defense": 75,
+   "speed": 95
+  },
+  "flavor": "It observes prey while hanging inverted from branches. When the chance presents itself, it swoops!"
+ },
+ {
+  "id": 473,
+  "name": "mamoswine",
+  "types": [
+   "ice",
+   "ground"
+  ],
+  "height": 25,
+  "weight": 2910,
+  "stats": {
+   "hp": 110,
+   "attack": 130,
+   "defense": 80,
+   "special-attack": 70,
+   "special-defense": 60,
+   "speed": 80
+  },
+  "flavor": "Its impressive tusks are made of ice. The population thinned when it turned warm after the ice age."
+ },
+ {
+  "id": 474,
+  "name": "porygon-z",
+  "types": [
+   "normal"
+  ],
+  "height": 9,
+  "weight": 340,
+  "stats": {
+   "hp": 85,
+   "attack": 80,
+   "defense": 70,
+   "special-attack": 135,
+   "special-defense": 75,
+   "speed": 90
+  },
+  "flavor": "Additional software was installed to make it a better Pokémon. It began acting oddly, however."
+ },
+ {
+  "id": 475,
+  "name": "gallade",
+  "types": [
+   "psychic",
+   "fighting"
+  ],
+  "height": 16,
+  "weight": 520,
+  "stats": {
+   "hp": 68,
+   "attack": 125,
+   "defense": 65,
+   "special-attack": 65,
+   "special-defense": 115,
+   "speed": 80
+  },
+  "flavor": "A master of courtesy and swordsmanship, it fights using extending swords on its elbows."
+ },
+ {
+  "id": 476,
+  "name": "probopass",
+  "types": [
+   "rock",
+   "steel"
+  ],
+  "height": 14,
+  "weight": 3400,
+  "stats": {
+   "hp": 60,
+   "attack": 55,
+   "defense": 145,
+   "special-attack": 75,
+   "special-defense": 150,
+   "speed": 40
+  },
+  "flavor": "It freely controls three units called Mini-Noses using magnetic force."
+ },
+ {
+  "id": 477,
+  "name": "dusknoir",
+  "types": [
+   "ghost"
+  ],
+  "height": 22,
+  "weight": 1066,
+  "stats": {
+   "hp": 45,
+   "attack": 100,
+   "defense": 135,
+   "special-attack": 65,
+   "special-defense": 135,
+   "speed": 45
+  },
+  "flavor": "The antenna on its head captures radio waves from the world of spirits that command it to take people there."
+ },
+ {
+  "id": 478,
+  "name": "froslass",
+  "types": [
+   "ice",
+   "ghost"
+  ],
+  "height": 13,
+  "weight": 266,
+  "stats": {
+   "hp": 70,
+   "attack": 80,
+   "defense": 70,
+   "special-attack": 80,
+   "special-defense": 70,
+   "speed": 110
+  },
+  "flavor": "It freezes foes with an icy breath nearly -60 degrees F. What seems to be its body is actually hollow."
+ },
+ {
+  "id": 479,
+  "name": "rotom",
+  "types": [
+   "electric",
+   "ghost"
+  ],
+  "height": 3,
+  "weight": 3,
+  "stats": {
+   "hp": 50,
+   "attack": 50,
+   "defense": 77,
+   "special-attack": 95,
+   "special-defense": 77,
+   "speed": 91
+  },
+  "flavor": "Research continues on this Pokémon, which could be the power source of a unique motor."
+ },
+ {
+  "id": 480,
+  "name": "uxie",
+  "types": [
+   "psychic"
+  ],
+  "height": 3,
+  "weight": 3,
+  "stats": {
+   "hp": 75,
+   "attack": 75,
+   "defense": 130,
+   "special-attack": 75,
+   "special-defense": 130,
+   "speed": 95
+  },
+  "flavor": "Known as “The Being of Knowledge.” It is said that it can wipe out the memory of those who see its eyes."
+ },
+ {
+  "id": 481,
+  "name": "mesprit",
+  "types": [
+   "psychic"
+  ],
+  "height": 3,
+  "weight": 3,
+  "stats": {
+   "hp": 80,
+   "attack": 105,
+   "defense": 105,
+   "special-attack": 105,
+   "special-defense": 105,
+   "speed": 80
+  },
+  "flavor": "Known as “The Being of Emotion.” It taught humans the nobility of sorrow, pain, and joy."
+ },
+ {
+  "id": 482,
+  "name": "azelf",
+  "types": [
+   "psychic"
+  ],
+  "height": 3,
+  "weight": 3,
+  "stats": {
+   "hp": 75,
+   "attack": 125,
+   "defense": 70,
+   "special-attack": 125,
+   "special-defense": 70,
+   "speed": 115
+  },
+  "flavor": "It is thought that Uxie, Mesprit, and Azelf all came from the same egg."
+ },
+ {
+  "id": 483,
+  "name": "dialga",
+  "types": [
+   "steel",
+   "dragon"
+  ],
+  "height": 54,
+  "weight": 6830,
+  "stats": {
+   "hp": 100,
+   "attack": 120,
+   "defense": 120,
+   "special-attack": 150,
+   "special-defense": 100,
+   "speed": 90
+  },
+  "flavor": "It has the power to control time. It appears in Sinnoh-region myths as an ancient deity."
+ },
+ {
+  "id": 484,
+  "name": "palkia",
+  "types": [
+   "water",
+   "dragon"
+  ],
+  "height": 42,
+  "weight": 3360,
+  "stats": {
+   "hp": 90,
+   "attack": 120,
+   "defense": 100,
+   "special-attack": 150,
+   "special-defense": 120,
+   "speed": 100
+  },
+  "flavor": "It has the ability to distort space. It is described as a deity in Sinnoh-region mythology."
+ },
+ {
+  "id": 485,
+  "name": "heatran",
+  "types": [
+   "fire",
+   "steel"
+  ],
+  "height": 17,
+  "weight": 4300,
+  "stats": {
+   "hp": 91,
+   "attack": 90,
+   "defense": 106,
+   "special-attack": 130,
+   "special-defense": 106,
+   "speed": 77
+  },
+  "flavor": "It dwells in volcanic caves. It digs in with its cross-shaped feet to crawl on ceilings and walls."
+ },
+ {
+  "id": 486,
+  "name": "regigigas",
+  "types": [
+   "normal"
+  ],
+  "height": 37,
+  "weight": 4200,
+  "stats": {
+   "hp": 110,
+   "attack": 160,
+   "defense": 110,
+   "special-attack": 80,
+   "special-defense": 110,
+   "speed": 100
+  },
+  "flavor": "There is an enduring legend that states this Pokémon towed continents with ropes."
+ },
+ {
+  "id": 487,
+  "name": "giratina-altered",
+  "types": [
+   "ghost",
+   "dragon"
+  ],
+  "height": 45,
+  "weight": 7500,
+  "stats": {
+   "hp": 150,
+   "attack": 100,
+   "defense": 120,
+   "special-attack": 100,
+   "special-defense": 120,
+   "speed": 90
+  },
+  "flavor": "A Pokémon that is said to live in a world on the reverse side of ours. It appears in an ancient cemetery."
+ },
+ {
+  "id": 488,
+  "name": "cresselia",
+  "types": [
+   "psychic"
+  ],
+  "height": 15,
+  "weight": 856,
+  "stats": {
+   "hp": 120,
+   "attack": 70,
+   "defense": 110,
+   "special-attack": 75,
+   "special-defense": 120,
+   "speed": 85
+  },
+  "flavor": "Shiny particles are released from its wings like a veil. It is said to represent the crescent moon."
+ },
+ {
+  "id": 489,
+  "name": "phione",
+  "types": [
+   "water"
+  ],
+  "height": 4,
+  "weight": 31,
+  "stats": {
+   "hp": 80,
+   "attack": 80,
+   "defense": 80,
+   "special-attack": 80,
+   "special-defense": 80,
+   "speed": 80
+  },
+  "flavor": "A Pokémon that lives in warm seas. It inflates the flotation sac on its head to drift and search for food."
+ },
+ {
+  "id": 490,
+  "name": "manaphy",
+  "types": [
+   "water"
+  ],
+  "height": 3,
+  "weight": 14,
+  "stats": {
+   "hp": 100,
+   "attack": 100,
+   "defense": 100,
+   "special-attack": 100,
+   "special-defense": 100,
+   "speed": 100
+  },
+  "flavor": "Born on a cold seafloor, it will swim great distances to return to its birthplace."
+ },
+ {
+  "id": 491,
+  "name": "darkrai",
+  "types": [
+   "dark"
+  ],
+  "height": 15,
+  "weight": 505,
+  "stats": {
+   "hp": 70,
+   "attack": 90,
+   "defense": 90,
+   "special-attack": 135,
+   "special-defense": 90,
+   "speed": 125
+  },
+  "flavor": "It can lull people to sleep and make them dream. It is active during nights of the new moon."
+ },
+ {
+  "id": 492,
+  "name": "shaymin-land",
+  "types": [
+   "grass"
+  ],
+  "height": 2,
+  "weight": 21,
+  "stats": {
+   "hp": 100,
+   "attack": 100,
+   "defense": 100,
+   "special-attack": 100,
+   "special-defense": 100,
+   "speed": 100
+  },
+  "flavor": "It lives in flower patches and avoids detection by curling up to look like a flowering plant."
+ },
+ {
+  "id": 493,
+  "name": "arceus",
+  "types": [
+   "normal"
+  ],
+  "height": 32,
+  "weight": 3200,
+  "stats": {
+   "hp": 120,
+   "attack": 120,
+   "defense": 120,
+   "special-attack": 120,
+   "special-defense": 120,
+   "speed": 120
+  },
+  "flavor": "It is said to have emerged from an egg in a place where there was nothing, then shaped the world."
+ },
+ {
+  "id": 494,
+  "name": "victini",
+  "types": [
+   "psychic",
+   "fire"
+  ],
+  "height": 4,
+  "weight": 40,
+  "stats": {
+   "hp": 100,
+   "attack": 100,
+   "defense": 100,
+   "special-attack": 100,
+   "special-defense": 100,
+   "speed": 100
+  },
+  "flavor": "This Pokémon brings victory. It is said that Trainers with Victini always win, regardless of the type of encounter."
+ },
+ {
+  "id": 495,
+  "name": "snivy",
+  "types": [
+   "grass"
+  ],
+  "height": 6,
+  "weight": 81,
+  "stats": {
+   "hp": 45,
+   "attack": 45,
+   "defense": 55,
+   "special-attack": 45,
+   "special-defense": 55,
+   "speed": 63
+  },
+  "flavor": "It is very intelligent and calm. Being exposed to lots of sunlight makes its movements swifter."
+ },
+ {
+  "id": 496,
+  "name": "servine",
+  "types": [
+   "grass"
+  ],
+  "height": 8,
+  "weight": 160,
+  "stats": {
+   "hp": 60,
+   "attack": 60,
+   "defense": 75,
+   "special-attack": 60,
+   "special-defense": 75,
+   "speed": 83
+  },
+  "flavor": "It moves along the ground as if sliding. Its swift movements befuddle its foes, and it then attacks with a vine whip."
+ },
+ {
+  "id": 497,
+  "name": "serperior",
+  "types": [
+   "grass"
+  ],
+  "height": 33,
+  "weight": 630,
+  "stats": {
+   "hp": 75,
+   "attack": 75,
+   "defense": 95,
+   "special-attack": 75,
+   "special-defense": 95,
+   "speed": 113
+  },
+  "flavor": "It can stop its opponents’ movements with just a glare. It takes in solar energy and boosts it internally."
+ },
+ {
+  "id": 498,
+  "name": "tepig",
+  "types": [
+   "fire"
+  ],
+  "height": 5,
+  "weight": 99,
+  "stats": {
+   "hp": 65,
+   "attack": 63,
+   "defense": 45,
+   "special-attack": 45,
+   "special-defense": 45,
+   "speed": 45
+  },
+  "flavor": "It can deftly dodge its foe’s attacks while shooting fireballs from its nose. It roasts berries before it eats them."
+ },
+ {
+  "id": 499,
+  "name": "pignite",
+  "types": [
+   "fire",
+   "fighting"
+  ],
+  "height": 10,
+  "weight": 555,
+  "stats": {
+   "hp": 90,
+   "attack": 93,
+   "defense": 55,
+   "special-attack": 70,
+   "special-defense": 55,
+   "speed": 55
+  },
+  "flavor": "When its internal fire flares up, its movements grow sharper and faster. When in trouble, it emits smoke."
+ },
+ {
+  "id": 500,
+  "name": "emboar",
+  "types": [
+   "fire",
+   "fighting"
+  ],
+  "height": 16,
+  "weight": 1500,
+  "stats": {
+   "hp": 110,
+   "attack": 123,
+   "defense": 65,
+   "special-attack": 100,
+   "special-defense": 65,
+   "speed": 65
+  },
+  "flavor": "It has mastered fast and powerful fighting moves. It grows a beard of fire."
+ },
+ {
+  "id": 501,
+  "name": "oshawott",
+  "types": [
+   "water"
+  ],
+  "height": 5,
+  "weight": 59,
+  "stats": {
+   "hp": 55,
+   "attack": 55,
+   "defense": 45,
+   "special-attack": 63,
+   "special-defense": 45,
+   "speed": 45
+  },
+  "flavor": "It fights using the scalchop on its stomach. In response to an attack, it retaliates immediately by slashing."
+ },
+ {
+  "id": 502,
+  "name": "dewott",
+  "types": [
+   "water"
+  ],
+  "height": 8,
+  "weight": 245,
+  "stats": {
+   "hp": 75,
+   "attack": 75,
+   "defense": 60,
+   "special-attack": 83,
+   "special-defense": 60,
+   "speed": 60
+  },
+  "flavor": "Strict training is how it learns its flowing double-scalchop technique."
+ },
+ {
+  "id": 503,
+  "name": "samurott",
+  "types": [
+   "water"
+  ],
+  "height": 15,
+  "weight": 946,
+  "stats": {
+   "hp": 95,
+   "attack": 100,
+   "defense": 85,
+   "special-attack": 108,
+   "special-defense": 70,
+   "speed": 70
+  },
+  "flavor": "One swing of the sword incorporated in its armor can fell an opponent. A simple glare from one of them quiets everybody."
+ },
+ {
+  "id": 504,
+  "name": "patrat",
+  "types": [
+   "normal"
+  ],
+  "height": 5,
+  "weight": 116,
+  "stats": {
+   "hp": 45,
+   "attack": 55,
+   "defense": 39,
+   "special-attack": 35,
+   "special-defense": 39,
+   "speed": 42
+  },
+  "flavor": "Using food stored in cheek pouches, they can keep watch for days. They use their tails to communicate with others."
+ },
+ {
+  "id": 505,
+  "name": "watchog",
+  "types": [
+   "normal"
+  ],
+  "height": 11,
+  "weight": 270,
+  "stats": {
+   "hp": 60,
+   "attack": 85,
+   "defense": 69,
+   "special-attack": 60,
+   "special-defense": 69,
+   "speed": 77
+  },
+  "flavor": "When they see an enemy, their tails stand high, and they spit the seeds of berries stored in their cheek pouches."
+ },
+ {
+  "id": 506,
+  "name": "lillipup",
+  "types": [
+   "normal"
+  ],
+  "height": 4,
+  "weight": 41,
+  "stats": {
+   "hp": 45,
+   "attack": 60,
+   "defense": 45,
+   "special-attack": 25,
+   "special-defense": 45,
+   "speed": 55
+  },
+  "flavor": "It faces strong opponents with great courage. But, when at a disadvantage in a fight, this intelligent Pokémon flees."
+ },
+ {
+  "id": 507,
+  "name": "herdier",
+  "types": [
+   "normal"
+  ],
+  "height": 9,
+  "weight": 147,
+  "stats": {
+   "hp": 65,
+   "attack": 80,
+   "defense": 65,
+   "special-attack": 35,
+   "special-defense": 65,
+   "speed": 60
+  },
+  "flavor": "It has black, cape-like fur that is very hard and decreases the amount of damage it receives."
+ },
+ {
+  "id": 508,
+  "name": "stoutland",
+  "types": [
+   "normal"
+  ],
+  "height": 12,
+  "weight": 610,
+  "stats": {
+   "hp": 85,
+   "attack": 110,
+   "defense": 90,
+   "special-attack": 45,
+   "special-defense": 90,
+   "speed": 80
+  },
+  "flavor": "It rescues people stranded by blizzards in the mountains. Its shaggy fur shields it from the cold."
+ },
+ {
+  "id": 509,
+  "name": "purrloin",
+  "types": [
+   "dark"
+  ],
+  "height": 4,
+  "weight": 101,
+  "stats": {
+   "hp": 41,
+   "attack": 50,
+   "defense": 37,
+   "special-attack": 50,
+   "special-defense": 37,
+   "speed": 66
+  },
+  "flavor": "They steal from people for fun, but their victims can’t help but forgive them. Their deceptively cute act is perfect."
+ },
+ {
+  "id": 510,
+  "name": "liepard",
+  "types": [
+   "dark"
+  ],
+  "height": 11,
+  "weight": 375,
+  "stats": {
+   "hp": 64,
+   "attack": 88,
+   "defense": 50,
+   "special-attack": 88,
+   "special-defense": 50,
+   "speed": 106
+  },
+  "flavor": "These Pokémon vanish and appear unexpectedly. Many Trainers are drawn to their beautiful form and fur."
+ },
+ {
+  "id": 511,
+  "name": "pansage",
+  "types": [
+   "grass"
+  ],
+  "height": 6,
+  "weight": 105,
+  "stats": {
+   "hp": 50,
+   "attack": 53,
+   "defense": 48,
+   "special-attack": 53,
+   "special-defense": 48,
+   "speed": 64
+  },
+  "flavor": "This Pokémon dwells deep in the forest. Eating a leaf from its head whisks weariness away as if by magic."
+ },
+ {
+  "id": 512,
+  "name": "simisage",
+  "types": [
+   "grass"
+  ],
+  "height": 11,
+  "weight": 305,
+  "stats": {
+   "hp": 75,
+   "attack": 98,
+   "defense": 63,
+   "special-attack": 98,
+   "special-defense": 63,
+   "speed": 101
+  },
+  "flavor": "Ill tempered, it fights by swinging its barbed tail around wildly. The leaf growing on its head is very bitter."
+ },
+ {
+  "id": 513,
+  "name": "pansear",
+  "types": [
+   "fire"
+  ],
+  "height": 6,
+  "weight": 110,
+  "stats": {
+   "hp": 50,
+   "attack": 53,
+   "defense": 48,
+   "special-attack": 53,
+   "special-defense": 48,
+   "speed": 64
+  },
+  "flavor": "When it is angered, the temperature of its head tuft reaches 600° F. It uses its tuft to roast berries."
+ },
+ {
+  "id": 514,
+  "name": "simisear",
+  "types": [
+   "fire"
+  ],
+  "height": 10,
+  "weight": 280,
+  "stats": {
+   "hp": 75,
+   "attack": 98,
+   "defense": 63,
+   "special-attack": 98,
+   "special-defense": 63,
+   "speed": 101
+  },
+  "flavor": "It loves sweets because they become energy for the fire burning inside its body."
+ },
+ {
+  "id": 515,
+  "name": "panpour",
+  "types": [
+   "water"
+  ],
+  "height": 6,
+  "weight": 135,
+  "stats": {
+   "hp": 50,
+   "attack": 53,
+   "defense": 48,
+   "special-attack": 53,
+   "special-defense": 48,
+   "speed": 64
+  },
+  "flavor": "The water stored inside the tuft on its head is full of nutrients. Plants that receive its water grow large."
+ },
+ {
+  "id": 516,
+  "name": "simipour",
+  "types": [
+   "water"
+  ],
+  "height": 10,
+  "weight": 290,
+  "stats": {
+   "hp": 75,
+   "attack": 98,
+   "defense": 63,
+   "special-attack": 98,
+   "special-defense": 63,
+   "speed": 101
+  },
+  "flavor": "The tuft on its head holds water. When the level runs low, it replenishes the tuft by siphoning up water with its tail."
+ },
+ {
+  "id": 517,
+  "name": "munna",
+  "types": [
+   "psychic"
+  ],
+  "height": 6,
+  "weight": 233,
+  "stats": {
+   "hp": 76,
+   "attack": 25,
+   "defense": 45,
+   "special-attack": 67,
+   "special-defense": 55,
+   "speed": 24
+  },
+  "flavor": "Munna always float in the air. People whose dreams are eaten by them forget what the dreams had been about."
+ },
+ {
+  "id": 518,
+  "name": "musharna",
+  "types": [
+   "psychic"
+  ],
+  "height": 11,
+  "weight": 605,
+  "stats": {
+   "hp": 116,
+   "attack": 55,
+   "defense": 85,
+   "special-attack": 107,
+   "special-defense": 95,
+   "speed": 29
+  },
+  "flavor": "The mist emanating from their foreheads is packed with the dreams of people and Pokémon."
+ },
+ {
+  "id": 519,
+  "name": "pidove",
+  "types": [
+   "normal",
+   "flying"
+  ],
+  "height": 3,
+  "weight": 21,
+  "stats": {
+   "hp": 50,
+   "attack": 55,
+   "defense": 50,
+   "special-attack": 36,
+   "special-defense": 30,
+   "speed": 43
+  },
+  "flavor": "Each follows its Trainer’s orders as best it can, but they sometimes fail to understand complicated commands."
+ },
+ {
+  "id": 520,
+  "name": "tranquill",
+  "types": [
+   "normal",
+   "flying"
+  ],
+  "height": 6,
+  "weight": 150,
+  "stats": {
+   "hp": 62,
+   "attack": 77,
+   "defense": 62,
+   "special-attack": 50,
+   "special-defense": 42,
+   "speed": 65
+  },
+  "flavor": "It can return to its Trainer’s location regardless of the distance separating them."
+ },
+ {
+  "id": 521,
+  "name": "unfezant",
+  "types": [
+   "normal",
+   "flying"
+  ],
+  "height": 12,
+  "weight": 290,
+  "stats": {
+   "hp": 80,
+   "attack": 115,
+   "defense": 80,
+   "special-attack": 65,
+   "special-defense": 55,
+   "speed": 93
+  },
+  "flavor": "Males swing their head plumage to threaten opponents. The females’ flying abilities surpass those of the males."
+ },
+ {
+  "id": 522,
+  "name": "blitzle",
+  "types": [
+   "electric"
+  ],
+  "height": 8,
+  "weight": 298,
+  "stats": {
+   "hp": 45,
+   "attack": 60,
+   "defense": 32,
+   "special-attack": 50,
+   "special-defense": 32,
+   "speed": 76
+  },
+  "flavor": "Its mane shines when it discharges electricity. They use their flashing manes to communicate with one another."
+ },
+ {
+  "id": 523,
+  "name": "zebstrika",
+  "types": [
+   "electric"
+  ],
+  "height": 16,
+  "weight": 795,
+  "stats": {
+   "hp": 75,
+   "attack": 100,
+   "defense": 63,
+   "special-attack": 80,
+   "special-defense": 63,
+   "speed": 116
+  },
+  "flavor": "They have lightning-like movements. When Zebstrika run at full speed, the sound of thunder reverberates."
+ },
+ {
+  "id": 524,
+  "name": "roggenrola",
+  "types": [
+   "rock"
+  ],
+  "height": 4,
+  "weight": 180,
+  "stats": {
+   "hp": 55,
+   "attack": 75,
+   "defense": 85,
+   "special-attack": 25,
+   "special-defense": 25,
+   "speed": 15
+  },
+  "flavor": "Its ear is hexagonal in shape. Compressed underground, its body is as hard as steel."
+ },
+ {
+  "id": 525,
+  "name": "boldore",
+  "types": [
+   "rock"
+  ],
+  "height": 9,
+  "weight": 1020,
+  "stats": {
+   "hp": 70,
+   "attack": 105,
+   "defense": 105,
+   "special-attack": 50,
+   "special-defense": 40,
+   "speed": 20
+  },
+  "flavor": "When it overflows with power, the orange crystal on its body glows. It looks for underground water in caves."
+ },
+ {
+  "id": 526,
+  "name": "gigalith",
+  "types": [
+   "rock"
+  ],
+  "height": 17,
+  "weight": 2600,
+  "stats": {
+   "hp": 85,
+   "attack": 135,
+   "defense": 130,
+   "special-attack": 60,
+   "special-defense": 80,
+   "speed": 25
+  },
+  "flavor": "Compressing the energy from its internal core lets it fire off an attack capable of blowing away a mountain."
+ },
+ {
+  "id": 527,
+  "name": "woobat",
+  "types": [
+   "psychic",
+   "flying"
+  ],
+  "height": 4,
+  "weight": 21,
+  "stats": {
+   "hp": 65,
+   "attack": 45,
+   "defense": 43,
+   "special-attack": 55,
+   "special-defense": 43,
+   "speed": 72
+  },
+  "flavor": "Its habitat is dark forests and caves. It emits ultrasonic waves from its nose to learn about its surroundings."
+ },
+ {
+  "id": 528,
+  "name": "swoobat",
+  "types": [
+   "psychic",
+   "flying"
+  ],
+  "height": 9,
+  "weight": 105,
+  "stats": {
+   "hp": 67,
+   "attack": 57,
+   "defense": 55,
+   "special-attack": 77,
+   "special-defense": 55,
+   "speed": 114
+  },
+  "flavor": "It emits sound waves of various frequencies from its nose, including some powerful enough to destroy rocks."
+ },
+ {
+  "id": 529,
+  "name": "drilbur",
+  "types": [
+   "ground"
+  ],
+  "height": 3,
+  "weight": 85,
+  "stats": {
+   "hp": 60,
+   "attack": 85,
+   "defense": 40,
+   "special-attack": 30,
+   "special-defense": 45,
+   "speed": 68
+  },
+  "flavor": "It can dig through the ground at a speed of 30 mph. It could give a car running aboveground a good race."
+ },
+ {
+  "id": 530,
+  "name": "excadrill",
+  "types": [
+   "ground",
+   "steel"
+  ],
+  "height": 7,
+  "weight": 404,
+  "stats": {
+   "hp": 110,
+   "attack": 135,
+   "defense": 60,
+   "special-attack": 50,
+   "special-defense": 65,
+   "speed": 88
+  },
+  "flavor": "It can help in tunnel construction. Its drill has evolved into steel strong enough to bore through iron plates."
+ },
+ {
+  "id": 531,
+  "name": "audino",
+  "types": [
+   "normal"
+  ],
+  "height": 11,
+  "weight": 310,
+  "stats": {
+   "hp": 103,
+   "attack": 60,
+   "defense": 86,
+   "special-attack": 60,
+   "special-defense": 86,
+   "speed": 50
+  },
+  "flavor": "It touches others with the feelers on its ears, using the sound of their heartbeats to tell how they are feeling."
+ },
+ {
+  "id": 532,
+  "name": "timburr",
+  "types": [
+   "fighting"
+  ],
+  "height": 6,
+  "weight": 125,
+  "stats": {
+   "hp": 75,
+   "attack": 80,
+   "defense": 55,
+   "special-attack": 25,
+   "special-defense": 35,
+   "speed": 35
+  },
+  "flavor": "It fights by swinging a piece of lumber around. It is close to evolving when it can handle the lumber without difficulty."
+ },
+ {
+  "id": 533,
+  "name": "gurdurr",
+  "types": [
+   "fighting"
+  ],
+  "height": 12,
+  "weight": 400,
+  "stats": {
+   "hp": 85,
+   "attack": 105,
+   "defense": 85,
+   "special-attack": 40,
+   "special-defense": 50,
+   "speed": 40
+  },
+  "flavor": "This Pokémon is so muscular and strongly built that even a group of wrestlers could not make it budge an inch."
+ },
+ {
+  "id": 534,
+  "name": "conkeldurr",
+  "types": [
+   "fighting"
+  ],
+  "height": 14,
+  "weight": 870,
+  "stats": {
+   "hp": 105,
+   "attack": 140,
+   "defense": 95,
+   "special-attack": 55,
+   "special-defense": 65,
+   "speed": 45
+  },
+  "flavor": "It is thought that Conkeldurr taught humans how to make concrete more than 2,000 years ago."
+ },
+ {
+  "id": 535,
+  "name": "tympole",
+  "types": [
+   "water"
+  ],
+  "height": 5,
+  "weight": 45,
+  "stats": {
+   "hp": 50,
+   "attack": 50,
+   "defense": 40,
+   "special-attack": 50,
+   "special-defense": 40,
+   "speed": 64
+  },
+  "flavor": "They warn others of danger by vibrating their cheeks to create a high-pitched sound."
+ },
+ {
+  "id": 536,
+  "name": "palpitoad",
+  "types": [
+   "water",
+   "ground"
+  ],
+  "height": 8,
+  "weight": 170,
+  "stats": {
+   "hp": 75,
+   "attack": 65,
+   "defense": 55,
+   "special-attack": 65,
+   "special-defense": 55,
+   "speed": 69
+  },
+  "flavor": "When they vibrate the bumps on their heads, they can make waves in water or earthquake-like vibrations on land."
+ },
+ {
+  "id": 537,
+  "name": "seismitoad",
+  "types": [
+   "water",
+   "ground"
+  ],
+  "height": 15,
+  "weight": 620,
+  "stats": {
+   "hp": 105,
+   "attack": 95,
+   "defense": 75,
+   "special-attack": 85,
+   "special-defense": 75,
+   "speed": 74
+  },
+  "flavor": "They shoot paralyzing liquid from their head bumps. They use vibration to hurt their opponents."
+ },
+ {
+  "id": 538,
+  "name": "throh",
+  "types": [
+   "fighting"
+  ],
+  "height": 13,
+  "weight": 555,
+  "stats": {
+   "hp": 120,
+   "attack": 100,
+   "defense": 85,
+   "special-attack": 30,
+   "special-defense": 85,
+   "speed": 45
+  },
+  "flavor": "When it tightens its belt, it becomes stronger. Wild Throh use vines to weave their own belts."
+ },
+ {
+  "id": 539,
+  "name": "sawk",
+  "types": [
+   "fighting"
+  ],
+  "height": 14,
+  "weight": 510,
+  "stats": {
+   "hp": 75,
+   "attack": 125,
+   "defense": 75,
+   "special-attack": 30,
+   "special-defense": 75,
+   "speed": 85
+  },
+  "flavor": "The sound of Sawk punching boulders and trees can be heard all the way from the mountains where they train."
+ },
+ {
+  "id": 540,
+  "name": "sewaddle",
+  "types": [
+   "bug",
+   "grass"
+  ],
+  "height": 3,
+  "weight": 25,
+  "stats": {
+   "hp": 45,
+   "attack": 53,
+   "defense": 70,
+   "special-attack": 40,
+   "special-defense": 60,
+   "speed": 42
+  },
+  "flavor": "Leavanny dress it in clothes they made for it when it hatched. It hides its head in its hood while it is sleeping."
+ },
+ {
+  "id": 541,
+  "name": "swadloon",
+  "types": [
+   "bug",
+   "grass"
+  ],
+  "height": 5,
+  "weight": 73,
+  "stats": {
+   "hp": 55,
+   "attack": 63,
+   "defense": 90,
+   "special-attack": 50,
+   "special-defense": 80,
+   "speed": 42
+  },
+  "flavor": "Forests where Swadloon live have superb foliage because the nutrients they make from fallen leaves nourish the plant life."
+ },
+ {
+  "id": 542,
+  "name": "leavanny",
+  "types": [
+   "bug",
+   "grass"
+  ],
+  "height": 12,
+  "weight": 205,
+  "stats": {
+   "hp": 75,
+   "attack": 103,
+   "defense": 80,
+   "special-attack": 70,
+   "special-defense": 80,
+   "speed": 92
+  },
+  "flavor": "Upon finding a small Pokémon, it weaves clothing for it from leaves, using the cutters on its arms and sticky silk."
+ },
+ {
+  "id": 543,
+  "name": "venipede",
+  "types": [
+   "bug",
+   "poison"
+  ],
+  "height": 4,
+  "weight": 53,
+  "stats": {
+   "hp": 30,
+   "attack": 45,
+   "defense": 59,
+   "special-attack": 30,
+   "special-defense": 39,
+   "speed": 57
+  },
+  "flavor": "Its bite injects a potent poison, enough to paralyze large bird Pokémon that try to prey on it."
+ },
+ {
+  "id": 544,
+  "name": "whirlipede",
+  "types": [
+   "bug",
+   "poison"
+  ],
+  "height": 12,
+  "weight": 585,
+  "stats": {
+   "hp": 40,
+   "attack": 55,
+   "defense": 99,
+   "special-attack": 40,
+   "special-defense": 79,
+   "speed": 47
+  },
+  "flavor": "Protected by a hard shell, it spins its body like a wheel and crashes furiously into its enemies."
+ },
+ {
+  "id": 545,
+  "name": "scolipede",
+  "types": [
+   "bug",
+   "poison"
+  ],
+  "height": 25,
+  "weight": 2005,
+  "stats": {
+   "hp": 60,
+   "attack": 100,
+   "defense": 89,
+   "special-attack": 55,
+   "special-defense": 69,
+   "speed": 112
+  },
+  "flavor": "With quick movements, it chases down its foes, attacking relentlessly with its horns until it prevails."
+ },
+ {
+  "id": 546,
+  "name": "cottonee",
+  "types": [
+   "grass",
+   "fairy"
+  ],
+  "height": 3,
+  "weight": 6,
+  "stats": {
+   "hp": 40,
+   "attack": 27,
+   "defense": 60,
+   "special-attack": 37,
+   "special-defense": 50,
+   "speed": 66
+  },
+  "flavor": "When attacked, it escapes by shooting cotton from its body. The cotton serves as a decoy to distract the attacker."
+ },
+ {
+  "id": 547,
+  "name": "whimsicott",
+  "types": [
+   "grass",
+   "fairy"
+  ],
+  "height": 7,
+  "weight": 66,
+  "stats": {
+   "hp": 60,
+   "attack": 67,
+   "defense": 85,
+   "special-attack": 77,
+   "special-defense": 75,
+   "speed": 116
+  },
+  "flavor": "Like the wind, it can slip through any gap, no matter how small. It leaves balls of white fluff behind."
+ },
+ {
+  "id": 548,
+  "name": "petilil",
+  "types": [
+   "grass"
+  ],
+  "height": 5,
+  "weight": 66,
+  "stats": {
+   "hp": 45,
+   "attack": 35,
+   "defense": 50,
+   "special-attack": 70,
+   "special-defense": 50,
+   "speed": 30
+  },
+  "flavor": "The leaves on its head are very bitter. Eating one of these leaves is known to refresh a tired body."
+ },
+ {
+  "id": 549,
+  "name": "lilligant",
+  "types": [
+   "grass"
+  ],
+  "height": 11,
+  "weight": 163,
+  "stats": {
+   "hp": 70,
+   "attack": 60,
+   "defense": 75,
+   "special-attack": 110,
+   "special-defense": 75,
+   "speed": 90
+  },
+  "flavor": "Even veteran Trainers face a challenge in getting its beautiful flower to bloom. This Pokémon is popular with celebrities."
+ },
+ {
+  "id": 550,
+  "name": "basculin-red-striped",
+  "types": [
+   "water"
+  ],
+  "height": 10,
+  "weight": 180,
+  "stats": {
+   "hp": 70,
+   "attack": 92,
+   "defense": 65,
+   "special-attack": 80,
+   "special-defense": 55,
+   "speed": 98
+  },
+  "flavor": "Red and blue Basculin get along so poorly, they’ll start fighting instantly. These Pokémon are very hostile."
+ },
+ {
+  "id": 551,
+  "name": "sandile",
+  "types": [
+   "ground",
+   "dark"
+  ],
+  "height": 7,
+  "weight": 152,
+  "stats": {
+   "hp": 50,
+   "attack": 72,
+   "defense": 35,
+   "special-attack": 35,
+   "special-defense": 35,
+   "speed": 65
+  },
+  "flavor": "They live buried in the sands of the desert. The sun-warmed sands prevent their body temperature from dropping."
+ },
+ {
+  "id": 552,
+  "name": "krokorok",
+  "types": [
+   "ground",
+   "dark"
+  ],
+  "height": 10,
+  "weight": 334,
+  "stats": {
+   "hp": 60,
+   "attack": 82,
+   "defense": 45,
+   "special-attack": 45,
+   "special-defense": 45,
+   "speed": 74
+  },
+  "flavor": "They live in groups of a few individuals. Protective membranes shield their eyes from sandstorms."
+ },
+ {
+  "id": 553,
+  "name": "krookodile",
+  "types": [
+   "ground",
+   "dark"
+  ],
+  "height": 15,
+  "weight": 963,
+  "stats": {
+   "hp": 95,
+   "attack": 117,
+   "defense": 80,
+   "special-attack": 65,
+   "special-defense": 70,
+   "speed": 92
+  },
+  "flavor": "They never allow prey to escape. Their jaws are so powerful, they can crush the body of an automobile."
+ },
+ {
+  "id": 554,
+  "name": "darumaka",
+  "types": [
+   "fire"
+  ],
+  "height": 6,
+  "weight": 375,
+  "stats": {
+   "hp": 70,
+   "attack": 90,
+   "defense": 45,
+   "special-attack": 15,
+   "special-defense": 45,
+   "speed": 50
+  },
+  "flavor": "When its internal fire is burning, it cannot calm down and it runs around. When the fire diminishes, it falls asleep."
+ },
+ {
+  "id": 555,
+  "name": "darmanitan-standard",
+  "types": [
+   "fire"
+  ],
+  "height": 13,
+  "weight": 929,
+  "stats": {
+   "hp": 105,
+   "attack": 140,
+   "defense": 55,
+   "special-attack": 30,
+   "special-defense": 55,
+   "speed": 95
+  },
+  "flavor": "Its internal fire burns at 2,500° F, making enough power that it can destroy a dump truck with one punch."
+ },
+ {
+  "id": 556,
+  "name": "maractus",
+  "types": [
+   "grass"
+  ],
+  "height": 10,
+  "weight": 280,
+  "stats": {
+   "hp": 75,
+   "attack": 86,
+   "defense": 67,
+   "special-attack": 106,
+   "special-defense": 67,
+   "speed": 60
+  },
+  "flavor": "It uses an up-tempo song and dance to drive away the bird Pokémon that prey on its flower seeds."
+ },
+ {
+  "id": 557,
+  "name": "dwebble",
+  "types": [
+   "bug",
+   "rock"
+  ],
+  "height": 3,
+  "weight": 145,
+  "stats": {
+   "hp": 50,
+   "attack": 65,
+   "defense": 85,
+   "special-attack": 35,
+   "special-defense": 35,
+   "speed": 55
+  },
+  "flavor": "This Pokémon can easily melt holes in hard rocks with a liquid secreted from its mouth."
+ },
+ {
+  "id": 558,
+  "name": "crustle",
+  "types": [
+   "bug",
+   "rock"
+  ],
+  "height": 14,
+  "weight": 2000,
+  "stats": {
+   "hp": 70,
+   "attack": 105,
+   "defense": 125,
+   "special-attack": 65,
+   "special-defense": 75,
+   "speed": 45
+  },
+  "flavor": "Competing for territory, Crustle fight viciously. The one whose boulder is broken is the loser of the battle."
+ },
+ {
+  "id": 559,
+  "name": "scraggy",
+  "types": [
+   "dark",
+   "fighting"
+  ],
+  "height": 6,
+  "weight": 118,
+  "stats": {
+   "hp": 50,
+   "attack": 75,
+   "defense": 70,
+   "special-attack": 35,
+   "special-defense": 70,
+   "speed": 48
+  },
+  "flavor": "Its skin has a rubbery elasticity, so it can reduce damage by defensively pulling its skin up to its neck."
+ },
+ {
+  "id": 560,
+  "name": "scrafty",
+  "types": [
+   "dark",
+   "fighting"
+  ],
+  "height": 11,
+  "weight": 300,
+  "stats": {
+   "hp": 65,
+   "attack": 90,
+   "defense": 115,
+   "special-attack": 45,
+   "special-defense": 115,
+   "speed": 58
+  },
+  "flavor": "Groups of them beat up anything that enters their territory. Each can spit acidic liquid from its mouth."
+ },
+ {
+  "id": 561,
+  "name": "sigilyph",
+  "types": [
+   "psychic",
+   "flying"
+  ],
+  "height": 14,
+  "weight": 140,
+  "stats": {
+   "hp": 72,
+   "attack": 58,
+   "defense": 80,
+   "special-attack": 103,
+   "special-defense": 80,
+   "speed": 97
+  },
+  "flavor": "They never vary the route they fly, because their memories of guarding an ancient city remain steadfast."
+ },
+ {
+  "id": 562,
+  "name": "yamask",
+  "types": [
+   "ghost"
+  ],
+  "height": 5,
+  "weight": 15,
+  "stats": {
+   "hp": 38,
+   "attack": 30,
+   "defense": 85,
+   "special-attack": 55,
+   "special-defense": 65,
+   "speed": 30
+  },
+  "flavor": "Each of them carries a mask that used to be its face when it was human. Sometimes they look at it and cry."
+ },
+ {
+  "id": 563,
+  "name": "cofagrigus",
+  "types": [
+   "ghost"
+  ],
+  "height": 17,
+  "weight": 765,
+  "stats": {
+   "hp": 58,
+   "attack": 50,
+   "defense": 145,
+   "special-attack": 95,
+   "special-defense": 105,
+   "speed": 30
+  },
+  "flavor": "It has been said that they swallow those who get too close and turn them into mummies. They like to eat gold nuggets."
+ },
+ {
+  "id": 564,
+  "name": "tirtouga",
+  "types": [
+   "water",
+   "rock"
+  ],
+  "height": 7,
+  "weight": 165,
+  "stats": {
+   "hp": 54,
+   "attack": 78,
+   "defense": 103,
+   "special-attack": 53,
+   "special-defense": 45,
+   "speed": 22
+  },
+  "flavor": "Restored from a fossil, this Pokémon can dive to depths beyond half a mile."
+ },
+ {
+  "id": 565,
+  "name": "carracosta",
+  "types": [
+   "water",
+   "rock"
+  ],
+  "height": 12,
+  "weight": 810,
+  "stats": {
+   "hp": 74,
+   "attack": 108,
+   "defense": 133,
+   "special-attack": 83,
+   "special-defense": 65,
+   "speed": 32
+  },
+  "flavor": "They can live both in the ocean and on land. A slap from one of them is enough to open a hole in the bottom of a tanker."
+ },
+ {
+  "id": 566,
+  "name": "archen",
+  "types": [
+   "rock",
+   "flying"
+  ],
+  "height": 5,
+  "weight": 95,
+  "stats": {
+   "hp": 55,
+   "attack": 112,
+   "defense": 45,
+   "special-attack": 74,
+   "special-defense": 45,
+   "speed": 70
+  },
+  "flavor": "Said to be an ancestor of bird Pokémon, they were unable to fly and moved about by hopping from one branch to another."
+ },
+ {
+  "id": 567,
+  "name": "archeops",
+  "types": [
+   "rock",
+   "flying"
+  ],
+  "height": 14,
+  "weight": 320,
+  "stats": {
+   "hp": 75,
+   "attack": 140,
+   "defense": 65,
+   "special-attack": 112,
+   "special-defense": 65,
+   "speed": 110
+  },
+  "flavor": "They are intelligent and will cooperate to catch prey. From the ground, they use a running start to take flight."
+ },
+ {
+  "id": 568,
+  "name": "trubbish",
+  "types": [
+   "poison"
+  ],
+  "height": 6,
+  "weight": 310,
+  "stats": {
+   "hp": 50,
+   "attack": 50,
+   "defense": 62,
+   "special-attack": 40,
+   "special-defense": 62,
+   "speed": 65
+  },
+  "flavor": "Inhaling the gas they belch will make you sleep for a week. They prefer unsanitary places."
+ },
+ {
+  "id": 569,
+  "name": "garbodor",
+  "types": [
+   "poison"
+  ],
+  "height": 19,
+  "weight": 1073,
+  "stats": {
+   "hp": 80,
+   "attack": 95,
+   "defense": 82,
+   "special-attack": 60,
+   "special-defense": 82,
+   "speed": 75
+  },
+  "flavor": "It clenches opponents with its left arm and finishes them off with foul-smelling poison gas belched from its mouth."
+ },
+ {
+  "id": 570,
+  "name": "zorua",
+  "types": [
+   "dark"
+  ],
+  "height": 7,
+  "weight": 125,
+  "stats": {
+   "hp": 40,
+   "attack": 65,
+   "defense": 40,
+   "special-attack": 80,
+   "special-defense": 40,
+   "speed": 65
+  },
+  "flavor": "It changes into the forms of others to surprise them. Apparently, it often transforms into a silent child."
+ },
+ {
+  "id": 571,
+  "name": "zoroark",
+  "types": [
+   "dark"
+  ],
+  "height": 16,
+  "weight": 811,
+  "stats": {
+   "hp": 60,
+   "attack": 105,
+   "defense": 60,
+   "special-attack": 120,
+   "special-defense": 60,
+   "speed": 105
+  },
+  "flavor": "Bonds between these Pokémon are very strong. It protects the safety of its pack by tricking its opponents."
+ },
+ {
+  "id": 572,
+  "name": "minccino",
+  "types": [
+   "normal"
+  ],
+  "height": 4,
+  "weight": 58,
+  "stats": {
+   "hp": 55,
+   "attack": 50,
+   "defense": 40,
+   "special-attack": 40,
+   "special-defense": 40,
+   "speed": 75
+  },
+  "flavor": "They greet one another by rubbing each other with their tails, which are always kept well groomed and clean."
+ },
+ {
+  "id": 573,
+  "name": "cinccino",
+  "types": [
+   "normal"
+  ],
+  "height": 5,
+  "weight": 75,
+  "stats": {
+   "hp": 75,
+   "attack": 95,
+   "defense": 60,
+   "special-attack": 65,
+   "special-defense": 60,
+   "speed": 115
+  },
+  "flavor": "Their white fur is coated in a special oil that makes it easy for them to deflect attacks."
+ },
+ {
+  "id": 574,
+  "name": "gothita",
+  "types": [
+   "psychic"
+  ],
+  "height": 4,
+  "weight": 58,
+  "stats": {
+   "hp": 45,
+   "attack": 30,
+   "defense": 50,
+   "special-attack": 55,
+   "special-defense": 65,
+   "speed": 45
+  },
+  "flavor": "Their ribbonlike feelers increase their psychic power. They are always staring at something."
+ },
+ {
+  "id": 575,
+  "name": "gothorita",
+  "types": [
+   "psychic"
+  ],
+  "height": 7,
+  "weight": 180,
+  "stats": {
+   "hp": 60,
+   "attack": 45,
+   "defense": 70,
+   "special-attack": 75,
+   "special-defense": 85,
+   "speed": 55
+  },
+  "flavor": "They use hypnosis to control people and Pokémon. Tales of Gothorita leading people astray are told in every corner."
+ },
+ {
+  "id": 576,
+  "name": "gothitelle",
+  "types": [
+   "psychic"
+  ],
+  "height": 15,
+  "weight": 440,
+  "stats": {
+   "hp": 70,
+   "attack": 55,
+   "defense": 95,
+   "special-attack": 95,
+   "special-defense": 110,
+   "speed": 65
+  },
+  "flavor": "Starry skies thousands of light-years away are visible in the space distorted by their intense psychic power."
+ },
+ {
+  "id": 577,
+  "name": "solosis",
+  "types": [
+   "psychic"
+  ],
+  "height": 3,
+  "weight": 10,
+  "stats": {
+   "hp": 45,
+   "attack": 30,
+   "defense": 40,
+   "special-attack": 105,
+   "special-defense": 50,
+   "speed": 20
+  },
+  "flavor": "They drive away attackers by unleashing psychic power. They can use telepathy to talk with others."
+ },
+ {
+  "id": 578,
+  "name": "duosion",
+  "types": [
+   "psychic"
+  ],
+  "height": 6,
+  "weight": 80,
+  "stats": {
+   "hp": 65,
+   "attack": 40,
+   "defense": 50,
+   "special-attack": 125,
+   "special-defense": 60,
+   "speed": 30
+  },
+  "flavor": "Since they have two divided brains, at times they suddenly try to take two different actions at once."
+ },
+ {
+  "id": 579,
+  "name": "reuniclus",
+  "types": [
+   "psychic"
+  ],
+  "height": 10,
+  "weight": 201,
+  "stats": {
+   "hp": 110,
+   "attack": 65,
+   "defense": 75,
+   "special-attack": 125,
+   "special-defense": 85,
+   "speed": 30
+  },
+  "flavor": "They use psychic power to control their arms, which are made of a special liquid. They can crush boulders psychically."
+ },
+ {
+  "id": 580,
+  "name": "ducklett",
+  "types": [
+   "water",
+   "flying"
+  ],
+  "height": 5,
+  "weight": 55,
+  "stats": {
+   "hp": 62,
+   "attack": 44,
+   "defense": 50,
+   "special-attack": 44,
+   "special-defense": 50,
+   "speed": 55
+  },
+  "flavor": "These bird Pokémon are excellent divers. They swim around in the water eating their favorite food--peat moss."
+ },
+ {
+  "id": 581,
+  "name": "swanna",
+  "types": [
+   "water",
+   "flying"
+  ],
+  "height": 13,
+  "weight": 242,
+  "stats": {
+   "hp": 75,
+   "attack": 87,
+   "defense": 63,
+   "special-attack": 87,
+   "special-defense": 63,
+   "speed": 98
+  },
+  "flavor": "Swanna start to dance at dusk. The one dancing in the middle is the leader of the flock."
+ },
+ {
+  "id": 582,
+  "name": "vanillite",
+  "types": [
+   "ice"
+  ],
+  "height": 4,
+  "weight": 57,
+  "stats": {
+   "hp": 36,
+   "attack": 50,
+   "defense": 50,
+   "special-attack": 65,
+   "special-defense": 60,
+   "speed": 44
+  },
+  "flavor": "The temperature of their breath is -58° F. They create snow crystals and make snow fall in the areas around them."
+ },
+ {
+  "id": 583,
+  "name": "vanillish",
+  "types": [
+   "ice"
+  ],
+  "height": 11,
+  "weight": 410,
+  "stats": {
+   "hp": 51,
+   "attack": 65,
+   "defense": 65,
+   "special-attack": 80,
+   "special-defense": 75,
+   "speed": 59
+  },
+  "flavor": "Snowy mountains are this Pokémon’s habitat. During an ancient ice age, they moved to southern areas."
+ },
+ {
+  "id": 584,
+  "name": "vanilluxe",
+  "types": [
+   "ice"
+  ],
+  "height": 13,
+  "weight": 575,
+  "stats": {
+   "hp": 71,
+   "attack": 95,
+   "defense": 85,
+   "special-attack": 110,
+   "special-defense": 95,
+   "speed": 79
+  },
+  "flavor": "Swallowing large amounts of water, they make snow clouds inside their bodies and attack their foes with violent blizzards."
+ },
+ {
+  "id": 585,
+  "name": "deerling",
+  "types": [
+   "normal",
+   "grass"
+  ],
+  "height": 6,
+  "weight": 195,
+  "stats": {
+   "hp": 60,
+   "attack": 60,
+   "defense": 50,
+   "special-attack": 40,
+   "special-defense": 50,
+   "speed": 75
+  },
+  "flavor": "The color and scent of their fur changes to match the mountain grass. When they sense hostility, they hide in the grass."
+ },
+ {
+  "id": 586,
+  "name": "sawsbuck",
+  "types": [
+   "normal",
+   "grass"
+  ],
+  "height": 19,
+  "weight": 925,
+  "stats": {
+   "hp": 80,
+   "attack": 100,
+   "defense": 70,
+   "special-attack": 60,
+   "special-defense": 70,
+   "speed": 95
+  },
+  "flavor": "They migrate according to the seasons. People can tell the season by looking at Sawsbuck’s horns."
+ },
+ {
+  "id": 587,
+  "name": "emolga",
+  "types": [
+   "electric",
+   "flying"
+  ],
+  "height": 4,
+  "weight": 50,
+  "stats": {
+   "hp": 55,
+   "attack": 75,
+   "defense": 60,
+   "special-attack": 75,
+   "special-defense": 60,
+   "speed": 103
+  },
+  "flavor": "The energy made in its cheeks’ electric pouches is stored inside its membrane and released while it is gliding."
+ },
+ {
+  "id": 588,
+  "name": "karrablast",
+  "types": [
+   "bug"
+  ],
+  "height": 5,
+  "weight": 59,
+  "stats": {
+   "hp": 50,
+   "attack": 75,
+   "defense": 45,
+   "special-attack": 40,
+   "special-defense": 45,
+   "speed": 60
+  },
+  "flavor": "These mysterious Pokémon evolve when they receive electrical stimulation while they are in the same place as Shelmet."
+ },
+ {
+  "id": 589,
+  "name": "escavalier",
+  "types": [
+   "bug",
+   "steel"
+  ],
+  "height": 10,
+  "weight": 330,
+  "stats": {
+   "hp": 70,
+   "attack": 135,
+   "defense": 105,
+   "special-attack": 60,
+   "special-defense": 105,
+   "speed": 20
+  },
+  "flavor": "They fly around at high speed, striking with their pointed spears. Even when in trouble, they face opponents bravely."
+ },
+ {
+  "id": 590,
+  "name": "foongus",
+  "types": [
+   "grass",
+   "poison"
+  ],
+  "height": 2,
+  "weight": 10,
+  "stats": {
+   "hp": 69,
+   "attack": 55,
+   "defense": 45,
+   "special-attack": 55,
+   "special-defense": 55,
+   "speed": 15
+  },
+  "flavor": "It lures people in with its Poké Ball pattern, then releases poison spores. Why it resembles a Poké Ball is unknown."
+ },
+ {
+  "id": 591,
+  "name": "amoonguss",
+  "types": [
+   "grass",
+   "poison"
+  ],
+  "height": 6,
+  "weight": 105,
+  "stats": {
+   "hp": 114,
+   "attack": 85,
+   "defense": 70,
+   "special-attack": 85,
+   "special-defense": 80,
+   "speed": 30
+  },
+  "flavor": "It lures prey close by dancing and waving its arm caps, which resemble Poké Balls, in a swaying motion."
+ },
+ {
+  "id": 592,
+  "name": "frillish-male",
+  "types": [
+   "water",
+   "ghost"
+  ],
+  "height": 12,
+  "weight": 330,
+  "stats": {
+   "hp": 55,
+   "attack": 40,
+   "defense": 50,
+   "special-attack": 65,
+   "special-defense": 85,
+   "speed": 40
+  },
+  "flavor": "With its thin, veil-like arms wrapped around the body of its opponent, it sinks to the ocean floor."
+ },
+ {
+  "id": 593,
+  "name": "jellicent-male",
+  "types": [
+   "water",
+   "ghost"
+  ],
+  "height": 22,
+  "weight": 1350,
+  "stats": {
+   "hp": 100,
+   "attack": 60,
+   "defense": 70,
+   "special-attack": 85,
+   "special-defense": 105,
+   "speed": 60
+  },
+  "flavor": "The fate of the ships and crew that wander into Jellicent’s habitat: all sunken, all lost, all vanished."
+ },
+ {
+  "id": 594,
+  "name": "alomomola",
+  "types": [
+   "water"
+  ],
+  "height": 12,
+  "weight": 316,
+  "stats": {
+   "hp": 165,
+   "attack": 75,
+   "defense": 80,
+   "special-attack": 40,
+   "special-defense": 45,
+   "speed": 65
+  },
+  "flavor": "The special membrane enveloping Alomomola has the ability to heal wounds."
+ },
+ {
+  "id": 595,
+  "name": "joltik",
+  "types": [
+   "bug",
+   "electric"
+  ],
+  "height": 1,
+  "weight": 6,
+  "stats": {
+   "hp": 50,
+   "attack": 47,
+   "defense": 50,
+   "special-attack": 57,
+   "special-defense": 50,
+   "speed": 65
+  },
+  "flavor": "Joltik that live in cities have learned a technique for sucking electricity from the outlets in houses."
+ },
+ {
+  "id": 596,
+  "name": "galvantula",
+  "types": [
+   "bug",
+   "electric"
+  ],
+  "height": 8,
+  "weight": 143,
+  "stats": {
+   "hp": 70,
+   "attack": 77,
+   "defense": 60,
+   "special-attack": 97,
+   "special-defense": 60,
+   "speed": 108
+  },
+  "flavor": "When attacked, they create an electric barrier by spitting out many electrically charged threads."
+ },
+ {
+  "id": 597,
+  "name": "ferroseed",
+  "types": [
+   "grass",
+   "steel"
+  ],
+  "height": 6,
+  "weight": 188,
+  "stats": {
+   "hp": 44,
+   "attack": 50,
+   "defense": 91,
+   "special-attack": 24,
+   "special-defense": 86,
+   "speed": 10
+  },
+  "flavor": "When threatened, it attacks by shooting a barrage of spikes, which gives it a chance to escape by rolling away."
+ },
+ {
+  "id": 598,
+  "name": "ferrothorn",
+  "types": [
+   "grass",
+   "steel"
+  ],
+  "height": 10,
+  "weight": 1100,
+  "stats": {
+   "hp": 74,
+   "attack": 94,
+   "defense": 131,
+   "special-attack": 54,
+   "special-defense": 116,
+   "speed": 20
+  },
+  "flavor": "It fights by swinging around its three spiky feelers. A hit from these steel spikes can reduce a boulder to rubble."
+ },
+ {
+  "id": 599,
+  "name": "klink",
+  "types": [
+   "steel"
+  ],
+  "height": 3,
+  "weight": 210,
+  "stats": {
+   "hp": 40,
+   "attack": 55,
+   "defense": 70,
+   "special-attack": 45,
+   "special-defense": 60,
+   "speed": 30
+  },
+  "flavor": "The two minigears that mesh together are predetermined. Each will rebound from other minigears without meshing."
+ },
+ {
+  "id": 600,
+  "name": "klang",
+  "types": [
+   "steel"
+  ],
+  "height": 6,
+  "weight": 510,
+  "stats": {
+   "hp": 60,
+   "attack": 80,
+   "defense": 95,
+   "special-attack": 70,
+   "special-defense": 85,
+   "speed": 50
+  },
+  "flavor": "By changing the direction in which it rotates, it communicates its feelings to others. When angry, it rotates faster."
+ },
+ {
+  "id": 601,
+  "name": "klinklang",
+  "types": [
+   "steel"
+  ],
+  "height": 6,
+  "weight": 810,
+  "stats": {
+   "hp": 60,
+   "attack": 100,
+   "defense": 115,
+   "special-attack": 70,
+   "special-defense": 85,
+   "speed": 90
+  },
+  "flavor": "Its red core functions as an energy tank. It fires the charged energy through its spikes into an area."
+ },
+ {
+  "id": 602,
+  "name": "tynamo",
+  "types": [
+   "electric"
+  ],
+  "height": 2,
+  "weight": 3,
+  "stats": {
+   "hp": 35,
+   "attack": 55,
+   "defense": 40,
+   "special-attack": 45,
+   "special-defense": 40,
+   "speed": 60
+  },
+  "flavor": "While one alone doesn’t have much power, a chain of many Tynamo can be as powerful as lightning."
+ },
+ {
+  "id": 603,
+  "name": "eelektrik",
+  "types": [
+   "electric"
+  ],
+  "height": 12,
+  "weight": 220,
+  "stats": {
+   "hp": 65,
+   "attack": 85,
+   "defense": 70,
+   "special-attack": 75,
+   "special-defense": 70,
+   "speed": 40
+  },
+  "flavor": "They coil around foes and shock them with electricity-generating organs that seem simply to be circular patterns."
+ },
+ {
+  "id": 604,
+  "name": "eelektross",
+  "types": [
+   "electric"
+  ],
+  "height": 21,
+  "weight": 805,
+  "stats": {
+   "hp": 85,
+   "attack": 115,
+   "defense": 80,
+   "special-attack": 105,
+   "special-defense": 80,
+   "speed": 50
+  },
+  "flavor": "They crawl out of the ocean using their arms. They will attack prey on shore and immediately drag it into the ocean."
+ },
+ {
+  "id": 605,
+  "name": "elgyem",
+  "types": [
+   "psychic"
+  ],
+  "height": 5,
+  "weight": 90,
+  "stats": {
+   "hp": 55,
+   "attack": 55,
+   "defense": 55,
+   "special-attack": 85,
+   "special-defense": 55,
+   "speed": 30
+  },
+  "flavor": "It uses its strong psychic power to squeeze its opponent’s brain, causing unendurable headaches."
+ },
+ {
+  "id": 606,
+  "name": "beheeyem",
+  "types": [
+   "psychic"
+  ],
+  "height": 10,
+  "weight": 345,
+  "stats": {
+   "hp": 75,
+   "attack": 75,
+   "defense": 75,
+   "special-attack": 125,
+   "special-defense": 95,
+   "speed": 40
+  },
+  "flavor": "It can manipulate an opponent’s memory. Apparently, it communicates by flashing its three different-colored fingers."
+ },
+ {
+  "id": 607,
+  "name": "litwick",
+  "types": [
+   "ghost",
+   "fire"
+  ],
+  "height": 3,
+  "weight": 31,
+  "stats": {
+   "hp": 50,
+   "attack": 30,
+   "defense": 55,
+   "special-attack": 65,
+   "special-defense": 55,
+   "speed": 20
+  },
+  "flavor": "Litwick shines a light that absorbs the life energy of people and Pokémon, which becomes the fuel that it burns."
+ },
+ {
+  "id": 608,
+  "name": "lampent",
+  "types": [
+   "ghost",
+   "fire"
+  ],
+  "height": 6,
+  "weight": 130,
+  "stats": {
+   "hp": 60,
+   "attack": 40,
+   "defense": 60,
+   "special-attack": 95,
+   "special-defense": 60,
+   "speed": 55
+  },
+  "flavor": "This ominous Pokémon is feared. Through cities it wanders, searching for the spirits of the fallen."
+ },
+ {
+  "id": 609,
+  "name": "chandelure",
+  "types": [
+   "ghost",
+   "fire"
+  ],
+  "height": 10,
+  "weight": 343,
+  "stats": {
+   "hp": 60,
+   "attack": 55,
+   "defense": 90,
+   "special-attack": 145,
+   "special-defense": 90,
+   "speed": 80
+  },
+  "flavor": "It absorbs a spirit, which it then burns. By waving the flames on its arms, it puts its foes into a hypnotic trance."
+ },
+ {
+  "id": 610,
+  "name": "axew",
+  "types": [
+   "dragon"
+  ],
+  "height": 6,
+  "weight": 180,
+  "stats": {
+   "hp": 46,
+   "attack": 87,
+   "defense": 60,
+   "special-attack": 30,
+   "special-defense": 40,
+   "speed": 57
+  },
+  "flavor": "They use their tusks to crush the berries they eat. Repeated regrowth makes their tusks strong and sharp."
+ },
+ {
+  "id": 611,
+  "name": "fraxure",
+  "types": [
+   "dragon"
+  ],
+  "height": 10,
+  "weight": 360,
+  "stats": {
+   "hp": 66,
+   "attack": 117,
+   "defense": 70,
+   "special-attack": 40,
+   "special-defense": 50,
+   "speed": 67
+  },
+  "flavor": "Since a broken tusk will not grow back, they diligently sharpen their tusks on river rocks after they’ve been fighting."
+ },
+ {
+  "id": 612,
+  "name": "haxorus",
+  "types": [
+   "dragon"
+  ],
+  "height": 18,
+  "weight": 1055,
+  "stats": {
+   "hp": 76,
+   "attack": 147,
+   "defense": 90,
+   "special-attack": 60,
+   "special-defense": 70,
+   "speed": 97
+  },
+  "flavor": "They are kind but can be relentless when defending territory. They challenge foes with tusks that can cut steel."
+ },
+ {
+  "id": 613,
+  "name": "cubchoo",
+  "types": [
+   "ice"
+  ],
+  "height": 5,
+  "weight": 85,
+  "stats": {
+   "hp": 55,
+   "attack": 70,
+   "defense": 40,
+   "special-attack": 60,
+   "special-defense": 40,
+   "speed": 40
+  },
+  "flavor": "When it is not feeling well, its mucus gets watery and the power of its Ice-type moves decreases."
+ },
+ {
+  "id": 614,
+  "name": "beartic",
+  "types": [
+   "ice"
+  ],
+  "height": 26,
+  "weight": 2600,
+  "stats": {
+   "hp": 95,
+   "attack": 130,
+   "defense": 80,
+   "special-attack": 70,
+   "special-defense": 80,
+   "speed": 50
+  },
+  "flavor": "It can make its breath freeze at will. Very able in the water, it swims around in northern seas and catches prey."
+ },
+ {
+  "id": 615,
+  "name": "cryogonal",
+  "types": [
+   "ice"
+  ],
+  "height": 11,
+  "weight": 1480,
+  "stats": {
+   "hp": 80,
+   "attack": 50,
+   "defense": 50,
+   "special-attack": 95,
+   "special-defense": 135,
+   "speed": 105
+  },
+  "flavor": "When its body temperature goes up, it turns into steam and vanishes. When its temperature lowers, it returns to ice."
+ },
+ {
+  "id": 616,
+  "name": "shelmet",
+  "types": [
+   "bug"
+  ],
+  "height": 4,
+  "weight": 77,
+  "stats": {
+   "hp": 50,
+   "attack": 40,
+   "defense": 85,
+   "special-attack": 40,
+   "special-defense": 65,
+   "speed": 25
+  },
+  "flavor": "When attacked, it defends itself by closing the lid of its shell. It can spit a sticky, poisonous liquid."
+ },
+ {
+  "id": 617,
+  "name": "accelgor",
+  "types": [
+   "bug"
+  ],
+  "height": 8,
+  "weight": 253,
+  "stats": {
+   "hp": 80,
+   "attack": 70,
+   "defense": 40,
+   "special-attack": 100,
+   "special-defense": 60,
+   "speed": 145
+  },
+  "flavor": "When its body dries out, it weakens. So, to prevent dehydration, it wraps itself in many layers of thin membrane."
+ },
+ {
+  "id": 618,
+  "name": "stunfisk",
+  "types": [
+   "ground",
+   "electric"
+  ],
+  "height": 7,
+  "weight": 110,
+  "stats": {
+   "hp": 109,
+   "attack": 66,
+   "defense": 84,
+   "special-attack": 81,
+   "special-defense": 99,
+   "speed": 32
+  },
+  "flavor": "Its skin is very hard, so it is unhurt even if stepped on by sumo wrestlers. It smiles when transmitting electricity."
+ },
+ {
+  "id": 619,
+  "name": "mienfoo",
+  "types": [
+   "fighting"
+  ],
+  "height": 9,
+  "weight": 200,
+  "stats": {
+   "hp": 45,
+   "attack": 85,
+   "defense": 50,
+   "special-attack": 55,
+   "special-defense": 50,
+   "speed": 65
+  },
+  "flavor": "In fights, they dominate with onslaughts of flowing, continuous attacks. With their sharp claws, they cut enemies."
+ },
+ {
+  "id": 620,
+  "name": "mienshao",
+  "types": [
+   "fighting"
+  ],
+  "height": 14,
+  "weight": 355,
+  "stats": {
+   "hp": 65,
+   "attack": 125,
+   "defense": 60,
+   "special-attack": 95,
+   "special-defense": 60,
+   "speed": 105
+  },
+  "flavor": "It wields the fur on its arms like a whip. Its arm attacks come with such rapidity that they cannot even be seen."
+ },
+ {
+  "id": 621,
+  "name": "druddigon",
+  "types": [
+   "dragon"
+  ],
+  "height": 16,
+  "weight": 1390,
+  "stats": {
+   "hp": 77,
+   "attack": 120,
+   "defense": 90,
+   "special-attack": 60,
+   "special-defense": 90,
+   "speed": 48
+  },
+  "flavor": "It warms its body by absorbing sunlight with its wings. When its body temperature falls, it can no longer move."
+ },
+ {
+  "id": 622,
+  "name": "golett",
+  "types": [
+   "ground",
+   "ghost"
+  ],
+  "height": 10,
+  "weight": 920,
+  "stats": {
+   "hp": 59,
+   "attack": 74,
+   "defense": 50,
+   "special-attack": 35,
+   "special-defense": 50,
+   "speed": 35
+  },
+  "flavor": "The energy that burns inside it enables it to move, but no one has yet been able to identify this energy."
+ },
+ {
+  "id": 623,
+  "name": "golurk",
+  "types": [
+   "ground",
+   "ghost"
+  ],
+  "height": 28,
+  "weight": 3300,
+  "stats": {
+   "hp": 89,
+   "attack": 124,
+   "defense": 80,
+   "special-attack": 55,
+   "special-defense": 80,
+   "speed": 55
+  },
+  "flavor": "It flies across the sky at Mach speeds. Removing the seal on its chest makes its internal energy go out of control."
+ },
+ {
+  "id": 624,
+  "name": "pawniard",
+  "types": [
+   "dark",
+   "steel"
+  ],
+  "height": 5,
+  "weight": 102,
+  "stats": {
+   "hp": 45,
+   "attack": 85,
+   "defense": 70,
+   "special-attack": 40,
+   "special-defense": 40,
+   "speed": 60
+  },
+  "flavor": "Blades comprise this Pokémon’s entire body. If battling dulls the blades, it sharpens them on stones by the river."
+ },
+ {
+  "id": 625,
+  "name": "bisharp",
+  "types": [
+   "dark",
+   "steel"
+  ],
+  "height": 16,
+  "weight": 700,
+  "stats": {
+   "hp": 65,
+   "attack": 125,
+   "defense": 100,
+   "special-attack": 60,
+   "special-defense": 70,
+   "speed": 70
+  },
+  "flavor": "It leads a group of Pawniard. It battles to become the boss, but will be driven from the group if it loses."
+ },
+ {
+  "id": 626,
+  "name": "bouffalant",
+  "types": [
+   "normal"
+  ],
+  "height": 16,
+  "weight": 946,
+  "stats": {
+   "hp": 95,
+   "attack": 110,
+   "defense": 95,
+   "special-attack": 40,
+   "special-defense": 95,
+   "speed": 55
+  },
+  "flavor": "Their fluffy fur absorbs damage, even if they strike foes with a fierce headbutt."
+ },
+ {
+  "id": 627,
+  "name": "rufflet",
+  "types": [
+   "normal",
+   "flying"
+  ],
+  "height": 5,
+  "weight": 105,
+  "stats": {
+   "hp": 70,
+   "attack": 83,
+   "defense": 50,
+   "special-attack": 37,
+   "special-defense": 50,
+   "speed": 60
+  },
+  "flavor": "They crush berries with their talons. They bravely stand up to any opponent, no matter how strong it is."
+ },
+ {
+  "id": 628,
+  "name": "braviary",
+  "types": [
+   "normal",
+   "flying"
+  ],
+  "height": 15,
+  "weight": 410,
+  "stats": {
+   "hp": 100,
+   "attack": 123,
+   "defense": 75,
+   "special-attack": 57,
+   "special-defense": 75,
+   "speed": 80
+  },
+  "flavor": "They fight for their friends without any thought about danger to themselves. One can carry a car while flying."
+ },
+ {
+  "id": 629,
+  "name": "vullaby",
+  "types": [
+   "dark",
+   "flying"
+  ],
+  "height": 5,
+  "weight": 90,
+  "stats": {
+   "hp": 70,
+   "attack": 55,
+   "defense": 75,
+   "special-attack": 45,
+   "special-defense": 65,
+   "speed": 60
+  },
+  "flavor": "Its wings are too tiny to allow it to fly. As the time approaches for it to evolve, it discards the bones it was wearing."
+ },
+ {
+  "id": 630,
+  "name": "mandibuzz",
+  "types": [
+   "dark",
+   "flying"
+  ],
+  "height": 12,
+  "weight": 395,
+  "stats": {
+   "hp": 110,
+   "attack": 65,
+   "defense": 105,
+   "special-attack": 55,
+   "special-defense": 95,
+   "speed": 80
+  },
+  "flavor": "It makes a nest out of bones it finds. It grabs weakened prey in its talons and hauls it to its nest of bones."
+ },
+ {
+  "id": 631,
+  "name": "heatmor",
+  "types": [
+   "fire"
+  ],
+  "height": 14,
+  "weight": 580,
+  "stats": {
+   "hp": 85,
+   "attack": 97,
+   "defense": 66,
+   "special-attack": 105,
+   "special-defense": 66,
+   "speed": 65
+  },
+  "flavor": "It breathes through a hole in its tail while it burns with an internal fire. Durant is its prey."
+ },
+ {
+  "id": 632,
+  "name": "durant",
+  "types": [
+   "bug",
+   "steel"
+  ],
+  "height": 3,
+  "weight": 330,
+  "stats": {
+   "hp": 58,
+   "attack": 109,
+   "defense": 112,
+   "special-attack": 48,
+   "special-defense": 48,
+   "speed": 109
+  },
+  "flavor": "They attack in groups, covering themselves in steel armor to protect themselves from Heatmor."
+ },
+ {
+  "id": 633,
+  "name": "deino",
+  "types": [
+   "dark",
+   "dragon"
+  ],
+  "height": 8,
+  "weight": 173,
+  "stats": {
+   "hp": 52,
+   "attack": 65,
+   "defense": 50,
+   "special-attack": 45,
+   "special-defense": 50,
+   "speed": 38
+  },
+  "flavor": "It tends to bite everything, and it is not a picky eater. Approaching it carelessly is dangerous."
+ },
+ {
+  "id": 634,
+  "name": "zweilous",
+  "types": [
+   "dark",
+   "dragon"
+  ],
+  "height": 14,
+  "weight": 500,
+  "stats": {
+   "hp": 72,
+   "attack": 85,
+   "defense": 70,
+   "special-attack": 65,
+   "special-defense": 70,
+   "speed": 58
+  },
+  "flavor": "After it has eaten up all the food in its territory, it moves to another area. Its two heads do not get along."
+ },
+ {
+  "id": 635,
+  "name": "hydreigon",
+  "types": [
+   "dark",
+   "dragon"
+  ],
+  "height": 18,
+  "weight": 1600,
+  "stats": {
+   "hp": 92,
+   "attack": 105,
+   "defense": 90,
+   "special-attack": 125,
+   "special-defense": 90,
+   "speed": 98
+  },
+  "flavor": "This brutal Pokémon travels the skies on its six wings. Anything that moves seems like a foe to it, triggering its attack."
+ },
+ {
+  "id": 636,
+  "name": "larvesta",
+  "types": [
+   "bug",
+   "fire"
+  ],
+  "height": 11,
+  "weight": 288,
+  "stats": {
+   "hp": 55,
+   "attack": 85,
+   "defense": 55,
+   "special-attack": 50,
+   "special-defense": 55,
+   "speed": 60
+  },
+  "flavor": "This Pokémon was believed to have been born from the sun. When it evolves, its entire body is engulfed in flames."
+ },
+ {
+  "id": 637,
+  "name": "volcarona",
+  "types": [
+   "bug",
+   "fire"
+  ],
+  "height": 16,
+  "weight": 460,
+  "stats": {
+   "hp": 85,
+   "attack": 60,
+   "defense": 65,
+   "special-attack": 135,
+   "special-defense": 105,
+   "speed": 100
+  },
+  "flavor": "When volcanic ash darkened the atmosphere, it is said that Volcarona’s fire provided a replacement for the sun."
+ },
+ {
+  "id": 638,
+  "name": "cobalion",
+  "types": [
+   "steel",
+   "fighting"
+  ],
+  "height": 21,
+  "weight": 2500,
+  "stats": {
+   "hp": 91,
+   "attack": 90,
+   "defense": 129,
+   "special-attack": 90,
+   "special-defense": 72,
+   "speed": 108
+  },
+  "flavor": "This legendary Pokémon battled against humans to protect Pokémon. Its personality is calm and composed."
+ },
+ {
+  "id": 639,
+  "name": "terrakion",
+  "types": [
+   "rock",
+   "fighting"
+  ],
+  "height": 19,
+  "weight": 2600,
+  "stats": {
+   "hp": 91,
+   "attack": 129,
+   "defense": 90,
+   "special-attack": 72,
+   "special-defense": 90,
+   "speed": 108
+  },
+  "flavor": "This Pokémon came to the defense of Pokémon that had lost their homes in a war among humans."
+ },
+ {
+  "id": 640,
+  "name": "virizion",
+  "types": [
+   "grass",
+   "fighting"
+  ],
+  "height": 20,
+  "weight": 2000,
+  "stats": {
+   "hp": 91,
+   "attack": 90,
+   "defense": 72,
+   "special-attack": 90,
+   "special-defense": 129,
+   "speed": 108
+  },
+  "flavor": "This Pokémon fought humans in order to protect its friends. Legends about it continue to be passed down."
+ },
+ {
+  "id": 641,
+  "name": "tornadus-incarnate",
+  "types": [
+   "flying"
+  ],
+  "height": 15,
+  "weight": 630,
+  "stats": {
+   "hp": 79,
+   "attack": 115,
+   "defense": 70,
+   "special-attack": 125,
+   "special-defense": 80,
+   "speed": 111
+  },
+  "flavor": "The lower half of its body is wrapped in a cloud of energy. It zooms through the sky at 200 mph."
+ },
+ {
+  "id": 642,
+  "name": "thundurus-incarnate",
+  "types": [
+   "electric",
+   "flying"
+  ],
+  "height": 15,
+  "weight": 610,
+  "stats": {
+   "hp": 79,
+   "attack": 115,
+   "defense": 70,
+   "special-attack": 125,
+   "special-defense": 80,
+   "speed": 111
+  },
+  "flavor": "Countless charred remains mar the landscape of places through which Thundurus has passed."
+ },
+ {
+  "id": 643,
+  "name": "reshiram",
+  "types": [
+   "dragon",
+   "fire"
+  ],
+  "height": 32,
+  "weight": 3300,
+  "stats": {
+   "hp": 100,
+   "attack": 120,
+   "defense": 100,
+   "special-attack": 150,
+   "special-defense": 120,
+   "speed": 90
+  },
+  "flavor": "This Pokémon appears in legends. It sends flames into the air from its tail, burning up everything around it."
+ },
+ {
+  "id": 644,
+  "name": "zekrom",
+  "types": [
+   "dragon",
+   "electric"
+  ],
+  "height": 29,
+  "weight": 3450,
+  "stats": {
+   "hp": 100,
+   "attack": 150,
+   "defense": 120,
+   "special-attack": 120,
+   "special-defense": 100,
+   "speed": 90
+  },
+  "flavor": "Concealing itself in lightning clouds, it flies throughout the Unova region. It creates electricity in its tail."
+ },
+ {
+  "id": 645,
+  "name": "landorus-incarnate",
+  "types": [
+   "ground",
+   "flying"
+  ],
+  "height": 15,
+  "weight": 680,
+  "stats": {
+   "hp": 89,
+   "attack": 125,
+   "defense": 90,
+   "special-attack": 115,
+   "special-defense": 80,
+   "speed": 101
+  },
+  "flavor": "Lands visited by Landorus grant such bountiful crops that it has been hailed as “The Guardian of the Fields.”"
+ },
+ {
+  "id": 646,
+  "name": "kyurem",
+  "types": [
+   "dragon",
+   "ice"
+  ],
+  "height": 30,
+  "weight": 3250,
+  "stats": {
+   "hp": 125,
+   "attack": 130,
+   "defense": 90,
+   "special-attack": 130,
+   "special-defense": 90,
+   "speed": 95
+  },
+  "flavor": "It generates a powerful, freezing energy inside itself, but its body became frozen when the energy leaked out."
+ },
+ {
+  "id": 647,
+  "name": "keldeo-ordinary",
+  "types": [
+   "water",
+   "fighting"
+  ],
+  "height": 14,
+  "weight": 485,
+  "stats": {
+   "hp": 91,
+   "attack": 72,
+   "defense": 90,
+   "special-attack": 129,
+   "special-defense": 90,
+   "speed": 108
+  },
+  "flavor": "By blasting water from its hooves, it can glide across water. It excels at using leg moves while battling."
+ },
+ {
+  "id": 648,
+  "name": "meloetta-aria",
+  "types": [
+   "normal",
+   "psychic"
+  ],
+  "height": 6,
+  "weight": 65,
+  "stats": {
+   "hp": 100,
+   "attack": 77,
+   "defense": 77,
+   "special-attack": 128,
+   "special-defense": 128,
+   "speed": 90
+  },
+  "flavor": "Its melodies are sung with a special vocalization method that can control the feelings of those who hear it."
+ },
+ {
+  "id": 649,
+  "name": "genesect",
+  "types": [
+   "bug",
+   "steel"
+  ],
+  "height": 15,
+  "weight": 825,
+  "stats": {
+   "hp": 71,
+   "attack": 120,
+   "defense": 95,
+   "special-attack": 120,
+   "special-defense": 95,
+   "speed": 99
+  },
+  "flavor": "Over 300 million years ago, it was feared as the strongest of hunters. It has been modified by Team Plasma."
+ },
+ {
+  "id": 650,
+  "name": "chespin",
+  "types": [
+   "grass"
+  ],
+  "height": 4,
+  "weight": 90,
+  "stats": {
+   "hp": 56,
+   "attack": 61,
+   "defense": 65,
+   "special-attack": 48,
+   "special-defense": 45,
+   "speed": 38
+  },
+  "flavor": "The quills on its head are usually soft. When it flexes them, the points become so hard and sharp that they can pierce rock."
+ },
+ {
+  "id": 651,
+  "name": "quilladin",
+  "types": [
+   "grass"
+  ],
+  "height": 7,
+  "weight": 290,
+  "stats": {
+   "hp": 61,
+   "attack": 78,
+   "defense": 95,
+   "special-attack": 56,
+   "special-defense": 58,
+   "speed": 57
+  },
+  "flavor": "It relies on its sturdy shell to deflect predators’ attacks. It counterattacks with its sharp quills."
+ },
+ {
+  "id": 652,
+  "name": "chesnaught",
+  "types": [
+   "grass",
+   "fighting"
+  ],
+  "height": 16,
+  "weight": 900,
+  "stats": {
+   "hp": 88,
+   "attack": 107,
+   "defense": 122,
+   "special-attack": 74,
+   "special-defense": 75,
+   "speed": 64
+  },
+  "flavor": "Its Tackle is forceful enough to flip a 50-ton tank. It shields its allies from danger with its own body."
+ },
+ {
+  "id": 653,
+  "name": "fennekin",
+  "types": [
+   "fire"
+  ],
+  "height": 4,
+  "weight": 94,
+  "stats": {
+   "hp": 40,
+   "attack": 45,
+   "defense": 40,
+   "special-attack": 62,
+   "special-defense": 60,
+   "speed": 60
+  },
+  "flavor": "Eating a twig fills it with energy, and its roomy ears give vent to air hotter than 390 degrees Fahrenheit."
+ },
+ {
+  "id": 654,
+  "name": "braixen",
+  "types": [
+   "fire"
+  ],
+  "height": 10,
+  "weight": 145,
+  "stats": {
+   "hp": 59,
+   "attack": 59,
+   "defense": 58,
+   "special-attack": 90,
+   "special-defense": 70,
+   "speed": 73
+  },
+  "flavor": "It has a twig stuck in its tail. With friction from its tail fur, it sets the twig on fire and launches into battle."
+ },
+ {
+  "id": 655,
+  "name": "delphox",
+  "types": [
+   "fire",
+   "psychic"
+  ],
+  "height": 15,
+  "weight": 390,
+  "stats": {
+   "hp": 75,
+   "attack": 69,
+   "defense": 72,
+   "special-attack": 114,
+   "special-defense": 100,
+   "speed": 104
+  },
+  "flavor": "It gazes into the flame at the tip of its branch to achieve a focused state, which allows it to see into the future."
+ },
+ {
+  "id": 656,
+  "name": "froakie",
+  "types": [
+   "water"
+  ],
+  "height": 3,
+  "weight": 70,
+  "stats": {
+   "hp": 41,
+   "attack": 56,
+   "defense": 40,
+   "special-attack": 62,
+   "special-defense": 44,
+   "speed": 71
+  },
+  "flavor": "It secretes flexible bubbles from its chest and back. The bubbles reduce the damage it would otherwise take when attacked."
+ },
+ {
+  "id": 657,
+  "name": "frogadier",
+  "types": [
+   "water"
+  ],
+  "height": 6,
+  "weight": 109,
+  "stats": {
+   "hp": 54,
+   "attack": 63,
+   "defense": 52,
+   "special-attack": 83,
+   "special-defense": 56,
+   "speed": 97
+  },
+  "flavor": "It can throw bubble-covered pebbles with precise control, hitting empty cans up to a hundred feet away."
+ },
+ {
+  "id": 658,
+  "name": "greninja",
+  "types": [
+   "water",
+   "dark"
+  ],
+  "height": 15,
+  "weight": 400,
+  "stats": {
+   "hp": 72,
+   "attack": 95,
+   "defense": 67,
+   "special-attack": 103,
+   "special-defense": 71,
+   "speed": 122
+  },
+  "flavor": "It creates throwing stars out of compressed water. When it spins them and throws them at high speed, these stars can split metal in two."
+ },
+ {
+  "id": 659,
+  "name": "bunnelby",
+  "types": [
+   "normal"
+  ],
+  "height": 4,
+  "weight": 50,
+  "stats": {
+   "hp": 38,
+   "attack": 36,
+   "defense": 38,
+   "special-attack": 32,
+   "special-defense": 36,
+   "speed": 57
+  },
+  "flavor": "They use their large ears to dig burrows. They will dig the whole night through."
+ },
+ {
+  "id": 660,
+  "name": "diggersby",
+  "types": [
+   "normal",
+   "ground"
+  ],
+  "height": 10,
+  "weight": 424,
+  "stats": {
+   "hp": 85,
+   "attack": 56,
+   "defense": 77,
+   "special-attack": 50,
+   "special-defense": 77,
+   "speed": 78
+  },
+  "flavor": "With their powerful ears, they can heft boulders of a ton or more with ease. They can be a big help at construction sites."
+ },
+ {
+  "id": 661,
+  "name": "fletchling",
+  "types": [
+   "normal",
+   "flying"
+  ],
+  "height": 3,
+  "weight": 17,
+  "stats": {
+   "hp": 45,
+   "attack": 50,
+   "defense": 43,
+   "special-attack": 40,
+   "special-defense": 38,
+   "speed": 62
+  },
+  "flavor": "These friendly Pokémon send signals to one another with beautiful chirps and tail-feather movements."
+ },
+ {
+  "id": 662,
+  "name": "fletchinder",
+  "types": [
+   "fire",
+   "flying"
+  ],
+  "height": 7,
+  "weight": 160,
+  "stats": {
+   "hp": 62,
+   "attack": 73,
+   "defense": 55,
+   "special-attack": 56,
+   "special-defense": 52,
+   "speed": 84
+  },
+  "flavor": "From its beak, it expels embers that set the tall grass on fire. Then it pounces on the bewildered prey that pop out of the grass."
+ },
+ {
+  "id": 663,
+  "name": "talonflame",
+  "types": [
+   "fire",
+   "flying"
+  ],
+  "height": 12,
+  "weight": 245,
+  "stats": {
+   "hp": 78,
+   "attack": 81,
+   "defense": 71,
+   "special-attack": 74,
+   "special-defense": 69,
+   "speed": 126
+  },
+  "flavor": "In the fever of an exciting battle, it showers embers from the gaps between its feathers and takes to the air."
+ },
+ {
+  "id": 664,
+  "name": "scatterbug",
+  "types": [
+   "bug"
+  ],
+  "height": 3,
+  "weight": 25,
+  "stats": {
+   "hp": 38,
+   "attack": 35,
+   "defense": 40,
+   "special-attack": 27,
+   "special-defense": 25,
+   "speed": 35
+  },
+  "flavor": "When under attack from bird Pokémon, it spews a poisonous black powder that causes paralysis on contact."
+ },
+ {
+  "id": 665,
+  "name": "spewpa",
+  "types": [
+   "bug"
+  ],
+  "height": 3,
+  "weight": 84,
+  "stats": {
+   "hp": 45,
+   "attack": 22,
+   "defense": 60,
+   "special-attack": 27,
+   "special-defense": 30,
+   "speed": 29
+  },
+  "flavor": "It lives hidden within thicket shadows. When predators attack, it quickly bristles the fur covering its body in an effort to threaten them."
+ },
+ {
+  "id": 666,
+  "name": "vivillon",
+  "types": [
+   "bug",
+   "flying"
+  ],
+  "height": 12,
+  "weight": 170,
+  "stats": {
+   "hp": 80,
+   "attack": 52,
+   "defense": 50,
+   "special-attack": 90,
+   "special-defense": 50,
+   "speed": 89
+  },
+  "flavor": "Vivillon with many different patterns are found all over the world. These patterns are affected by the climate of their habitat."
+ },
+ {
+  "id": 667,
+  "name": "litleo",
+  "types": [
+   "fire",
+   "normal"
+  ],
+  "height": 6,
+  "weight": 135,
+  "stats": {
+   "hp": 62,
+   "attack": 50,
+   "defense": 58,
+   "special-attack": 73,
+   "special-defense": 54,
+   "speed": 72
+  },
+  "flavor": "The stronger the opponent it faces, the more heat surges from its mane and the more power flows through its body."
+ },
+ {
+  "id": 668,
+  "name": "pyroar-male",
+  "types": [
+   "fire",
+   "normal"
+  ],
+  "height": 15,
+  "weight": 815,
+  "stats": {
+   "hp": 86,
+   "attack": 68,
+   "defense": 72,
+   "special-attack": 109,
+   "special-defense": 66,
+   "speed": 106
+  },
+  "flavor": "The male with the largest mane of fire is the leader of the pride."
+ },
+ {
+  "id": 669,
+  "name": "flabebe",
+  "types": [
+   "fairy"
+  ],
+  "height": 1,
+  "weight": 1,
+  "stats": {
+   "hp": 44,
+   "attack": 38,
+   "defense": 39,
+   "special-attack": 61,
+   "special-defense": 79,
+   "speed": 42
+  },
+  "flavor": "It draws out and controls the hidden power of flowers. The flower Flabébé holds is most likely part of its body."
+ },
+ {
+  "id": 670,
+  "name": "floette",
+  "types": [
+   "fairy"
+  ],
+  "height": 2,
+  "weight": 9,
+  "stats": {
+   "hp": 54,
+   "attack": 45,
+   "defense": 47,
+   "special-attack": 75,
+   "special-defense": 98,
+   "speed": 52
+  },
+  "flavor": "It flutters around fields of flowers and cares for flowers that are starting to wilt. It draws out the hidden power of flowers to battle."
+ },
+ {
+  "id": 671,
+  "name": "florges",
+  "types": [
+   "fairy"
+  ],
+  "height": 11,
+  "weight": 100,
+  "stats": {
+   "hp": 78,
+   "attack": 65,
+   "defense": 68,
+   "special-attack": 112,
+   "special-defense": 154,
+   "speed": 75
+  },
+  "flavor": "It claims exquisite flower gardens as its territory, and it obtains power from basking in the energy emitted by flowering plants."
+ },
+ {
+  "id": 672,
+  "name": "skiddo",
+  "types": [
+   "grass"
+  ],
+  "height": 9,
+  "weight": 310,
+  "stats": {
+   "hp": 66,
+   "attack": 65,
+   "defense": 48,
+   "special-attack": 62,
+   "special-defense": 57,
+   "speed": 52
+  },
+  "flavor": "Thought to be one of the first Pokémon to live in harmony with humans, it has a placid disposition."
+ },
+ {
+  "id": 673,
+  "name": "gogoat",
+  "types": [
+   "grass"
+  ],
+  "height": 17,
+  "weight": 910,
+  "stats": {
+   "hp": 123,
+   "attack": 100,
+   "defense": 62,
+   "special-attack": 97,
+   "special-defense": 81,
+   "speed": 68
+  },
+  "flavor": "It can tell how its Trainer is feeling by subtle shifts in the grip on its horns. This empathic sense lets them run as if one being."
+ },
+ {
+  "id": 674,
+  "name": "pancham",
+  "types": [
+   "fighting"
+  ],
+  "height": 6,
+  "weight": 80,
+  "stats": {
+   "hp": 67,
+   "attack": 82,
+   "defense": 62,
+   "special-attack": 46,
+   "special-defense": 48,
+   "speed": 43
+  },
+  "flavor": "It does its best to be taken seriously by its enemies, but its glare is not sufficiently intimidating. Chewing on a leaf is its trademark."
+ },
+ {
+  "id": 675,
+  "name": "pangoro",
+  "types": [
+   "fighting",
+   "dark"
+  ],
+  "height": 21,
+  "weight": 1360,
+  "stats": {
+   "hp": 95,
+   "attack": 124,
+   "defense": 78,
+   "special-attack": 69,
+   "special-defense": 71,
+   "speed": 58
+  },
+  "flavor": "From the slight twitches of its bamboo leaf, it deduces its opponent’s movements. It’s eager to tussle but kindhearted toward its companions."
+ },
+ {
+  "id": 676,
+  "name": "furfrou",
+  "types": [
+   "normal"
+  ],
+  "height": 12,
+  "weight": 280,
+  "stats": {
+   "hp": 75,
+   "attack": 80,
+   "defense": 60,
+   "special-attack": 65,
+   "special-defense": 90,
+   "speed": 102
+  },
+  "flavor": "Trimming its fluffy fur not only makes it more elegant but also increases the swiftness of its movements."
+ },
+ {
+  "id": 677,
+  "name": "espurr",
+  "types": [
+   "psychic"
+  ],
+  "height": 3,
+  "weight": 35,
+  "stats": {
+   "hp": 62,
+   "attack": 48,
+   "defense": 54,
+   "special-attack": 63,
+   "special-defense": 60,
+   "speed": 68
+  },
+  "flavor": "The organ that emits its intense psychic power is sheltered by its ears to keep power from leaking out."
+ },
+ {
+  "id": 678,
+  "name": "meowstic-male",
+  "types": [
+   "psychic"
+  ],
+  "height": 6,
+  "weight": 85,
+  "stats": {
+   "hp": 74,
+   "attack": 48,
+   "defense": 76,
+   "special-attack": 83,
+   "special-defense": 81,
+   "speed": 104
+  },
+  "flavor": "When in danger, it raises its ears and releases enough psychic power to grind a 10-ton truck into dust."
+ },
+ {
+  "id": 679,
+  "name": "honedge",
+  "types": [
+   "steel",
+   "ghost"
+  ],
+  "height": 8,
+  "weight": 20,
+  "stats": {
+   "hp": 45,
+   "attack": 80,
+   "defense": 100,
+   "special-attack": 35,
+   "special-defense": 37,
+   "speed": 28
+  },
+  "flavor": "Apparently this Pokémon is born when a departed spirit inhabits a sword. It attaches itself to people and drinks their life force."
+ },
+ {
+  "id": 680,
+  "name": "doublade",
+  "types": [
+   "steel",
+   "ghost"
+  ],
+  "height": 8,
+  "weight": 45,
+  "stats": {
+   "hp": 59,
+   "attack": 110,
+   "defense": 150,
+   "special-attack": 45,
+   "special-defense": 49,
+   "speed": 35
+  },
+  "flavor": "When Honedge evolves, it divides into two swords, which cooperate via telepathy to coordinate attacks and slash their enemies to ribbons."
+ },
+ {
+  "id": 681,
+  "name": "aegislash-shield",
+  "types": [
+   "steel",
+   "ghost"
+  ],
+  "height": 17,
+  "weight": 530,
+  "stats": {
+   "hp": 60,
+   "attack": 50,
+   "defense": 140,
+   "special-attack": 50,
+   "special-defense": 140,
+   "speed": 60
+  },
+  "flavor": "Generations of kings were attended by these Pokémon, which used their spectral power to manipulate and control people and Pokémon."
+ },
+ {
+  "id": 682,
+  "name": "spritzee",
+  "types": [
+   "fairy"
+  ],
+  "height": 2,
+  "weight": 5,
+  "stats": {
+   "hp": 78,
+   "attack": 52,
+   "defense": 60,
+   "special-attack": 63,
+   "special-defense": 65,
+   "speed": 23
+  },
+  "flavor": "It emits a scent that enraptures those who smell it. This fragrance changes depending on what it has eaten."
+ },
+ {
+  "id": 683,
+  "name": "aromatisse",
+  "types": [
+   "fairy"
+  ],
+  "height": 8,
+  "weight": 155,
+  "stats": {
+   "hp": 101,
+   "attack": 72,
+   "defense": 72,
+   "special-attack": 99,
+   "special-defense": 89,
+   "speed": 29
+  },
+  "flavor": "It devises various scents, pleasant and unpleasant, and emits scents that its enemies dislike in order to gain an edge in battle."
+ },
+ {
+  "id": 684,
+  "name": "swirlix",
+  "types": [
+   "fairy"
+  ],
+  "height": 4,
+  "weight": 35,
+  "stats": {
+   "hp": 62,
+   "attack": 48,
+   "defense": 66,
+   "special-attack": 59,
+   "special-defense": 57,
+   "speed": 49
+  },
+  "flavor": "To entangle its opponents in battle, it extrudes white threads as sweet and sticky as cotton candy."
+ },
+ {
+  "id": 685,
+  "name": "slurpuff",
+  "types": [
+   "fairy"
+  ],
+  "height": 8,
+  "weight": 50,
+  "stats": {
+   "hp": 82,
+   "attack": 80,
+   "defense": 86,
+   "special-attack": 85,
+   "special-defense": 75,
+   "speed": 72
+  },
+  "flavor": "It can distinguish the faintest of scents. It puts its sensitive sense of smell to use by helping pastry chefs in their work."
+ },
+ {
+  "id": 686,
+  "name": "inkay",
+  "types": [
+   "dark",
+   "psychic"
+  ],
+  "height": 4,
+  "weight": 35,
+  "stats": {
+   "hp": 53,
+   "attack": 54,
+   "defense": 53,
+   "special-attack": 37,
+   "special-defense": 46,
+   "speed": 45
+  },
+  "flavor": "Opponents who stare at the flashing of the light-emitting spots on its body become dazed and lose their will to fight."
+ },
+ {
+  "id": 687,
+  "name": "malamar",
+  "types": [
+   "dark",
+   "psychic"
+  ],
+  "height": 15,
+  "weight": 470,
+  "stats": {
+   "hp": 86,
+   "attack": 92,
+   "defense": 88,
+   "special-attack": 68,
+   "special-defense": 75,
+   "speed": 73
+  },
+  "flavor": "It wields the most compelling hypnotic powers of any Pokémon, and it forces others to do whatever it wants."
+ },
+ {
+  "id": 688,
+  "name": "binacle",
+  "types": [
+   "rock",
+   "water"
+  ],
+  "height": 5,
+  "weight": 310,
+  "stats": {
+   "hp": 42,
+   "attack": 52,
+   "defense": 67,
+   "special-attack": 39,
+   "special-defense": 56,
+   "speed": 50
+  },
+  "flavor": "Two Binacle live together on one rock. When they fight, one of them will move to a different rock."
+ },
+ {
+  "id": 689,
+  "name": "barbaracle",
+  "types": [
+   "rock",
+   "water"
+  ],
+  "height": 13,
+  "weight": 960,
+  "stats": {
+   "hp": 72,
+   "attack": 105,
+   "defense": 115,
+   "special-attack": 54,
+   "special-defense": 86,
+   "speed": 68
+  },
+  "flavor": "When they evolve, two Binacle multiply into seven. They fight with the power of seven Binacle."
+ },
+ {
+  "id": 690,
+  "name": "skrelp",
+  "types": [
+   "poison",
+   "water"
+  ],
+  "height": 5,
+  "weight": 73,
+  "stats": {
+   "hp": 50,
+   "attack": 60,
+   "defense": 60,
+   "special-attack": 60,
+   "special-defense": 60,
+   "speed": 30
+  },
+  "flavor": "Camouflaged as rotten kelp, they spray liquid poison on prey that approaches unawares and then finish it off."
+ },
+ {
+  "id": 691,
+  "name": "dragalge",
+  "types": [
+   "poison",
+   "dragon"
+  ],
+  "height": 18,
+  "weight": 815,
+  "stats": {
+   "hp": 65,
+   "attack": 75,
+   "defense": 90,
+   "special-attack": 97,
+   "special-defense": 123,
+   "speed": 44
+  },
+  "flavor": "Their poison is strong enough to eat through the hull of a tanker, and they spit it indiscriminately at anything that enters their territory."
+ },
+ {
+  "id": 692,
+  "name": "clauncher",
+  "types": [
+   "water"
+  ],
+  "height": 5,
+  "weight": 83,
+  "stats": {
+   "hp": 50,
+   "attack": 53,
+   "defense": 62,
+   "special-attack": 58,
+   "special-defense": 63,
+   "speed": 44
+  },
+  "flavor": "They knock down flying prey by firing compressed water from their massive claws like shooting a pistol."
+ },
+ {
+  "id": 693,
+  "name": "clawitzer",
+  "types": [
+   "water"
+  ],
+  "height": 13,
+  "weight": 353,
+  "stats": {
+   "hp": 71,
+   "attack": 73,
+   "defense": 88,
+   "special-attack": 120,
+   "special-defense": 89,
+   "speed": 59
+  },
+  "flavor": "Their enormous claws launch cannonballs of water powerful enough to pierce tanker hulls."
+ },
+ {
+  "id": 694,
+  "name": "helioptile",
+  "types": [
+   "electric",
+   "normal"
+  ],
+  "height": 5,
+  "weight": 60,
+  "stats": {
+   "hp": 44,
+   "attack": 38,
+   "defense": 33,
+   "special-attack": 61,
+   "special-defense": 43,
+   "speed": 70
+  },
+  "flavor": "They make their home in deserts. They can generate their energy from basking in the sun, so eating food is not a requirement."
+ },
+ {
+  "id": 695,
+  "name": "heliolisk",
+  "types": [
+   "electric",
+   "normal"
+  ],
+  "height": 10,
+  "weight": 210,
+  "stats": {
+   "hp": 62,
+   "attack": 55,
+   "defense": 52,
+   "special-attack": 109,
+   "special-defense": 94,
+   "speed": 109
+  },
+  "flavor": "They flare their frills and generate energy. A single Heliolisk can generate sufficient electricity to power a skyscraper."
+ },
+ {
+  "id": 696,
+  "name": "tyrunt",
+  "types": [
+   "rock",
+   "dragon"
+  ],
+  "height": 8,
+  "weight": 260,
+  "stats": {
+   "hp": 58,
+   "attack": 89,
+   "defense": 77,
+   "special-attack": 45,
+   "special-defense": 45,
+   "speed": 48
+  },
+  "flavor": "This Pokémon was restored from a fossil. If something happens that it doesn’t like, it throws a tantrum and runs wild."
+ },
+ {
+  "id": 697,
+  "name": "tyrantrum",
+  "types": [
+   "rock",
+   "dragon"
+  ],
+  "height": 25,
+  "weight": 2700,
+  "stats": {
+   "hp": 82,
+   "attack": 121,
+   "defense": 119,
+   "special-attack": 69,
+   "special-defense": 59,
+   "speed": 71
+  },
+  "flavor": "Thanks to its gargantuan jaws, which could shred thick metal plates as if they were paper, it was invincible in the ancient world it once inhabited."
+ },
+ {
+  "id": 698,
+  "name": "amaura",
+  "types": [
+   "rock",
+   "ice"
+  ],
+  "height": 13,
+  "weight": 252,
+  "stats": {
+   "hp": 77,
+   "attack": 59,
+   "defense": 50,
+   "special-attack": 67,
+   "special-defense": 63,
+   "speed": 46
+  },
+  "flavor": "This ancient Pokémon was restored from part of its body that had been frozen in ice for over 100 million years."
+ },
+ {
+  "id": 699,
+  "name": "aurorus",
+  "types": [
+   "rock",
+   "ice"
+  ],
+  "height": 27,
+  "weight": 2250,
+  "stats": {
+   "hp": 123,
+   "attack": 77,
+   "defense": 72,
+   "special-attack": 99,
+   "special-defense": 92,
+   "speed": 58
+  },
+  "flavor": "The diamond-shaped crystals on its body expel air as cold as -240 degrees Fahrenheit, surrounding its enemies and encasing them in ice."
+ },
+ {
+  "id": 700,
+  "name": "sylveon",
+  "types": [
+   "fairy"
+  ],
+  "height": 10,
+  "weight": 235,
+  "stats": {
+   "hp": 95,
+   "attack": 65,
+   "defense": 65,
+   "special-attack": 110,
+   "special-defense": 130,
+   "speed": 60
+  },
+  "flavor": "It sends a soothing aura from its ribbonlike feelers to calm fights."
+ },
+ {
+  "id": 701,
+  "name": "hawlucha",
+  "types": [
+   "fighting",
+   "flying"
+  ],
+  "height": 8,
+  "weight": 215,
+  "stats": {
+   "hp": 78,
+   "attack": 92,
+   "defense": 75,
+   "special-attack": 74,
+   "special-defense": 63,
+   "speed": 118
+  },
+  "flavor": "Although its body is small, its proficient fighting skills enable it to keep up with big bruisers like Machamp and Hariyama."
+ },
+ {
+  "id": 702,
+  "name": "dedenne",
+  "types": [
+   "electric",
+   "fairy"
+  ],
+  "height": 2,
+  "weight": 22,
+  "stats": {
+   "hp": 67,
+   "attack": 58,
+   "defense": 57,
+   "special-attack": 81,
+   "special-defense": 67,
+   "speed": 101
+  },
+  "flavor": "Its whiskers serve as antennas. By sending and receiving electrical waves, it can communicate with others over vast distances."
+ },
+ {
+  "id": 703,
+  "name": "carbink",
+  "types": [
+   "rock",
+   "fairy"
+  ],
+  "height": 3,
+  "weight": 57,
+  "stats": {
+   "hp": 50,
+   "attack": 50,
+   "defense": 150,
+   "special-attack": 50,
+   "special-defense": 150,
+   "speed": 50
+  },
+  "flavor": "Born from the temperatures and pressures deep underground, it fires beams from the stone in its head."
+ },
+ {
+  "id": 704,
+  "name": "goomy",
+  "types": [
+   "dragon"
+  ],
+  "height": 3,
+  "weight": 28,
+  "stats": {
+   "hp": 45,
+   "attack": 50,
+   "defense": 35,
+   "special-attack": 55,
+   "special-defense": 75,
+   "speed": 40
+  },
+  "flavor": "The weakest Dragon-type Pokémon, it lives in damp, shady places, so its body doesn’t dry out."
+ },
+ {
+  "id": 705,
+  "name": "sliggoo",
+  "types": [
+   "dragon"
+  ],
+  "height": 8,
+  "weight": 175,
+  "stats": {
+   "hp": 68,
+   "attack": 75,
+   "defense": 53,
+   "special-attack": 83,
+   "special-defense": 113,
+   "speed": 60
+  },
+  "flavor": "It drives away opponents by excreting a sticky liquid that can dissolve anything. Its eyes devolved, so it can’t see anything."
+ },
+ {
+  "id": 706,
+  "name": "goodra",
+  "types": [
+   "dragon"
+  ],
+  "height": 20,
+  "weight": 1505,
+  "stats": {
+   "hp": 90,
+   "attack": 100,
+   "defense": 70,
+   "special-attack": 110,
+   "special-defense": 150,
+   "speed": 80
+  },
+  "flavor": "This very friendly Dragon-type Pokémon will hug its beloved Trainer, leaving that Trainer covered in sticky slime."
+ },
+ {
+  "id": 707,
+  "name": "klefki",
+  "types": [
+   "steel",
+   "fairy"
+  ],
+  "height": 2,
+  "weight": 30,
+  "stats": {
+   "hp": 57,
+   "attack": 80,
+   "defense": 91,
+   "special-attack": 80,
+   "special-defense": 87,
+   "speed": 75
+  },
+  "flavor": "These key collectors threaten any attackers by fiercely jingling their keys at them."
+ },
+ {
+  "id": 708,
+  "name": "phantump",
+  "types": [
+   "ghost",
+   "grass"
+  ],
+  "height": 4,
+  "weight": 70,
+  "stats": {
+   "hp": 43,
+   "attack": 70,
+   "defense": 48,
+   "special-attack": 50,
+   "special-defense": 60,
+   "speed": 38
+  },
+  "flavor": "These Pokémon are created when spirits possess rotten tree stumps. They prefer to live in abandoned forests."
+ },
+ {
+  "id": 709,
+  "name": "trevenant",
+  "types": [
+   "ghost",
+   "grass"
+  ],
+  "height": 15,
+  "weight": 710,
+  "stats": {
+   "hp": 85,
+   "attack": 110,
+   "defense": 76,
+   "special-attack": 65,
+   "special-defense": 82,
+   "speed": 56
+  },
+  "flavor": "It can control trees at will. It will trap people who harm the forest, so they can never leave."
+ },
+ {
+  "id": 710,
+  "name": "pumpkaboo-average",
+  "types": [
+   "ghost",
+   "grass"
+  ],
+  "height": 4,
+  "weight": 50,
+  "stats": {
+   "hp": 49,
+   "attack": 66,
+   "defense": 70,
+   "special-attack": 44,
+   "special-defense": 55,
+   "speed": 51
+  },
+  "flavor": "The pumpkin body is inhabited by a spirit trapped in this world. As the sun sets, it becomes restless and active."
+ },
+ {
+  "id": 711,
+  "name": "gourgeist-average",
+  "types": [
+   "ghost",
+   "grass"
+  ],
+  "height": 9,
+  "weight": 125,
+  "stats": {
+   "hp": 65,
+   "attack": 90,
+   "defense": 122,
+   "special-attack": 58,
+   "special-defense": 75,
+   "speed": 84
+  },
+  "flavor": "Singing in eerie voices, they wander town streets on the night of the new moon. Anyone who hears their song is cursed."
+ },
+ {
+  "id": 712,
+  "name": "bergmite",
+  "types": [
+   "ice"
+  ],
+  "height": 10,
+  "weight": 995,
+  "stats": {
+   "hp": 55,
+   "attack": 69,
+   "defense": 85,
+   "special-attack": 32,
+   "special-defense": 35,
+   "speed": 28
+  },
+  "flavor": "It blocks opponents’ attacks with the ice that shields its body. It uses cold air to repair any cracks with new ice."
+ },
+ {
+  "id": 713,
+  "name": "avalugg",
+  "types": [
+   "ice"
+  ],
+  "height": 20,
+  "weight": 5050,
+  "stats": {
+   "hp": 95,
+   "attack": 117,
+   "defense": 184,
+   "special-attack": 44,
+   "special-defense": 46,
+   "speed": 28
+  },
+  "flavor": "Its ice-covered body is as hard as steel. Its cumbersome frame crushes anything that stands in its way."
+ },
+ {
+  "id": 714,
+  "name": "noibat",
+  "types": [
+   "flying",
+   "dragon"
+  ],
+  "height": 5,
+  "weight": 80,
+  "stats": {
+   "hp": 40,
+   "attack": 30,
+   "defense": 35,
+   "special-attack": 45,
+   "special-defense": 40,
+   "speed": 55
+  },
+  "flavor": "They live in pitch-black caves. Their enormous ears can emit ultrasonic waves of 200,000 hertz."
+ },
+ {
+  "id": 715,
+  "name": "noivern",
+  "types": [
+   "flying",
+   "dragon"
+  ],
+  "height": 15,
+  "weight": 850,
+  "stats": {
+   "hp": 85,
+   "attack": 70,
+   "defense": 80,
+   "special-attack": 97,
+   "special-defense": 80,
+   "speed": 123
+  },
+  "flavor": "They fly around on moonless nights and attack careless prey. Nothing can beat them in a battle in the dark."
+ },
+ {
+  "id": 716,
+  "name": "xerneas",
+  "types": [
+   "fairy"
+  ],
+  "height": 30,
+  "weight": 2150,
+  "stats": {
+   "hp": 126,
+   "attack": 131,
+   "defense": 95,
+   "special-attack": 131,
+   "special-defense": 98,
+   "speed": 99
+  },
+  "flavor": "Legends say it can share eternal life. It slept for a thousand years in the form of a tree before its revival."
+ },
+ {
+  "id": 717,
+  "name": "yveltal",
+  "types": [
+   "dark",
+   "flying"
+  ],
+  "height": 58,
+  "weight": 2030,
+  "stats": {
+   "hp": 126,
+   "attack": 131,
+   "defense": 95,
+   "special-attack": 131,
+   "special-defense": 98,
+   "speed": 99
+  },
+  "flavor": "When this legendary Pokémon’s wings and tail feathers spread wide and glow red, it absorbs the life force of living creatures."
+ },
+ {
+  "id": 718,
+  "name": "zygarde-50",
+  "types": [
+   "dragon",
+   "ground"
+  ],
+  "height": 50,
+  "weight": 3050,
+  "stats": {
+   "hp": 108,
+   "attack": 100,
+   "defense": 121,
+   "special-attack": 81,
+   "special-defense": 95,
+   "speed": 95
+  },
+  "flavor": "When the Kalos region’s ecosystem falls into disarray, it appears and reveals its secret power."
+ },
+ {
+  "id": 719,
+  "name": "diancie",
+  "types": [
+   "rock",
+   "fairy"
+  ],
+  "height": 7,
+  "weight": 88,
+  "stats": {
+   "hp": 50,
+   "attack": 100,
+   "defense": 150,
+   "special-attack": 100,
+   "special-defense": 150,
+   "speed": 50
+  },
+  "flavor": "A sudden transformation of Carbink, its pink, glimmering body is said to be the loveliest sight in the whole world."
+ },
+ {
+  "id": 720,
+  "name": "hoopa",
+  "types": [
+   "psychic",
+   "ghost"
+  ],
+  "height": 5,
+  "weight": 90,
+  "stats": {
+   "hp": 80,
+   "attack": 110,
+   "defense": 60,
+   "special-attack": 150,
+   "special-defense": 130,
+   "speed": 70
+  },
+  "flavor": "This troublemaker sends anything and everything to faraway places using its loop, which can warp space."
+ },
+ {
+  "id": 721,
+  "name": "volcanion",
+  "types": [
+   "fire",
+   "water"
+  ],
+  "height": 17,
+  "weight": 1950,
+  "stats": {
+   "hp": 80,
+   "attack": 110,
+   "defense": 120,
+   "special-attack": 130,
+   "special-defense": 90,
+   "speed": 70
+  },
+  "flavor": "It lets out billows of steam and disappears into the dense fog. It’s said to live in mountains where humans do not tread."
+ },
+ {
+  "id": 722,
+  "name": "rowlet",
+  "types": [
+   "grass",
+   "flying"
+  ],
+  "height": 3,
+  "weight": 15,
+  "stats": {
+   "hp": 68,
+   "attack": 55,
+   "defense": 55,
+   "special-attack": 50,
+   "special-defense": 50,
+   "speed": 42
+  },
+  "flavor": "This wary Pokémon uses photosynthesis to store up energy during the day, while becoming active at night."
+ },
+ {
+  "id": 723,
+  "name": "dartrix",
+  "types": [
+   "grass",
+   "flying"
+  ],
+  "height": 7,
+  "weight": 160,
+  "stats": {
+   "hp": 78,
+   "attack": 75,
+   "defense": 75,
+   "special-attack": 70,
+   "special-defense": 70,
+   "speed": 52
+  },
+  "flavor": "A bit of a dandy, it spends its free time preening its wings. Its preoccupation with any dirt on its plumage can leave it unable to battle."
+ },
+ {
+  "id": 724,
+  "name": "decidueye",
+  "types": [
+   "grass",
+   "ghost"
+  ],
+  "height": 16,
+  "weight": 366,
+  "stats": {
+   "hp": 78,
+   "attack": 107,
+   "defense": 75,
+   "special-attack": 100,
+   "special-defense": 100,
+   "speed": 70
+  },
+  "flavor": "It fires arrow quills from its wings with such precision, they can pierce a pebble at distances over a hundred yards."
+ },
+ {
+  "id": 725,
+  "name": "litten",
+  "types": [
+   "fire"
+  ],
+  "height": 4,
+  "weight": 43,
+  "stats": {
+   "hp": 45,
+   "attack": 65,
+   "defense": 40,
+   "special-attack": 60,
+   "special-defense": 40,
+   "speed": 70
+  },
+  "flavor": "While grooming itself, it builds up fur inside its stomach. It sets the fur alight and spews fiery attacks, which change based on how it coughs."
+ },
+ {
+  "id": 726,
+  "name": "torracat",
+  "types": [
+   "fire"
+  ],
+  "height": 7,
+  "weight": 250,
+  "stats": {
+   "hp": 65,
+   "attack": 85,
+   "defense": 50,
+   "special-attack": 80,
+   "special-defense": 50,
+   "speed": 90
+  },
+  "flavor": "At its throat, it bears a bell of fire. The bell rings brightly whenever this Pokémon spits fire."
+ },
+ {
+  "id": 727,
+  "name": "incineroar",
+  "types": [
+   "fire",
+   "dark"
+  ],
+  "height": 18,
+  "weight": 830,
+  "stats": {
+   "hp": 95,
+   "attack": 115,
+   "defense": 90,
+   "special-attack": 80,
+   "special-defense": 90,
+   "speed": 60
+  },
+  "flavor": "This Pokémon has a violent, selfish disposition. If it’s not in the mood to listen, it will ignore its Trainer’s orders with complete nonchalance."
+ },
+ {
+  "id": 728,
+  "name": "popplio",
+  "types": [
+   "water"
+  ],
+  "height": 4,
+  "weight": 75,
+  "stats": {
+   "hp": 50,
+   "attack": 54,
+   "defense": 54,
+   "special-attack": 66,
+   "special-defense": 56,
+   "speed": 40
+  },
+  "flavor": "This Pokémon snorts body fluids from its nose, blowing balloons to smash into its foes. It’s famous for being a hard worker."
+ },
+ {
+  "id": 729,
+  "name": "brionne",
+  "types": [
+   "water"
+  ],
+  "height": 6,
+  "weight": 175,
+  "stats": {
+   "hp": 60,
+   "attack": 69,
+   "defense": 69,
+   "special-attack": 91,
+   "special-defense": 81,
+   "speed": 50
+  },
+  "flavor": "A skillful dancer, it creates a sequence of water balloons as it dances, and briskly bombards its enemies."
+ },
+ {
+  "id": 730,
+  "name": "primarina",
+  "types": [
+   "water",
+   "fairy"
+  ],
+  "height": 18,
+  "weight": 440,
+  "stats": {
+   "hp": 80,
+   "attack": 74,
+   "defense": 74,
+   "special-attack": 126,
+   "special-defense": 116,
+   "speed": 60
+  },
+  "flavor": "It controls its water balloons with song. The melody is learned from others of its kind and is passed down from one generation to the next."
+ },
+ {
+  "id": 731,
+  "name": "pikipek",
+  "types": [
+   "normal",
+   "flying"
+  ],
+  "height": 3,
+  "weight": 12,
+  "stats": {
+   "hp": 35,
+   "attack": 75,
+   "defense": 30,
+   "special-attack": 30,
+   "special-defense": 30,
+   "speed": 65
+  },
+  "flavor": "It can peck at a rate of 16 times a second to drill holes in trees. It uses the holes for food storage and for nesting."
+ },
+ {
+  "id": 732,
+  "name": "trumbeak",
+  "types": [
+   "normal",
+   "flying"
+  ],
+  "height": 6,
+  "weight": 148,
+  "stats": {
+   "hp": 55,
+   "attack": 85,
+   "defense": 50,
+   "special-attack": 40,
+   "special-defense": 50,
+   "speed": 75
+  },
+  "flavor": "It eats berries and stores their seeds in its beak. When it encounters enemies or prey, it fires off all the seeds in a burst."
+ },
+ {
+  "id": 733,
+  "name": "toucannon",
+  "types": [
+   "normal",
+   "flying"
+  ],
+  "height": 11,
+  "weight": 260,
+  "stats": {
+   "hp": 80,
+   "attack": 120,
+   "defense": 75,
+   "special-attack": 75,
+   "special-defense": 75,
+   "speed": 60
+  },
+  "flavor": "When it battles, its beak heats up. The temperature can easily exceed 212 degrees Fahrenheit, causing severe burns when it hits."
+ },
+ {
+  "id": 734,
+  "name": "yungoos",
+  "types": [
+   "normal"
+  ],
+  "height": 4,
+  "weight": 60,
+  "stats": {
+   "hp": 48,
+   "attack": 70,
+   "defense": 30,
+   "special-attack": 30,
+   "special-defense": 30,
+   "speed": 45
+  },
+  "flavor": "With its sharp fangs, it will bite anything. It did not originally live in Alola but was imported from another region."
+ },
+ {
+  "id": 735,
+  "name": "gumshoos",
+  "types": [
+   "normal"
+  ],
+  "height": 7,
+  "weight": 142,
+  "stats": {
+   "hp": 88,
+   "attack": 110,
+   "defense": 60,
+   "special-attack": 55,
+   "special-defense": 60,
+   "speed": 45
+  },
+  "flavor": "When it finds a trace of its prey, it patiently stakes out the location...but it’s always snoozing by nightfall."
+ },
+ {
+  "id": 736,
+  "name": "grubbin",
+  "types": [
+   "bug"
+  ],
+  "height": 4,
+  "weight": 44,
+  "stats": {
+   "hp": 47,
+   "attack": 62,
+   "defense": 45,
+   "special-attack": 55,
+   "special-defense": 45,
+   "speed": 46
+  },
+  "flavor": "Its strong jaw enables it to scrape trees and slurp out the sap. It normally lives underground."
+ },
+ {
+  "id": 737,
+  "name": "charjabug",
+  "types": [
+   "bug",
+   "electric"
+  ],
+  "height": 5,
+  "weight": 105,
+  "stats": {
+   "hp": 57,
+   "attack": 82,
+   "defense": 95,
+   "special-attack": 55,
+   "special-defense": 75,
+   "speed": 36
+  },
+  "flavor": "Its body is capable of storing electricity. On camping trips, people are grateful to have one around."
+ },
+ {
+  "id": 738,
+  "name": "vikavolt",
+  "types": [
+   "bug",
+   "electric"
+  ],
+  "height": 15,
+  "weight": 450,
+  "stats": {
+   "hp": 77,
+   "attack": 70,
+   "defense": 90,
+   "special-attack": 145,
+   "special-defense": 75,
+   "speed": 43
+  },
+  "flavor": "It zips around, on sharp lookout for an opening. It concentrates electrical energy within its large jaws and uses it to zap its enemies."
+ },
+ {
+  "id": 739,
+  "name": "crabrawler",
+  "types": [
+   "fighting"
+  ],
+  "height": 6,
+  "weight": 70,
+  "stats": {
+   "hp": 47,
+   "attack": 82,
+   "defense": 57,
+   "special-attack": 42,
+   "special-defense": 47,
+   "speed": 63
+  },
+  "flavor": "While guarding its weak points with its pincers, it looks for an opening and unleashes punches. When it loses, it foams at the mouth and faints."
+ },
+ {
+  "id": 740,
+  "name": "crabominable",
+  "types": [
+   "fighting",
+   "ice"
+  ],
+  "height": 17,
+  "weight": 1800,
+  "stats": {
+   "hp": 97,
+   "attack": 132,
+   "defense": 77,
+   "special-attack": 62,
+   "special-defense": 67,
+   "speed": 43
+  },
+  "flavor": "It aimed for the top but got lost and ended up on a snowy mountain. Being forced to endure the cold, this Pokémon evolved and grew fur."
+ },
+ {
+  "id": 741,
+  "name": "oricorio-baile",
+  "types": [
+   "fire",
+   "flying"
+  ],
+  "height": 6,
+  "weight": 34,
+  "stats": {
+   "hp": 75,
+   "attack": 70,
+   "defense": 70,
+   "special-attack": 98,
+   "special-defense": 70,
+   "speed": 93
+  },
+  "flavor": "It beats its wings together to create fire. As it moves in the steps of its beautiful dance, it bathes opponents in intense flames."
+ },
+ {
+  "id": 742,
+  "name": "cutiefly",
+  "types": [
+   "bug",
+   "fairy"
+  ],
+  "height": 1,
+  "weight": 2,
+  "stats": {
+   "hp": 40,
+   "attack": 45,
+   "defense": 40,
+   "special-attack": 55,
+   "special-defense": 40,
+   "speed": 84
+  },
+  "flavor": "It feeds on the nectar and pollen of flowers. Because it’s able to sense auras, it can identify which flowers are about to bloom."
+ },
+ {
+  "id": 743,
+  "name": "ribombee",
+  "types": [
+   "bug",
+   "fairy"
+  ],
+  "height": 2,
+  "weight": 5,
+  "stats": {
+   "hp": 60,
+   "attack": 55,
+   "defense": 60,
+   "special-attack": 95,
+   "special-defense": 70,
+   "speed": 124
+  },
+  "flavor": "It rolls up pollen into puffs. It makes many different varieties, some used as food and others used in battle."
+ },
+ {
+  "id": 744,
+  "name": "rockruff",
+  "types": [
+   "rock"
+  ],
+  "height": 5,
+  "weight": 92,
+  "stats": {
+   "hp": 45,
+   "attack": 65,
+   "defense": 40,
+   "special-attack": 30,
+   "special-defense": 40,
+   "speed": 60
+  },
+  "flavor": "It’s considered to be a good Pokémon for beginners because of its friendliness, but its disposition grows rougher as it grows up."
+ },
+ {
+  "id": 745,
+  "name": "lycanroc-midday",
+  "types": [
+   "rock"
+  ],
+  "height": 8,
+  "weight": 250,
+  "stats": {
+   "hp": 75,
+   "attack": 115,
+   "defense": 65,
+   "special-attack": 55,
+   "special-defense": 65,
+   "speed": 112
+  },
+  "flavor": "Its quick movements confuse its enemies. Well equipped with claws and fangs, it also uses the sharp rocks in its mane as weapons."
+ },
+ {
+  "id": 746,
+  "name": "wishiwashi-solo",
+  "types": [
+   "water"
+  ],
+  "height": 2,
+  "weight": 3,
+  "stats": {
+   "hp": 45,
+   "attack": 20,
+   "defense": 20,
+   "special-attack": 25,
+   "special-defense": 25,
+   "speed": 40
+  },
+  "flavor": "When it’s in trouble, its eyes moisten and begin to shine. The shining light attracts its comrades, and they stand together against their enemies."
+ },
+ {
+  "id": 747,
+  "name": "mareanie",
+  "types": [
+   "poison",
+   "water"
+  ],
+  "height": 4,
+  "weight": 80,
+  "stats": {
+   "hp": 50,
+   "attack": 53,
+   "defense": 62,
+   "special-attack": 43,
+   "special-defense": 52,
+   "speed": 45
+  },
+  "flavor": "It plunges the poison spike on its head into its prey. When the prey has weakened, Mareanie deals the finishing blow with its 10 tentacles."
+ },
+ {
+  "id": 748,
+  "name": "toxapex",
+  "types": [
+   "poison",
+   "water"
+  ],
+  "height": 7,
+  "weight": 145,
+  "stats": {
+   "hp": 50,
+   "attack": 63,
+   "defense": 152,
+   "special-attack": 53,
+   "special-defense": 142,
+   "speed": 35
+  },
+  "flavor": "Toxapex crawls along the ocean floor on its 12 legs. It leaves a trail of Corsola bits scattered in its wake."
+ },
+ {
+  "id": 749,
+  "name": "mudbray",
+  "types": [
+   "ground"
+  ],
+  "height": 10,
+  "weight": 1100,
+  "stats": {
+   "hp": 70,
+   "attack": 100,
+   "defense": 70,
+   "special-attack": 45,
+   "special-defense": 55,
+   "speed": 45
+  },
+  "flavor": "The mud stuck to Mudbray’s hooves enhances its grip and its powerful running gait."
+ },
+ {
+  "id": 750,
+  "name": "mudsdale",
+  "types": [
+   "ground"
+  ],
+  "height": 25,
+  "weight": 9200,
+  "stats": {
+   "hp": 100,
+   "attack": 125,
+   "defense": 100,
+   "special-attack": 55,
+   "special-defense": 85,
+   "speed": 35
+  },
+  "flavor": "It spits a mud that provides resistance to both wind and rain, so the walls of old houses were often coated with it."
+ },
+ {
+  "id": 751,
+  "name": "dewpider",
+  "types": [
+   "water",
+   "bug"
+  ],
+  "height": 3,
+  "weight": 40,
+  "stats": {
+   "hp": 38,
+   "attack": 40,
+   "defense": 52,
+   "special-attack": 40,
+   "special-defense": 72,
+   "speed": 27
+  },
+  "flavor": "It crawls onto the land in search of food. Its water bubble allows it to breathe and protects its soft head."
+ },
+ {
+  "id": 752,
+  "name": "araquanid",
+  "types": [
+   "water",
+   "bug"
+  ],
+  "height": 18,
+  "weight": 820,
+  "stats": {
+   "hp": 68,
+   "attack": 70,
+   "defense": 92,
+   "special-attack": 50,
+   "special-defense": 132,
+   "speed": 42
+  },
+  "flavor": "It delivers headbutts with the water bubble on its head. Small Pokémon get sucked into the bubble, where they drown."
+ },
+ {
+  "id": 753,
+  "name": "fomantis",
+  "types": [
+   "grass"
+  ],
+  "height": 3,
+  "weight": 15,
+  "stats": {
+   "hp": 40,
+   "attack": 55,
+   "defense": 35,
+   "special-attack": 50,
+   "special-defense": 35,
+   "speed": 35
+  },
+  "flavor": "During the day, it sleeps and soaks up light. When night falls, it walks around looking for a safer place to sleep."
+ },
+ {
+  "id": 754,
+  "name": "lurantis",
+  "types": [
+   "grass"
+  ],
+  "height": 9,
+  "weight": 185,
+  "stats": {
+   "hp": 70,
+   "attack": 105,
+   "defense": 90,
+   "special-attack": 80,
+   "special-defense": 90,
+   "speed": 45
+  },
+  "flavor": "It requires a lot of effort to maintain Lurantis’s vivid coloring, but some collectors enjoy this work and treat it as their hobby."
+ },
+ {
+  "id": 755,
+  "name": "morelull",
+  "types": [
+   "grass",
+   "fairy"
+  ],
+  "height": 2,
+  "weight": 15,
+  "stats": {
+   "hp": 40,
+   "attack": 35,
+   "defense": 55,
+   "special-attack": 65,
+   "special-defense": 75,
+   "speed": 15
+  },
+  "flavor": "It scatters spores that flicker and glow. Anyone seeing these lights falls into a deep slumber."
+ },
+ {
+  "id": 756,
+  "name": "shiinotic",
+  "types": [
+   "grass",
+   "fairy"
+  ],
+  "height": 10,
+  "weight": 115,
+  "stats": {
+   "hp": 60,
+   "attack": 45,
+   "defense": 80,
+   "special-attack": 90,
+   "special-defense": 100,
+   "speed": 30
+  },
+  "flavor": "Forests where Shiinotic live are treacherous to enter at night. People confused by its strange lights can never find their way home again."
+ },
+ {
+  "id": 757,
+  "name": "salandit",
+  "types": [
+   "poison",
+   "fire"
+  ],
+  "height": 6,
+  "weight": 48,
+  "stats": {
+   "hp": 48,
+   "attack": 44,
+   "defense": 40,
+   "special-attack": 71,
+   "special-defense": 40,
+   "speed": 77
+  },
+  "flavor": "It burns its bodily fluids to create a poisonous gas. When its enemies become disoriented from inhaling the gas, it attacks them."
+ },
+ {
+  "id": 758,
+  "name": "salazzle",
+  "types": [
+   "poison",
+   "fire"
+  ],
+  "height": 12,
+  "weight": 222,
+  "stats": {
+   "hp": 68,
+   "attack": 64,
+   "defense": 60,
+   "special-attack": 111,
+   "special-defense": 60,
+   "speed": 117
+  },
+  "flavor": "For some reason, only females have been found. It creates a reverse harem of male Salandit that it lives with."
+ },
+ {
+  "id": 759,
+  "name": "stufful",
+  "types": [
+   "normal",
+   "fighting"
+  ],
+  "height": 5,
+  "weight": 68,
+  "stats": {
+   "hp": 70,
+   "attack": 75,
+   "defense": 50,
+   "special-attack": 45,
+   "special-defense": 50,
+   "speed": 50
+  },
+  "flavor": "Despite its adorable appearance, when it gets angry and flails about, its arms and legs could knock a pro wrestler sprawling."
+ },
+ {
+  "id": 760,
+  "name": "bewear",
+  "types": [
+   "normal",
+   "fighting"
+  ],
+  "height": 21,
+  "weight": 1350,
+  "stats": {
+   "hp": 120,
+   "attack": 125,
+   "defense": 80,
+   "special-attack": 55,
+   "special-defense": 60,
+   "speed": 60
+  },
+  "flavor": "This immensely dangerous Pokémon possesses overwhelming physical strength. Its habitat is generally off-limits."
+ },
+ {
+  "id": 761,
+  "name": "bounsweet",
+  "types": [
+   "grass"
+  ],
+  "height": 3,
+  "weight": 32,
+  "stats": {
+   "hp": 42,
+   "attack": 30,
+   "defense": 38,
+   "special-attack": 30,
+   "special-defense": 38,
+   "speed": 32
+  },
+  "flavor": "A delectable aroma pours from its body. They are often swallowed whole by Toucannon lured by that wafting deliciousness."
+ },
+ {
+  "id": 762,
+  "name": "steenee",
+  "types": [
+   "grass"
+  ],
+  "height": 7,
+  "weight": 82,
+  "stats": {
+   "hp": 52,
+   "attack": 40,
+   "defense": 48,
+   "special-attack": 40,
+   "special-defense": 48,
+   "speed": 62
+  },
+  "flavor": "The sepals on its head developed to protect its body. These are quite hard, so even if pecked by bird Pokémon, this Pokémon is totally fine."
+ },
+ {
+  "id": 763,
+  "name": "tsareena",
+  "types": [
+   "grass"
+  ],
+  "height": 12,
+  "weight": 214,
+  "stats": {
+   "hp": 72,
+   "attack": 120,
+   "defense": 98,
+   "special-attack": 50,
+   "special-defense": 98,
+   "speed": 72
+  },
+  "flavor": "Its long, striking legs aren’t just for show but to be used to kick with skill. In victory, it shows off by kicking the defeated, laughing boisterously."
+ },
+ {
+  "id": 764,
+  "name": "comfey",
+  "types": [
+   "fairy"
+  ],
+  "height": 1,
+  "weight": 3,
+  "stats": {
+   "hp": 51,
+   "attack": 52,
+   "defense": 90,
+   "special-attack": 82,
+   "special-defense": 110,
+   "speed": 100
+  },
+  "flavor": "It attaches flowers to its highly nutritious vine. This revitalizes the flowers, and they give off an aromatic scent."
+ },
+ {
+  "id": 765,
+  "name": "oranguru",
+  "types": [
+   "normal",
+   "psychic"
+  ],
+  "height": 15,
+  "weight": 760,
+  "stats": {
+   "hp": 90,
+   "attack": 60,
+   "defense": 80,
+   "special-attack": 90,
+   "special-defense": 110,
+   "speed": 60
+  },
+  "flavor": "Known for its extreme intelligence, this Pokémon will look down on inexperienced Trainers, so it’s best suited to veteran Trainers."
+ },
+ {
+  "id": 766,
+  "name": "passimian",
+  "types": [
+   "fighting"
+  ],
+  "height": 20,
+  "weight": 828,
+  "stats": {
+   "hp": 100,
+   "attack": 120,
+   "defense": 90,
+   "special-attack": 40,
+   "special-defense": 60,
+   "speed": 80
+  },
+  "flavor": "They form groups of roughly 20 individuals. Their mutual bond is remarkable—they will never let down a comrade."
+ },
+ {
+  "id": 767,
+  "name": "wimpod",
+  "types": [
+   "bug",
+   "water"
+  ],
+  "height": 5,
+  "weight": 120,
+  "stats": {
+   "hp": 25,
+   "attack": 35,
+   "defense": 40,
+   "special-attack": 20,
+   "special-defense": 30,
+   "speed": 80
+  },
+  "flavor": "This Pokémon is a coward. As it desperately dashes off, the flailing of its many legs leaves a sparkling clean path in its wake."
+ },
+ {
+  "id": 768,
+  "name": "golisopod",
+  "types": [
+   "bug",
+   "water"
+  ],
+  "height": 20,
+  "weight": 1080,
+  "stats": {
+   "hp": 75,
+   "attack": 125,
+   "defense": 140,
+   "special-attack": 60,
+   "special-defense": 90,
+   "speed": 40
+  },
+  "flavor": "With a flashing slash of its giant sharp claws, it cleaves seawater—or even air—right in two."
+ },
+ {
+  "id": 769,
+  "name": "sandygast",
+  "types": [
+   "ghost",
+   "ground"
+  ],
+  "height": 5,
+  "weight": 700,
+  "stats": {
+   "hp": 55,
+   "attack": 55,
+   "defense": 80,
+   "special-attack": 70,
+   "special-defense": 45,
+   "speed": 15
+  },
+  "flavor": "Born from a sand mound playfully built by a child, this Pokémon embodies the grudges of the departed."
+ },
+ {
+  "id": 770,
+  "name": "palossand",
+  "types": [
+   "ghost",
+   "ground"
+  ],
+  "height": 13,
+  "weight": 2500,
+  "stats": {
+   "hp": 85,
+   "attack": 75,
+   "defense": 110,
+   "special-attack": 100,
+   "special-defense": 75,
+   "speed": 35
+  },
+  "flavor": "Possessed people controlled by this Pokémon transformed its sand mound into a castle. As it evolved, its power to curse grew ever stronger."
+ },
+ {
+  "id": 771,
+  "name": "pyukumuku",
+  "types": [
+   "water"
+  ],
+  "height": 3,
+  "weight": 12,
+  "stats": {
+   "hp": 55,
+   "attack": 60,
+   "defense": 130,
+   "special-attack": 30,
+   "special-defense": 130,
+   "speed": 5
+  },
+  "flavor": "It lives in shallow seas, such as areas near a beach. It can eject its internal organs, which it uses to engulf its prey or battle enemies."
+ },
+ {
+  "id": 772,
+  "name": "type-null",
+  "types": [
+   "normal"
+  ],
+  "height": 19,
+  "weight": 1205,
+  "stats": {
+   "hp": 95,
+   "attack": 95,
+   "defense": 95,
+   "special-attack": 95,
+   "special-defense": 95,
+   "speed": 59
+  },
+  "flavor": "The heavy control mask it wears suppresses its intrinsic capabilities. This Pokémon has some hidden special power."
+ },
+ {
+  "id": 773,
+  "name": "silvally",
+  "types": [
+   "normal"
+  ],
+  "height": 23,
+  "weight": 1005,
+  "stats": {
+   "hp": 95,
+   "attack": 95,
+   "defense": 95,
+   "special-attack": 95,
+   "special-defense": 95,
+   "speed": 95
+  },
+  "flavor": "Its trust in its partner is what awakens it. This Pokémon is capable of changing its type, a flexibility that is well displayed in battle."
+ },
+ {
+  "id": 774,
+  "name": "minior-red-meteor",
+  "types": [
+   "rock",
+   "flying"
+  ],
+  "height": 3,
+  "weight": 400,
+  "stats": {
+   "hp": 60,
+   "attack": 60,
+   "defense": 100,
+   "special-attack": 60,
+   "special-defense": 100,
+   "speed": 60
+  },
+  "flavor": "Originally making its home in the ozone layer, it hurtles to the ground when the shell enclosing its body grows too heavy."
+ },
+ {
+  "id": 775,
+  "name": "komala",
+  "types": [
+   "normal"
+  ],
+  "height": 4,
+  "weight": 199,
+  "stats": {
+   "hp": 65,
+   "attack": 115,
+   "defense": 65,
+   "special-attack": 75,
+   "special-defense": 95,
+   "speed": 65
+  },
+  "flavor": "It is born asleep, and it dies asleep. All its movements are apparently no more than the results of it tossing and turning in its dreams."
+ },
+ {
+  "id": 776,
+  "name": "turtonator",
+  "types": [
+   "fire",
+   "dragon"
+  ],
+  "height": 20,
+  "weight": 2120,
+  "stats": {
+   "hp": 60,
+   "attack": 78,
+   "defense": 135,
+   "special-attack": 91,
+   "special-defense": 85,
+   "speed": 36
+  },
+  "flavor": "The shell on its back is chemically unstable and explodes violently if struck. The hole in its stomach is its weak point."
+ },
+ {
+  "id": 777,
+  "name": "togedemaru",
+  "types": [
+   "electric",
+   "steel"
+  ],
+  "height": 3,
+  "weight": 33,
+  "stats": {
+   "hp": 65,
+   "attack": 98,
+   "defense": 63,
+   "special-attack": 40,
+   "special-defense": 73,
+   "speed": 96
+  },
+  "flavor": "The spiny fur on its back is normally at rest. When this Pokémon becomes agitated, its fur stands on end and stabs into its attackers."
+ },
+ {
+  "id": 778,
+  "name": "mimikyu-disguised",
+  "types": [
+   "ghost",
+   "fairy"
+  ],
+  "height": 2,
+  "weight": 7,
+  "stats": {
+   "hp": 55,
+   "attack": 90,
+   "defense": 80,
+   "special-attack": 50,
+   "special-defense": 105,
+   "speed": 96
+  },
+  "flavor": "Its actual appearance is unknown. A scholar who saw what was under its rag was overwhelmed by terror and died from the shock."
+ },
+ {
+  "id": 779,
+  "name": "bruxish",
+  "types": [
+   "water",
+   "psychic"
+  ],
+  "height": 9,
+  "weight": 190,
+  "stats": {
+   "hp": 68,
+   "attack": 105,
+   "defense": 70,
+   "special-attack": 70,
+   "special-defense": 70,
+   "speed": 92
+  },
+  "flavor": "When it unleashes its psychic power from the protuberance on its head, the grating sound of grinding teeth echoes through the area."
+ },
+ {
+  "id": 780,
+  "name": "drampa",
+  "types": [
+   "normal",
+   "dragon"
+  ],
+  "height": 30,
+  "weight": 1850,
+  "stats": {
+   "hp": 78,
+   "attack": 60,
+   "defense": 85,
+   "special-attack": 135,
+   "special-defense": 91,
+   "speed": 36
+  },
+  "flavor": "It has a compassionate personality, but if it is angered, it completely destroys its surroundings with its intense breath."
+ },
+ {
+  "id": 781,
+  "name": "dhelmise",
+  "types": [
+   "ghost",
+   "grass"
+  ],
+  "height": 39,
+  "weight": 2100,
+  "stats": {
+   "hp": 70,
+   "attack": 131,
+   "defense": 100,
+   "special-attack": 86,
+   "special-defense": 90,
+   "speed": 40
+  },
+  "flavor": "Swinging its massive anchor, it can KO Wailord in a single blow. What appears to be green seaweed is actually its body."
+ },
+ {
+  "id": 782,
+  "name": "jangmo-o",
+  "types": [
+   "dragon"
+  ],
+  "height": 6,
+  "weight": 297,
+  "stats": {
+   "hp": 45,
+   "attack": 55,
+   "defense": 65,
+   "special-attack": 45,
+   "special-defense": 45,
+   "speed": 45
+  },
+  "flavor": "It expresses its feelings by smacking its scales. Metallic sounds echo through the tall mountains where Jangmo-o lives."
+ },
+ {
+  "id": 783,
+  "name": "hakamo-o",
+  "types": [
+   "dragon",
+   "fighting"
+  ],
+  "height": 12,
+  "weight": 470,
+  "stats": {
+   "hp": 55,
+   "attack": 75,
+   "defense": 90,
+   "special-attack": 65,
+   "special-defense": 70,
+   "speed": 65
+  },
+  "flavor": "It leaps at its prey with a courageous shout. Its scaly punches tear its opponents to shreds."
+ },
+ {
+  "id": 784,
+  "name": "kommo-o",
+  "types": [
+   "dragon",
+   "fighting"
+  ],
+  "height": 16,
+  "weight": 782,
+  "stats": {
+   "hp": 75,
+   "attack": 110,
+   "defense": 125,
+   "special-attack": 100,
+   "special-defense": 105,
+   "speed": 85
+  },
+  "flavor": "When it spots enemies, it threatens them by jingling the scales on its tail. Weak opponents will crack and flee in panic."
+ },
+ {
+  "id": 785,
+  "name": "tapu-koko",
+  "types": [
+   "electric",
+   "fairy"
+  ],
+  "height": 18,
+  "weight": 205,
+  "stats": {
+   "hp": 70,
+   "attack": 115,
+   "defense": 85,
+   "special-attack": 95,
+   "special-defense": 75,
+   "speed": 130
+  },
+  "flavor": "This guardian deity of Melemele is brimming with curiosity. It summons thunderclouds and stores their lightning inside its body."
+ },
+ {
+  "id": 786,
+  "name": "tapu-lele",
+  "types": [
+   "psychic",
+   "fairy"
+  ],
+  "height": 12,
+  "weight": 186,
+  "stats": {
+   "hp": 70,
+   "attack": 85,
+   "defense": 75,
+   "special-attack": 130,
+   "special-defense": 115,
+   "speed": 95
+  },
+  "flavor": "This guardian deity of Akala is guilelessly cruel. The fragrant aroma of flowers is the source of its energy."
+ },
+ {
+  "id": 787,
+  "name": "tapu-bulu",
+  "types": [
+   "grass",
+   "fairy"
+  ],
+  "height": 19,
+  "weight": 455,
+  "stats": {
+   "hp": 70,
+   "attack": 130,
+   "defense": 115,
+   "special-attack": 85,
+   "special-defense": 95,
+   "speed": 75
+  },
+  "flavor": "It pulls large trees up by the roots and swings them around. It causes vegetation to grow, and then it absorbs energy from the growth."
+ },
+ {
+  "id": 788,
+  "name": "tapu-fini",
+  "types": [
+   "water",
+   "fairy"
+  ],
+  "height": 13,
+  "weight": 212,
+  "stats": {
+   "hp": 70,
+   "attack": 75,
+   "defense": 115,
+   "special-attack": 95,
+   "special-defense": 130,
+   "speed": 85
+  },
+  "flavor": "The dense fog it creates brings the downfall and destruction of its confused enemies. Ocean currents are the source of its energy."
+ },
+ {
+  "id": 789,
+  "name": "cosmog",
+  "types": [
+   "psychic"
+  ],
+  "height": 2,
+  "weight": 1,
+  "stats": {
+   "hp": 43,
+   "attack": 29,
+   "defense": 31,
+   "special-attack": 29,
+   "special-defense": 31,
+   "speed": 37
+  },
+  "flavor": "Its body is gaseous and frail. It slowly grows as it collects dust from the atmosphere."
+ },
+ {
+  "id": 790,
+  "name": "cosmoem",
+  "types": [
+   "psychic"
+  ],
+  "height": 1,
+  "weight": 9999,
+  "stats": {
+   "hp": 43,
+   "attack": 29,
+   "defense": 131,
+   "special-attack": 29,
+   "special-defense": 131,
+   "speed": 37
+  },
+  "flavor": "Motionless as if dead, its body is faintly warm to the touch. In the distant past, it was called the cocoon of the stars."
+ },
+ {
+  "id": 791,
+  "name": "solgaleo",
+  "types": [
+   "psychic",
+   "steel"
+  ],
+  "height": 34,
+  "weight": 2300,
+  "stats": {
+   "hp": 137,
+   "attack": 137,
+   "defense": 107,
+   "special-attack": 113,
+   "special-defense": 89,
+   "speed": 97
+  },
+  "flavor": "It is said to live in another world. The intense light it radiates from the surface of its body can make the darkest of nights light up like midday."
+ },
+ {
+  "id": 792,
+  "name": "lunala",
+  "types": [
+   "psychic",
+   "ghost"
+  ],
+  "height": 40,
+  "weight": 1200,
+  "stats": {
+   "hp": 137,
+   "attack": 113,
+   "defense": 89,
+   "special-attack": 137,
+   "special-defense": 107,
+   "speed": 97
+  },
+  "flavor": "It is said to be a female evolution of Cosmog. When its third eye activates, away it flies to another world."
+ },
+ {
+  "id": 793,
+  "name": "nihilego",
+  "types": [
+   "rock",
+   "poison"
+  ],
+  "height": 12,
+  "weight": 555,
+  "stats": {
+   "hp": 109,
+   "attack": 53,
+   "defense": 47,
+   "special-attack": 127,
+   "special-defense": 131,
+   "speed": 103
+  },
+  "flavor": "One of several mysterious Ultra Beasts. People on the street report observing those infested by it suddenly becoming violent."
+ },
+ {
+  "id": 794,
+  "name": "buzzwole",
+  "types": [
+   "bug",
+   "fighting"
+  ],
+  "height": 24,
+  "weight": 3336,
+  "stats": {
+   "hp": 107,
+   "attack": 139,
+   "defense": 139,
+   "special-attack": 53,
+   "special-defense": 53,
+   "speed": 79
+  },
+  "flavor": "This Ultra Beast appeared from another world. It shows off its body, but whether that display is a boast or a threat remains unclear."
+ },
+ {
+  "id": 795,
+  "name": "pheromosa",
+  "types": [
+   "bug",
+   "fighting"
+  ],
+  "height": 18,
+  "weight": 250,
+  "stats": {
+   "hp": 71,
+   "attack": 137,
+   "defense": 37,
+   "special-attack": 137,
+   "special-defense": 37,
+   "speed": 151
+  },
+  "flavor": "One of the dangerous Ultra Beasts, it has been spotted running across the land at terrific speeds."
+ },
+ {
+  "id": 796,
+  "name": "xurkitree",
+  "types": [
+   "electric"
+  ],
+  "height": 38,
+  "weight": 1000,
+  "stats": {
+   "hp": 83,
+   "attack": 89,
+   "defense": 71,
+   "special-attack": 173,
+   "special-defense": 71,
+   "speed": 83
+  },
+  "flavor": "One of the mysterious life-forms known as Ultra Beasts. Astonishing electric shocks emanate from its entire body, according to witnesses."
+ },
+ {
+  "id": 797,
+  "name": "celesteela",
+  "types": [
+   "steel",
+   "flying"
+  ],
+  "height": 92,
+  "weight": 9999,
+  "stats": {
+   "hp": 97,
+   "attack": 101,
+   "defense": 103,
+   "special-attack": 107,
+   "special-defense": 101,
+   "speed": 61
+  },
+  "flavor": "It appeared from the Ultra Wormhole. Witnesses observed it flying across the sky at high speed."
+ },
+ {
+  "id": 798,
+  "name": "kartana",
+  "types": [
+   "grass",
+   "steel"
+  ],
+  "height": 3,
+  "weight": 1,
+  "stats": {
+   "hp": 59,
+   "attack": 181,
+   "defense": 131,
+   "special-attack": 59,
+   "special-defense": 31,
+   "speed": 109
+  },
+  "flavor": "This Ultra Beast came from the Ultra Wormhole. It seems not to attack enemies on its own, but its sharp body is a dangerous weapon in itself."
+ },
+ {
+  "id": 799,
+  "name": "guzzlord",
+  "types": [
+   "dark",
+   "dragon"
+  ],
+  "height": 55,
+  "weight": 8880,
+  "stats": {
+   "hp": 223,
+   "attack": 101,
+   "defense": 53,
+   "special-attack": 97,
+   "special-defense": 53,
+   "speed": 43
+  },
+  "flavor": "It has gobbled mountains and swallowed whole buildings, according to reports. It’s one of the Ultra Beasts."
+ },
+ {
+  "id": 800,
+  "name": "necrozma",
+  "types": [
+   "psychic"
+  ],
+  "height": 24,
+  "weight": 2300,
+  "stats": {
+   "hp": 97,
+   "attack": 107,
+   "defense": 101,
+   "special-attack": 127,
+   "special-defense": 89,
+   "speed": 79
+  },
+  "flavor": "Reminiscent of the Ultra Beasts, this life-form, apparently asleep underground, is thought to have come from another world in ancient times."
+ },
+ {
+  "id": 801,
+  "name": "magearna",
+  "types": [
+   "steel",
+   "fairy"
+  ],
+  "height": 10,
+  "weight": 805,
+  "stats": {
+   "hp": 80,
+   "attack": 95,
+   "defense": 115,
+   "special-attack": 130,
+   "special-defense": 115,
+   "speed": 65
+  },
+  "flavor": "This artificial Pokémon, constructed more than 500 years ago, can understand human speech but cannot itself speak."
+ },
+ {
+  "id": 802,
+  "name": "marshadow",
+  "types": [
+   "fighting",
+   "ghost"
+  ],
+  "height": 7,
+  "weight": 222,
+  "stats": {
+   "hp": 90,
+   "attack": 125,
+   "defense": 80,
+   "special-attack": 90,
+   "special-defense": 90,
+   "speed": 125
+  },
+  "flavor": "Able to conceal itself in shadows, it never appears before humans, so its very existence was the stuff of myth."
+ },
+ {
+  "id": 803,
+  "name": "poipole",
+  "types": [
+   "poison"
+  ],
+  "height": 6,
+  "weight": 18,
+  "stats": {
+   "hp": 67,
+   "attack": 73,
+   "defense": 67,
+   "special-attack": 73,
+   "special-defense": 67,
+   "speed": 73
+  },
+  "flavor": "This Ultra Beast is well enough liked to be chosen as a first partner in its own world."
+ },
+ {
+  "id": 804,
+  "name": "naganadel",
+  "types": [
+   "poison",
+   "dragon"
+  ],
+  "height": 36,
+  "weight": 1500,
+  "stats": {
+   "hp": 73,
+   "attack": 73,
+   "defense": 73,
+   "special-attack": 127,
+   "special-defense": 73,
+   "speed": 121
+  },
+  "flavor": "It stores hundreds of liters of poisonous liquid inside its body. It is one of the organisms known as UBs."
+ },
+ {
+  "id": 805,
+  "name": "stakataka",
+  "types": [
+   "rock",
+   "steel"
+  ],
+  "height": 55,
+  "weight": 8200,
+  "stats": {
+   "hp": 61,
+   "attack": 131,
+   "defense": 211,
+   "special-attack": 53,
+   "special-defense": 101,
+   "speed": 13
+  },
+  "flavor": "It appeared from an Ultra Wormhole. Each one appears to be made up of many life-forms stacked one on top of each other."
+ },
+ {
+  "id": 806,
+  "name": "blacephalon",
+  "types": [
+   "fire",
+   "ghost"
+  ],
+  "height": 18,
+  "weight": 130,
+  "stats": {
+   "hp": 53,
+   "attack": 127,
+   "defense": 53,
+   "special-attack": 151,
+   "special-defense": 79,
+   "speed": 107
+  },
+  "flavor": "It slithers toward people. Then, without warning, it triggers the explosion of its own head. It’s apparently one kind of Ultra Beast."
+ },
+ {
+  "id": 807,
+  "name": "zeraora",
+  "types": [
+   "electric"
+  ],
+  "height": 15,
+  "weight": 445,
+  "stats": {
+   "hp": 88,
+   "attack": 112,
+   "defense": 75,
+   "special-attack": 102,
+   "special-defense": 80,
+   "speed": 143
+  },
+  "flavor": "It electrifies its claws and tears its opponents apart with them. Even if they dodge its attack, they’ll be electrocuted by the flying sparks."
+ },
+ {
+  "id": 808,
+  "name": "meltan",
+  "types": [
+   "steel"
+  ],
+  "height": 2,
+  "weight": 80,
+  "stats": {
+   "hp": 46,
+   "attack": 65,
+   "defense": 65,
+   "special-attack": 55,
+   "special-defense": 35,
+   "speed": 34
+  },
+  "flavor": "It dissolves and eats metal. Circulating liquid metal within its body is how it generates energy."
+ },
+ {
+  "id": 809,
+  "name": "melmetal",
+  "types": [
+   "steel"
+  ],
+  "height": 25,
+  "weight": 8000,
+  "stats": {
+   "hp": 135,
+   "attack": 143,
+   "defense": 143,
+   "special-attack": 80,
+   "special-defense": 65,
+   "speed": 34
+  },
+  "flavor": "Revered long ago for its capacity to create iron from nothing, for some reason it has come back to life after 3,000 years."
+ },
+ {
+  "id": 810,
+  "name": "grookey",
+  "types": [
+   "grass"
+  ],
+  "height": 3,
+  "weight": 50,
+  "stats": {
+   "hp": 50,
+   "attack": 65,
+   "defense": 50,
+   "special-attack": 40,
+   "special-defense": 40,
+   "speed": 65
+  },
+  "flavor": "When it uses its special stick to strike up a beat, the sound waves produced carry revitalizing energy to the plants and flowers in the area."
+ },
+ {
+  "id": 811,
+  "name": "thwackey",
+  "types": [
+   "grass"
+  ],
+  "height": 7,
+  "weight": 140,
+  "stats": {
+   "hp": 70,
+   "attack": 85,
+   "defense": 70,
+   "special-attack": 55,
+   "special-defense": 60,
+   "speed": 80
+  },
+  "flavor": "The faster a Thwackey can beat out a rhythm with its two sticks, the more respect it wins from its peers."
+ },
+ {
+  "id": 812,
+  "name": "rillaboom",
+  "types": [
+   "grass"
+  ],
+  "height": 21,
+  "weight": 900,
+  "stats": {
+   "hp": 100,
+   "attack": 125,
+   "defense": 90,
+   "special-attack": 60,
+   "special-defense": 70,
+   "speed": 85
+  },
+  "flavor": "By drumming, it taps into the power of its special tree stump. The roots of the stump follow its direction in battle."
+ },
+ {
+  "id": 813,
+  "name": "scorbunny",
+  "types": [
+   "fire"
+  ],
+  "height": 3,
+  "weight": 45,
+  "stats": {
+   "hp": 50,
+   "attack": 71,
+   "defense": 40,
+   "special-attack": 40,
+   "special-defense": 40,
+   "speed": 69
+  },
+  "flavor": "A warm-up of running around gets fire energy coursing through this Pokémon’s body. Once that happens, it’s ready to fight at full power."
+ },
+ {
+  "id": 814,
+  "name": "raboot",
+  "types": [
+   "fire"
+  ],
+  "height": 6,
+  "weight": 90,
+  "stats": {
+   "hp": 65,
+   "attack": 86,
+   "defense": 60,
+   "special-attack": 55,
+   "special-defense": 60,
+   "speed": 94
+  },
+  "flavor": "Its thick and fluffy fur protects it from the cold and enables it to use hotter fire moves."
+ },
+ {
+  "id": 815,
+  "name": "cinderace",
+  "types": [
+   "fire"
+  ],
+  "height": 14,
+  "weight": 330,
+  "stats": {
+   "hp": 80,
+   "attack": 116,
+   "defense": 75,
+   "special-attack": 65,
+   "special-defense": 75,
+   "speed": 119
+  },
+  "flavor": "It juggles a pebble with its feet, turning it into a burning soccer ball. Its shots strike opponents hard and leave them scorched."
+ },
+ {
+  "id": 816,
+  "name": "sobble",
+  "types": [
+   "water"
+  ],
+  "height": 3,
+  "weight": 40,
+  "stats": {
+   "hp": 50,
+   "attack": 40,
+   "defense": 40,
+   "special-attack": 70,
+   "special-defense": 40,
+   "speed": 70
+  },
+  "flavor": "When scared, this Pokémon cries. Its tears pack the chemical punch of 100 onions, and attackers won’t be able to resist weeping."
+ },
+ {
+  "id": 817,
+  "name": "drizzile",
+  "types": [
+   "water"
+  ],
+  "height": 7,
+  "weight": 115,
+  "stats": {
+   "hp": 65,
+   "attack": 60,
+   "defense": 55,
+   "special-attack": 95,
+   "special-defense": 55,
+   "speed": 90
+  },
+  "flavor": "A clever combatant, this Pokémon battles using water balloons created with moisture secreted from its palms."
+ },
+ {
+  "id": 818,
+  "name": "inteleon",
+  "types": [
+   "water"
+  ],
+  "height": 19,
+  "weight": 452,
+  "stats": {
+   "hp": 70,
+   "attack": 85,
+   "defense": 65,
+   "special-attack": 125,
+   "special-defense": 65,
+   "speed": 120
+  },
+  "flavor": "It has many hidden capabilities, such as fingertips that can shoot water and a membrane on its back that it can use to glide through the air."
+ },
+ {
+  "id": 819,
+  "name": "skwovet",
+  "types": [
+   "normal"
+  ],
+  "height": 3,
+  "weight": 25,
+  "stats": {
+   "hp": 70,
+   "attack": 55,
+   "defense": 55,
+   "special-attack": 35,
+   "special-defense": 35,
+   "speed": 25
+  },
+  "flavor": "Found throughout the Galar region, this Pokémon becomes uneasy if its cheeks are ever completely empty of berries."
+ },
+ {
+  "id": 820,
+  "name": "greedent",
+  "types": [
+   "normal"
+  ],
+  "height": 6,
+  "weight": 60,
+  "stats": {
+   "hp": 120,
+   "attack": 95,
+   "defense": 95,
+   "special-attack": 55,
+   "special-defense": 75,
+   "speed": 20
+  },
+  "flavor": "It stashes berries in its tail—so many berries that they fall out constantly. But this Pokémon is a bit slow-witted, so it doesn’t notice the loss."
+ },
+ {
+  "id": 821,
+  "name": "rookidee",
+  "types": [
+   "flying"
+  ],
+  "height": 2,
+  "weight": 18,
+  "stats": {
+   "hp": 38,
+   "attack": 47,
+   "defense": 35,
+   "special-attack": 33,
+   "special-defense": 35,
+   "speed": 57
+  },
+  "flavor": "It will bravely challenge any opponent, no matter how powerful. This Pokémon benefits from every battle—even a defeat increases its strength a bit."
+ },
+ {
+  "id": 822,
+  "name": "corvisquire",
+  "types": [
+   "flying"
+  ],
+  "height": 8,
+  "weight": 160,
+  "stats": {
+   "hp": 68,
+   "attack": 67,
+   "defense": 55,
+   "special-attack": 43,
+   "special-defense": 55,
+   "speed": 77
+  },
+  "flavor": "Smart enough to use tools in battle, these Pokémon have been seen picking up rocks and flinging them or using ropes to wrap up enemies."
+ },
+ {
+  "id": 823,
+  "name": "corviknight",
+  "types": [
+   "flying",
+   "steel"
+  ],
+  "height": 22,
+  "weight": 750,
+  "stats": {
+   "hp": 98,
+   "attack": 87,
+   "defense": 105,
+   "special-attack": 53,
+   "special-defense": 85,
+   "speed": 67
+  },
+  "flavor": "This Pokémon reigns supreme in the skies of the Galar region. The black luster of its steel body could drive terror into the heart of any foe."
+ },
+ {
+  "id": 824,
+  "name": "blipbug",
+  "types": [
+   "bug"
+  ],
+  "height": 4,
+  "weight": 80,
+  "stats": {
+   "hp": 25,
+   "attack": 20,
+   "defense": 20,
+   "special-attack": 25,
+   "special-defense": 45,
+   "speed": 45
+  },
+  "flavor": "A constant collector of information, this Pokémon is very smart. Very strong is what it isn’t."
+ },
+ {
+  "id": 825,
+  "name": "dottler",
+  "types": [
+   "bug",
+   "psychic"
+  ],
+  "height": 4,
+  "weight": 195,
+  "stats": {
+   "hp": 50,
+   "attack": 35,
+   "defense": 80,
+   "special-attack": 50,
+   "special-defense": 90,
+   "speed": 30
+  },
+  "flavor": "It barely moves, but it’s still alive. Hiding in its shell without food or water seems to have awakened its psychic powers."
+ },
+ {
+  "id": 826,
+  "name": "orbeetle",
+  "types": [
+   "bug",
+   "psychic"
+  ],
+  "height": 4,
+  "weight": 408,
+  "stats": {
+   "hp": 60,
+   "attack": 45,
+   "defense": 110,
+   "special-attack": 80,
+   "special-defense": 120,
+   "speed": 90
+  },
+  "flavor": "It’s famous for its high level of intelligence, and the large size of its brain is proof that it also possesses immense psychic power."
+ },
+ {
+  "id": 827,
+  "name": "nickit",
+  "types": [
+   "dark"
+  ],
+  "height": 6,
+  "weight": 89,
+  "stats": {
+   "hp": 40,
+   "attack": 28,
+   "defense": 28,
+   "special-attack": 47,
+   "special-defense": 52,
+   "speed": 50
+  },
+  "flavor": "Aided by the soft pads on its feet, it silently raids the food stores of other Pokémon. It survives off its ill-gotten gains."
+ },
+ {
+  "id": 828,
+  "name": "thievul",
+  "types": [
+   "dark"
+  ],
+  "height": 12,
+  "weight": 199,
+  "stats": {
+   "hp": 70,
+   "attack": 58,
+   "defense": 58,
+   "special-attack": 87,
+   "special-defense": 92,
+   "speed": 90
+  },
+  "flavor": "It secretly marks potential targets with a scent. By following the scent, it stalks its targets and steals from them when they least expect it."
+ },
+ {
+  "id": 829,
+  "name": "gossifleur",
+  "types": [
+   "grass"
+  ],
+  "height": 4,
+  "weight": 22,
+  "stats": {
+   "hp": 40,
+   "attack": 40,
+   "defense": 60,
+   "special-attack": 40,
+   "special-defense": 60,
+   "speed": 10
+  },
+  "flavor": "It anchors itself in the ground with its single leg, then basks in the sun. After absorbing enough sunlight, its petals spread as it blooms brilliantly."
+ },
+ {
+  "id": 830,
+  "name": "eldegoss",
+  "types": [
+   "grass"
+  ],
+  "height": 5,
+  "weight": 25,
+  "stats": {
+   "hp": 60,
+   "attack": 50,
+   "defense": 90,
+   "special-attack": 80,
+   "special-defense": 120,
+   "speed": 60
+  },
+  "flavor": "The seeds attached to its cotton fluff are full of nutrients. It spreads them on the wind so that plants and other Pokémon can benefit from them."
+ },
+ {
+  "id": 831,
+  "name": "wooloo",
+  "types": [
+   "normal"
+  ],
+  "height": 6,
+  "weight": 60,
+  "stats": {
+   "hp": 42,
+   "attack": 40,
+   "defense": 55,
+   "special-attack": 40,
+   "special-defense": 45,
+   "speed": 48
+  },
+  "flavor": "Its curly fleece is such an effective cushion that this Pokémon could fall off a cliff and stand right back up at the bottom, unharmed."
+ },
+ {
+  "id": 832,
+  "name": "dubwool",
+  "types": [
+   "normal"
+  ],
+  "height": 13,
+  "weight": 430,
+  "stats": {
+   "hp": 72,
+   "attack": 80,
+   "defense": 100,
+   "special-attack": 60,
+   "special-defense": 90,
+   "speed": 88
+  },
+  "flavor": "Weave a carpet from its springy wool, and you end up with something closer to a trampoline. You’ll start to bounce the moment you set foot on it."
+ },
+ {
+  "id": 833,
+  "name": "chewtle",
+  "types": [
+   "water"
+  ],
+  "height": 3,
+  "weight": 85,
+  "stats": {
+   "hp": 50,
+   "attack": 64,
+   "defense": 50,
+   "special-attack": 38,
+   "special-defense": 38,
+   "speed": 44
+  },
+  "flavor": "Apparently the itch of its teething impels it to snap its jaws at anything in front of it."
+ },
+ {
+  "id": 834,
+  "name": "drednaw",
+  "types": [
+   "water",
+   "rock"
+  ],
+  "height": 10,
+  "weight": 1155,
+  "stats": {
+   "hp": 90,
+   "attack": 115,
+   "defense": 90,
+   "special-attack": 48,
+   "special-defense": 68,
+   "speed": 74
+  },
+  "flavor": "With jaws that can shear through steel rods, this highly aggressive Pokémon chomps down on its unfortunate prey."
+ },
+ {
+  "id": 835,
+  "name": "yamper",
+  "types": [
+   "electric"
+  ],
+  "height": 3,
+  "weight": 135,
+  "stats": {
+   "hp": 59,
+   "attack": 45,
+   "defense": 50,
+   "special-attack": 40,
+   "special-defense": 50,
+   "speed": 26
+  },
+  "flavor": "This Pokémon is very popular as a herding dog in the Galar region. As it runs, it generates electricity from the base of its tail."
+ },
+ {
+  "id": 836,
+  "name": "boltund",
+  "types": [
+   "electric"
+  ],
+  "height": 10,
+  "weight": 340,
+  "stats": {
+   "hp": 69,
+   "attack": 90,
+   "defense": 60,
+   "special-attack": 90,
+   "special-defense": 60,
+   "speed": 121
+  },
+  "flavor": "This Pokémon generates electricity and channels it into its legs to keep them going strong. Boltund can run nonstop for three full days."
+ },
+ {
+  "id": 837,
+  "name": "rolycoly",
+  "types": [
+   "rock"
+  ],
+  "height": 3,
+  "weight": 120,
+  "stats": {
+   "hp": 30,
+   "attack": 40,
+   "defense": 50,
+   "special-attack": 40,
+   "special-defense": 50,
+   "speed": 30
+  },
+  "flavor": "Most of its body has the same composition as coal. Fittingly, this Pokémon was first discovered in coal mines about 400 years ago."
+ },
+ {
+  "id": 838,
+  "name": "carkol",
+  "types": [
+   "rock",
+   "fire"
+  ],
+  "height": 11,
+  "weight": 780,
+  "stats": {
+   "hp": 80,
+   "attack": 60,
+   "defense": 90,
+   "special-attack": 60,
+   "special-defense": 70,
+   "speed": 50
+  },
+  "flavor": "It forms coal inside its body. Coal dropped by this Pokémon once helped fuel the lives of people in the Galar region."
+ },
+ {
+  "id": 839,
+  "name": "coalossal",
+  "types": [
+   "rock",
+   "fire"
+  ],
+  "height": 28,
+  "weight": 3105,
+  "stats": {
+   "hp": 110,
+   "attack": 80,
+   "defense": 120,
+   "special-attack": 80,
+   "special-defense": 90,
+   "speed": 30
+  },
+  "flavor": "It’s usually peaceful, but the vandalism of mines enrages it. Offenders will be incinerated with flames that reach 2,700 degrees Fahrenheit."
+ },
+ {
+  "id": 840,
+  "name": "applin",
+  "types": [
+   "grass",
+   "dragon"
+  ],
+  "height": 2,
+  "weight": 5,
+  "stats": {
+   "hp": 40,
+   "attack": 40,
+   "defense": 80,
+   "special-attack": 40,
+   "special-defense": 40,
+   "speed": 20
+  },
+  "flavor": "It spends its entire life inside an apple. It hides from its natural enemies, bird Pokémon, by pretending it’s just an apple and nothing more."
+ },
+ {
+  "id": 841,
+  "name": "flapple",
+  "types": [
+   "grass",
+   "dragon"
+  ],
+  "height": 3,
+  "weight": 10,
+  "stats": {
+   "hp": 70,
+   "attack": 110,
+   "defense": 80,
+   "special-attack": 95,
+   "special-defense": 60,
+   "speed": 70
+  },
+  "flavor": "It ate a sour apple, and that induced its evolution. In its cheeks, it stores an acid capable of causing chemical burns."
+ },
+ {
+  "id": 842,
+  "name": "appletun",
+  "types": [
+   "grass",
+   "dragon"
+  ],
+  "height": 4,
+  "weight": 130,
+  "stats": {
+   "hp": 110,
+   "attack": 85,
+   "defense": 80,
+   "special-attack": 100,
+   "special-defense": 80,
+   "speed": 30
+  },
+  "flavor": "Eating a sweet apple caused its evolution. A nectarous scent wafts from its body, luring in the bug Pokémon it preys on."
+ },
+ {
+  "id": 843,
+  "name": "silicobra",
+  "types": [
+   "ground"
+  ],
+  "height": 22,
+  "weight": 76,
+  "stats": {
+   "hp": 52,
+   "attack": 57,
+   "defense": 75,
+   "special-attack": 35,
+   "special-defense": 50,
+   "speed": 46
+  },
+  "flavor": "As it digs, it swallows sand and stores it in its neck pouch. The pouch can hold more than 17 pounds of sand."
+ },
+ {
+  "id": 844,
+  "name": "sandaconda",
+  "types": [
+   "ground"
+  ],
+  "height": 38,
+  "weight": 655,
+  "stats": {
+   "hp": 72,
+   "attack": 107,
+   "defense": 125,
+   "special-attack": 65,
+   "special-defense": 70,
+   "speed": 71
+  },
+  "flavor": "When it contracts its body, over 220 pounds of sand sprays from its nose. If it ever runs out of sand, it becomes disheartened."
+ },
+ {
+  "id": 845,
+  "name": "cramorant",
+  "types": [
+   "flying",
+   "water"
+  ],
+  "height": 8,
+  "weight": 180,
+  "stats": {
+   "hp": 70,
+   "attack": 85,
+   "defense": 55,
+   "special-attack": 85,
+   "special-defense": 95,
+   "speed": 85
+  },
+  "flavor": "It’s so strong that it can knock out some opponents in a single hit, but it also may forget what it’s battling midfight."
+ },
+ {
+  "id": 846,
+  "name": "arrokuda",
+  "types": [
+   "water"
+  ],
+  "height": 5,
+  "weight": 10,
+  "stats": {
+   "hp": 41,
+   "attack": 63,
+   "defense": 40,
+   "special-attack": 40,
+   "special-defense": 30,
+   "speed": 66
+  },
+  "flavor": "If it sees any movement around it, this Pokémon charges for it straightaway, leading with its sharply pointed jaw. It’s very proud of that jaw."
+ },
+ {
+  "id": 847,
+  "name": "barraskewda",
+  "types": [
+   "water"
+  ],
+  "height": 13,
+  "weight": 300,
+  "stats": {
+   "hp": 61,
+   "attack": 123,
+   "defense": 60,
+   "special-attack": 60,
+   "special-defense": 50,
+   "speed": 136
+  },
+  "flavor": "This Pokémon has a jaw that’s as sharp as a spear and as strong as steel. Apparently Barraskewda’s flesh is surprisingly tasty, too."
+ },
+ {
+  "id": 848,
+  "name": "toxel",
+  "types": [
+   "electric",
+   "poison"
+  ],
+  "height": 4,
+  "weight": 110,
+  "stats": {
+   "hp": 40,
+   "attack": 38,
+   "defense": 35,
+   "special-attack": 54,
+   "special-defense": 35,
+   "speed": 40
+  },
+  "flavor": "It stores poison in an internal poison sac and secretes that poison through its skin. If you touch this Pokémon, a tingling sensation follows."
+ },
+ {
+  "id": 849,
+  "name": "toxtricity-amped",
+  "types": [
+   "electric",
+   "poison"
+  ],
+  "height": 16,
+  "weight": 400,
+  "stats": {
+   "hp": 75,
+   "attack": 98,
+   "defense": 70,
+   "special-attack": 114,
+   "special-defense": 70,
+   "speed": 75
+  },
+  "flavor": "When this Pokémon sounds as if it’s strumming a guitar, it’s actually clawing at the protrusions on its chest to generate electricity."
+ },
+ {
+  "id": 850,
+  "name": "sizzlipede",
+  "types": [
+   "fire",
+   "bug"
+  ],
+  "height": 7,
+  "weight": 10,
+  "stats": {
+   "hp": 50,
+   "attack": 65,
+   "defense": 45,
+   "special-attack": 50,
+   "special-defense": 50,
+   "speed": 45
+  },
+  "flavor": "It stores flammable gas in its body and uses it to generate heat. The yellow sections on its belly get particularly hot."
+ },
+ {
+  "id": 851,
+  "name": "centiskorch",
+  "types": [
+   "fire",
+   "bug"
+  ],
+  "height": 30,
+  "weight": 1200,
+  "stats": {
+   "hp": 100,
+   "attack": 115,
+   "defense": 65,
+   "special-attack": 90,
+   "special-defense": 90,
+   "speed": 65
+  },
+  "flavor": "When it heats up, its body temperature reaches about 1,500 degrees Fahrenheit. It lashes its body like a whip and launches itself at enemies."
+ },
+ {
+  "id": 852,
+  "name": "clobbopus",
+  "types": [
+   "fighting"
+  ],
+  "height": 6,
+  "weight": 40,
+  "stats": {
+   "hp": 50,
+   "attack": 68,
+   "defense": 60,
+   "special-attack": 50,
+   "special-defense": 50,
+   "speed": 32
+  },
+  "flavor": "It’s very curious, but its means of investigating things is to try to punch them with its tentacles. The search for food is what brings it onto land."
+ },
+ {
+  "id": 853,
+  "name": "grapploct",
+  "types": [
+   "fighting"
+  ],
+  "height": 16,
+  "weight": 390,
+  "stats": {
+   "hp": 80,
+   "attack": 118,
+   "defense": 90,
+   "special-attack": 70,
+   "special-defense": 80,
+   "speed": 42
+  },
+  "flavor": "A body made up of nothing but muscle makes the grappling moves this Pokémon performs with its tentacles tremendously powerful."
+ },
+ {
+  "id": 854,
+  "name": "sinistea",
+  "types": [
+   "ghost"
+  ],
+  "height": 1,
+  "weight": 2,
+  "stats": {
+   "hp": 40,
+   "attack": 45,
+   "defense": 45,
+   "special-attack": 74,
+   "special-defense": 54,
+   "speed": 50
+  },
+  "flavor": "This Pokémon is said to have been born when a lonely spirit possessed a cold, leftover cup of tea."
+ },
+ {
+  "id": 855,
+  "name": "polteageist",
+  "types": [
+   "ghost"
+  ],
+  "height": 2,
+  "weight": 4,
+  "stats": {
+   "hp": 60,
+   "attack": 65,
+   "defense": 65,
+   "special-attack": 134,
+   "special-defense": 114,
+   "speed": 70
+  },
+  "flavor": "This species lives in antique teapots. Most pots are forgeries, but on rare occasions, an authentic work is found."
+ },
+ {
+  "id": 856,
+  "name": "hatenna",
+  "types": [
+   "psychic"
+  ],
+  "height": 4,
+  "weight": 34,
+  "stats": {
+   "hp": 42,
+   "attack": 30,
+   "defense": 45,
+   "special-attack": 56,
+   "special-defense": 53,
+   "speed": 39
+  },
+  "flavor": "Via the protrusion on its head, it senses other creatures’ emotions. If you don’t have a calm disposition, it will never warm up to you."
+ },
+ {
+  "id": 857,
+  "name": "hattrem",
+  "types": [
+   "psychic"
+  ],
+  "height": 6,
+  "weight": 48,
+  "stats": {
+   "hp": 57,
+   "attack": 40,
+   "defense": 65,
+   "special-attack": 86,
+   "special-defense": 73,
+   "speed": 49
+  },
+  "flavor": "No matter who you are, if you bring strong emotions near this Pokémon, it will silence you violently."
+ },
+ {
+  "id": 858,
+  "name": "hatterene",
+  "types": [
+   "psychic",
+   "fairy"
+  ],
+  "height": 21,
+  "weight": 51,
+  "stats": {
+   "hp": 57,
+   "attack": 90,
+   "defense": 95,
+   "special-attack": 136,
+   "special-defense": 103,
+   "speed": 29
+  },
+  "flavor": "It emits psychic power strong enough to cause headaches as a deterrent to the approach of others."
+ },
+ {
+  "id": 859,
+  "name": "impidimp",
+  "types": [
+   "dark",
+   "fairy"
+  ],
+  "height": 4,
+  "weight": 55,
+  "stats": {
+   "hp": 45,
+   "attack": 45,
+   "defense": 30,
+   "special-attack": 55,
+   "special-defense": 40,
+   "speed": 50
+  },
+  "flavor": "Through its nose, it sucks in the emanations produced by people and Pokémon when they feel annoyed. It thrives off this negative energy."
+ },
+ {
+  "id": 860,
+  "name": "morgrem",
+  "types": [
+   "dark",
+   "fairy"
+  ],
+  "height": 8,
+  "weight": 125,
+  "stats": {
+   "hp": 65,
+   "attack": 60,
+   "defense": 45,
+   "special-attack": 75,
+   "special-defense": 55,
+   "speed": 70
+  },
+  "flavor": "When it gets down on all fours as if to beg for forgiveness, it’s trying to lure opponents in so that it can stab them with its spear-like hair."
+ },
+ {
+  "id": 861,
+  "name": "grimmsnarl",
+  "types": [
+   "dark",
+   "fairy"
+  ],
+  "height": 15,
+  "weight": 610,
+  "stats": {
+   "hp": 95,
+   "attack": 120,
+   "defense": 65,
+   "special-attack": 95,
+   "special-defense": 75,
+   "speed": 60
+  },
+  "flavor": "With the hair wrapped around its body helping to enhance its muscles, this Pokémon can overwhelm even Machamp."
+ },
+ {
+  "id": 862,
+  "name": "obstagoon",
+  "types": [
+   "dark",
+   "normal"
+  ],
+  "height": 16,
+  "weight": 460,
+  "stats": {
+   "hp": 93,
+   "attack": 90,
+   "defense": 101,
+   "special-attack": 60,
+   "special-defense": 81,
+   "speed": 95
+  },
+  "flavor": "Its voice is staggering in volume. Obstagoon has a tendency to take on a threatening posture and shout—this move is known as Obstruct."
+ },
+ {
+  "id": 863,
+  "name": "perrserker",
+  "types": [
+   "steel"
+  ],
+  "height": 8,
+  "weight": 280,
+  "stats": {
+   "hp": 70,
+   "attack": 110,
+   "defense": 100,
+   "special-attack": 50,
+   "special-defense": 60,
+   "speed": 50
+  },
+  "flavor": "What appears to be an iron helmet is actually hardened hair. This Pokémon lives for the thrill of battle."
+ },
+ {
+  "id": 864,
+  "name": "cursola",
+  "types": [
+   "ghost"
+  ],
+  "height": 10,
+  "weight": 4,
+  "stats": {
+   "hp": 60,
+   "attack": 95,
+   "defense": 50,
+   "special-attack": 145,
+   "special-defense": 130,
+   "speed": 30
+  },
+  "flavor": "Its shell is overflowing with its heightened otherworldly energy. The ectoplasm serves as protection for this Pokémon’s core spirit."
+ },
+ {
+  "id": 865,
+  "name": "sirfetchd",
+  "types": [
+   "fighting"
+  ],
+  "height": 8,
+  "weight": 1170,
+  "stats": {
+   "hp": 62,
+   "attack": 135,
+   "defense": 95,
+   "special-attack": 68,
+   "special-defense": 82,
+   "speed": 65
+  },
+  "flavor": "Only Farfetch’d that have survived many battles can attain this evolution. When this Pokémon’s leek withers, it will retire from combat."
+ },
+ {
+  "id": 866,
+  "name": "mr-rime",
+  "types": [
+   "ice",
+   "psychic"
+  ],
+  "height": 15,
+  "weight": 582,
+  "stats": {
+   "hp": 80,
+   "attack": 85,
+   "defense": 75,
+   "special-attack": 110,
+   "special-defense": 100,
+   "speed": 70
+  },
+  "flavor": "It’s highly skilled at tap-dancing. It waves its cane of ice in time with its graceful movements."
+ },
+ {
+  "id": 867,
+  "name": "runerigus",
+  "types": [
+   "ground",
+   "ghost"
+  ],
+  "height": 16,
+  "weight": 666,
+  "stats": {
+   "hp": 58,
+   "attack": 95,
+   "defense": 145,
+   "special-attack": 50,
+   "special-defense": 105,
+   "speed": 30
+  },
+  "flavor": "A powerful curse was woven into an ancient painting. After absorbing the spirit of a Yamask, the painting began to move."
+ },
+ {
+  "id": 868,
+  "name": "milcery",
+  "types": [
+   "fairy"
+  ],
+  "height": 2,
+  "weight": 3,
+  "stats": {
+   "hp": 45,
+   "attack": 40,
+   "defense": 40,
+   "special-attack": 50,
+   "special-defense": 61,
+   "speed": 34
+  },
+  "flavor": "This Pokémon was born from sweet-smelling particles in the air. Its body is made of cream."
+ },
+ {
+  "id": 869,
+  "name": "alcremie",
+  "types": [
+   "fairy"
+  ],
+  "height": 3,
+  "weight": 5,
+  "stats": {
+   "hp": 65,
+   "attack": 60,
+   "defense": 75,
+   "special-attack": 110,
+   "special-defense": 121,
+   "speed": 64
+  },
+  "flavor": "When it trusts a Trainer, it will treat them to berries it’s decorated with cream."
+ },
+ {
+  "id": 870,
+  "name": "falinks",
+  "types": [
+   "fighting"
+  ],
+  "height": 30,
+  "weight": 620,
+  "stats": {
+   "hp": 65,
+   "attack": 100,
+   "defense": 100,
+   "special-attack": 70,
+   "special-defense": 60,
+   "speed": 75
+  },
+  "flavor": "Five of them are troopers, and one is the brass. The brass’s orders are absolute."
+ },
+ {
+  "id": 871,
+  "name": "pincurchin",
+  "types": [
+   "electric"
+  ],
+  "height": 3,
+  "weight": 10,
+  "stats": {
+   "hp": 48,
+   "attack": 101,
+   "defense": 95,
+   "special-attack": 91,
+   "special-defense": 85,
+   "speed": 15
+  },
+  "flavor": "It feeds on seaweed, using its teeth to scrape it off rocks. Electric current flows from the tips of its spines."
+ },
+ {
+  "id": 872,
+  "name": "snom",
+  "types": [
+   "ice",
+   "bug"
+  ],
+  "height": 3,
+  "weight": 38,
+  "stats": {
+   "hp": 30,
+   "attack": 25,
+   "defense": 35,
+   "special-attack": 45,
+   "special-defense": 30,
+   "speed": 20
+  },
+  "flavor": "It spits out thread imbued with a frigid sort of energy and uses it to tie its body to branches, disguising itself as an icicle while it sleeps."
+ },
+ {
+  "id": 873,
+  "name": "frosmoth",
+  "types": [
+   "ice",
+   "bug"
+  ],
+  "height": 13,
+  "weight": 420,
+  "stats": {
+   "hp": 70,
+   "attack": 65,
+   "defense": 60,
+   "special-attack": 125,
+   "special-defense": 90,
+   "speed": 65
+  },
+  "flavor": "Icy scales fall from its wings like snow as it flies over fields and mountains. The temperature of its wings is less than −290 degrees Fahrenheit."
+ },
+ {
+  "id": 874,
+  "name": "stonjourner",
+  "types": [
+   "rock"
+  ],
+  "height": 25,
+  "weight": 5200,
+  "stats": {
+   "hp": 100,
+   "attack": 125,
+   "defense": 135,
+   "special-attack": 20,
+   "special-defense": 20,
+   "speed": 70
+  },
+  "flavor": "It stands in grasslands, watching the sun’s descent from zenith to horizon. This Pokémon has a talent for delivering dynamic kicks."
+ },
+ {
+  "id": 875,
+  "name": "eiscue-ice",
+  "types": [
+   "ice"
+  ],
+  "height": 14,
+  "weight": 890,
+  "stats": {
+   "hp": 75,
+   "attack": 80,
+   "defense": 110,
+   "special-attack": 65,
+   "special-defense": 90,
+   "speed": 50
+  },
+  "flavor": "It drifted in on the flow of ocean waters from a frigid place. It keeps its head iced constantly to make sure it stays nice and cold."
+ },
+ {
+  "id": 876,
+  "name": "indeedee-male",
+  "types": [
+   "psychic",
+   "normal"
+  ],
+  "height": 9,
+  "weight": 280,
+  "stats": {
+   "hp": 60,
+   "attack": 65,
+   "defense": 55,
+   "special-attack": 105,
+   "special-defense": 95,
+   "speed": 95
+  },
+  "flavor": "It uses the horns on its head to sense the emotions of others. Males will act as valets for those they serve, looking after their every need."
+ },
+ {
+  "id": 877,
+  "name": "morpeko-full-belly",
+  "types": [
+   "electric",
+   "dark"
+  ],
+  "height": 3,
+  "weight": 30,
+  "stats": {
+   "hp": 58,
+   "attack": 95,
+   "defense": 58,
+   "special-attack": 70,
+   "special-defense": 58,
+   "speed": 97
+  },
+  "flavor": "As it eats the seeds stored up in its pocket-like pouches, this Pokémon is not just satisfying its constant hunger. It’s also generating electricity."
+ },
+ {
+  "id": 878,
+  "name": "cufant",
+  "types": [
+   "steel"
+  ],
+  "height": 12,
+  "weight": 1000,
+  "stats": {
+   "hp": 72,
+   "attack": 80,
+   "defense": 49,
+   "special-attack": 40,
+   "special-defense": 49,
+   "speed": 40
+  },
+  "flavor": "It digs up the ground with its trunk. It’s also very strong, being able to carry loads of over five tons without any problem at all."
+ },
+ {
+  "id": 879,
+  "name": "copperajah",
+  "types": [
+   "steel"
+  ],
+  "height": 30,
+  "weight": 6500,
+  "stats": {
+   "hp": 122,
+   "attack": 130,
+   "defense": 69,
+   "special-attack": 80,
+   "special-defense": 69,
+   "speed": 30
+  },
+  "flavor": "They came over from another region long ago and worked together with humans. Their green skin is resistant to water."
+ },
+ {
+  "id": 880,
+  "name": "dracozolt",
+  "types": [
+   "electric",
+   "dragon"
+  ],
+  "height": 18,
+  "weight": 1900,
+  "stats": {
+   "hp": 90,
+   "attack": 100,
+   "defense": 90,
+   "special-attack": 80,
+   "special-defense": 70,
+   "speed": 75
+  },
+  "flavor": "In ancient times, it was unbeatable thanks to its powerful lower body, but it went extinct anyway after it depleted all its plant-based food sources."
+ },
+ {
+  "id": 881,
+  "name": "arctozolt",
+  "types": [
+   "electric",
+   "ice"
+  ],
+  "height": 23,
+  "weight": 1500,
+  "stats": {
+   "hp": 90,
+   "attack": 100,
+   "defense": 90,
+   "special-attack": 90,
+   "special-defense": 80,
+   "speed": 55
+  },
+  "flavor": "The shaking of its freezing upper half is what generates its electricity. It has a hard time walking around."
+ },
+ {
+  "id": 882,
+  "name": "dracovish",
+  "types": [
+   "water",
+   "dragon"
+  ],
+  "height": 23,
+  "weight": 2150,
+  "stats": {
+   "hp": 90,
+   "attack": 90,
+   "defense": 100,
+   "special-attack": 70,
+   "special-defense": 80,
+   "speed": 75
+  },
+  "flavor": "Powerful legs and jaws made it the apex predator of its time. Its own overhunting of its prey was what drove it to extinction."
+ },
+ {
+  "id": 883,
+  "name": "arctovish",
+  "types": [
+   "water",
+   "ice"
+  ],
+  "height": 20,
+  "weight": 1750,
+  "stats": {
+   "hp": 90,
+   "attack": 90,
+   "defense": 100,
+   "special-attack": 80,
+   "special-defense": 90,
+   "speed": 55
+  },
+  "flavor": "Though it’s able to capture prey by freezing its surroundings, it has trouble eating the prey afterward because its mouth is on top of its head."
+ },
+ {
+  "id": 884,
+  "name": "duraludon",
+  "types": [
+   "steel",
+   "dragon"
+  ],
+  "height": 18,
+  "weight": 400,
+  "stats": {
+   "hp": 70,
+   "attack": 95,
+   "defense": 115,
+   "special-attack": 120,
+   "special-defense": 50,
+   "speed": 85
+  },
+  "flavor": "Its body resembles polished metal, and it’s both lightweight and strong. The only drawback is that it rusts easily."
+ },
+ {
+  "id": 885,
+  "name": "dreepy",
+  "types": [
+   "dragon",
+   "ghost"
+  ],
+  "height": 5,
+  "weight": 20,
+  "stats": {
+   "hp": 28,
+   "attack": 60,
+   "defense": 30,
+   "special-attack": 40,
+   "special-defense": 30,
+   "speed": 82
+  },
+  "flavor": "After being reborn as a ghost Pokémon, Dreepy wanders the areas it used to inhabit back when it was alive in prehistoric seas."
+ },
+ {
+  "id": 886,
+  "name": "drakloak",
+  "types": [
+   "dragon",
+   "ghost"
+  ],
+  "height": 14,
+  "weight": 110,
+  "stats": {
+   "hp": 68,
+   "attack": 80,
+   "defense": 50,
+   "special-attack": 60,
+   "special-defense": 50,
+   "speed": 102
+  },
+  "flavor": "It’s capable of flying faster than 120 mph. It battles alongside Dreepy and dotes on them until they successfully evolve."
+ },
+ {
+  "id": 887,
+  "name": "dragapult",
+  "types": [
+   "dragon",
+   "ghost"
+  ],
+  "height": 30,
+  "weight": 500,
+  "stats": {
+   "hp": 88,
+   "attack": 120,
+   "defense": 75,
+   "special-attack": 100,
+   "special-defense": 75,
+   "speed": 142
+  },
+  "flavor": "When it isn’t battling, it keeps Dreepy in the holes on its horns. Once a fight starts, it launches the Dreepy like supersonic missiles."
+ },
+ {
+  "id": 888,
+  "name": "zacian",
+  "types": [
+   "fairy"
+  ],
+  "height": 28,
+  "weight": 1100,
+  "stats": {
+   "hp": 92,
+   "attack": 120,
+   "defense": 115,
+   "special-attack": 80,
+   "special-defense": 115,
+   "speed": 138
+  },
+  "flavor": "Known as a legendary hero, this Pokémon absorbs metal particles, transforming them into a weapon it uses to battle."
+ },
+ {
+  "id": 889,
+  "name": "zamazenta",
+  "types": [
+   "fighting"
+  ],
+  "height": 29,
+  "weight": 2100,
+  "stats": {
+   "hp": 92,
+   "attack": 120,
+   "defense": 115,
+   "special-attack": 80,
+   "special-defense": 115,
+   "speed": 138
+  },
+  "flavor": "In times past, it worked together with a king of the people to save the Galar region. It absorbs metal that it then uses in battle."
+ },
+ {
+  "id": 890,
+  "name": "eternatus",
+  "types": [
+   "poison",
+   "dragon"
+  ],
+  "height": 200,
+  "weight": 9500,
+  "stats": {
+   "hp": 140,
+   "attack": 85,
+   "defense": 95,
+   "special-attack": 145,
+   "special-defense": 95,
+   "speed": 130
+  },
+  "flavor": "The core on its chest absorbs energy emanating from the lands of the Galar region. This energy is what allows Eternatus to stay active."
+ },
+ {
+  "id": 891,
+  "name": "kubfu",
+  "types": [
+   "fighting"
+  ],
+  "height": 6,
+  "weight": 120,
+  "stats": {
+   "hp": 60,
+   "attack": 90,
+   "defense": 60,
+   "special-attack": 53,
+   "special-defense": 50,
+   "speed": 72
+  },
+  "flavor": "Kubfu trains hard to perfect its moves. The moves it masters will determine which form it takes when it evolves."
+ },
+ {
+  "id": 892,
+  "name": "urshifu-single-strike",
+  "types": [
+   "fighting",
+   "dark"
+  ],
+  "height": 19,
+  "weight": 1050,
+  "stats": {
+   "hp": 100,
+   "attack": 130,
+   "defense": 100,
+   "special-attack": 63,
+   "special-defense": 60,
+   "speed": 97
+  },
+  "flavor": "This form of Urshifu is a strong believer in the one-hit KO. Its strategy is to leap in close to foes and land a devastating blow with a hardened fist."
+ },
+ {
+  "id": 893,
+  "name": "zarude",
+  "types": [
+   "dark",
+   "grass"
+  ],
+  "height": 18,
+  "weight": 700,
+  "stats": {
+   "hp": 105,
+   "attack": 120,
+   "defense": 105,
+   "special-attack": 70,
+   "special-defense": 95,
+   "speed": 105
+  },
+  "flavor": "Within dense forests, this Pokémon lives in a pack with others of its kind. It’s incredibly aggressive, and the other Pokémon of the forest fear it."
+ },
+ {
+  "id": 894,
+  "name": "regieleki",
+  "types": [
+   "electric"
+  ],
+  "height": 12,
+  "weight": 1450,
+  "stats": {
+   "hp": 80,
+   "attack": 100,
+   "defense": 50,
+   "special-attack": 100,
+   "special-defense": 50,
+   "speed": 200
+  },
+  "flavor": "This Pokémon is a cluster of electrical energy. It’s said that removing the rings on Regieleki’s body will unleash the Pokémon’s latent power."
+ },
+ {
+  "id": 895,
+  "name": "regidrago",
+  "types": [
+   "dragon"
+  ],
+  "height": 21,
+  "weight": 2000,
+  "stats": {
+   "hp": 200,
+   "attack": 100,
+   "defense": 50,
+   "special-attack": 100,
+   "special-defense": 50,
+   "speed": 80
+  },
+  "flavor": "An academic theory proposes that Regidrago’s arms were once the head of an ancient dragon Pokémon. The theory remains unproven."
+ },
+ {
+  "id": 896,
+  "name": "glastrier",
+  "types": [
+   "ice"
+  ],
+  "height": 22,
+  "weight": 8000,
+  "stats": {
+   "hp": 100,
+   "attack": 145,
+   "defense": 130,
+   "special-attack": 65,
+   "special-defense": 110,
+   "speed": 30
+  },
+  "flavor": "Glastrier emits intense cold from its hooves. It’s also a belligerent Pokémon—anything it wants, it takes by force."
+ },
+ {
+  "id": 897,
+  "name": "spectrier",
+  "types": [
+   "ghost"
+  ],
+  "height": 20,
+  "weight": 445,
+  "stats": {
+   "hp": 100,
+   "attack": 65,
+   "defense": 60,
+   "special-attack": 145,
+   "special-defense": 80,
+   "speed": 130
+  },
+  "flavor": "It probes its surroundings with all its senses save one—it doesn’t use its sense of sight. Spectrier’s kicks are said to separate soul from body."
+ },
+ {
+  "id": 898,
+  "name": "calyrex",
+  "types": [
+   "psychic",
+   "grass"
+  ],
+  "height": 11,
+  "weight": 77,
+  "stats": {
+   "hp": 100,
+   "attack": 80,
+   "defense": 80,
+   "special-attack": 80,
+   "special-defense": 80,
+   "speed": 80
+  },
+  "flavor": "Calyrex is a merciful Pokémon, capable of providing healing and blessings. It reigned over the Galar region in times of yore."
+ },
+ {
+  "id": 899,
+  "name": "wyrdeer",
+  "types": [
+   "normal",
+   "psychic"
+  ],
+  "height": 18,
+  "weight": 951,
+  "stats": {
+   "hp": 103,
+   "attack": 105,
+   "defense": 72,
+   "special-attack": 105,
+   "special-defense": 75,
+   "speed": 65
+  },
+  "flavor": "The black orbs shine with an uncanny light when the Pokémon is erecting invisible barriers. The fur shed from its beard retains heat well and is a highly useful material for winter clothing."
+ },
+ {
+  "id": 900,
+  "name": "kleavor",
+  "types": [
+   "bug",
+   "rock"
+  ],
+  "height": 18,
+  "weight": 890,
+  "stats": {
+   "hp": 70,
+   "attack": 135,
+   "defense": 95,
+   "special-attack": 45,
+   "special-defense": 70,
+   "speed": 85
+  },
+  "flavor": "A violent creature that fells towering trees with its crude axes and shields itself with hard stone. If one should chance upon this Pokémon in the wilds, one's only recourse is to flee."
+ },
+ {
+  "id": 901,
+  "name": "ursaluna",
+  "types": [
+   "ground",
+   "normal"
+  ],
+  "height": 24,
+  "weight": 2900,
+  "stats": {
+   "hp": 130,
+   "attack": 140,
+   "defense": 105,
+   "special-attack": 45,
+   "special-defense": 80,
+   "speed": 50
+  },
+  "flavor": "I believe it was Hisui's swampy terrain that gave Ursaluna its burly physique and newfound capacity to manipulate peat at will."
+ },
+ {
+  "id": 902,
+  "name": "basculegion-male",
+  "types": [
+   "water",
+   "ghost"
+  ],
+  "height": 30,
+  "weight": 1100,
+  "stats": {
+   "hp": 120,
+   "attack": 112,
+   "defense": 65,
+   "special-attack": 80,
+   "special-defense": 75,
+   "speed": 78
+  },
+  "flavor": "Clads itself in the souls of comrades that perished before fulfilling their goals of journeying upstream. No other species throughout all Hisui's rivers is Basculegion's equal."
+ },
+ {
+  "id": 903,
+  "name": "sneasler",
+  "types": [
+   "fighting",
+   "poison"
+  ],
+  "height": 13,
+  "weight": 430,
+  "stats": {
+   "hp": 80,
+   "attack": 130,
+   "defense": 60,
+   "special-attack": 40,
+   "special-defense": 80,
+   "speed": 120
+  },
+  "flavor": "Because of Sneasler's virulent poison and daunting physical prowess, no other species could hope to best it on the frozen highlands. Preferring solitude, this species does not form packs."
+ },
+ {
+  "id": 904,
+  "name": "overqwil",
+  "types": [
+   "dark",
+   "poison"
+  ],
+  "height": 25,
+  "weight": 605,
+  "stats": {
+   "hp": 85,
+   "attack": 115,
+   "defense": 95,
+   "special-attack": 65,
+   "special-defense": 65,
+   "speed": 85
+  },
+  "flavor": "Its lancelike spikes and savage temperament have earned it the nickname ”sea fiend.” It slurps up poison to nourish itself."
+ },
+ {
+  "id": 905,
+  "name": "enamorus-incarnate",
+  "types": [
+   "fairy",
+   "flying"
+  ],
+  "height": 16,
+  "weight": 480,
+  "stats": {
+   "hp": 74,
+   "attack": 115,
+   "defense": 70,
+   "special-attack": 135,
+   "special-defense": 80,
+   "speed": 106
+  },
+  "flavor": "When it flies to this land from across the sea, the bitter winter comes to an end. According to legend, this Pokémon's love gives rise to the budding of fresh life across Hisui."
+ },
+ {
+  "id": 906,
+  "name": "sprigatito",
+  "types": [
+   "grass"
+  ],
+  "height": 4,
+  "weight": 41,
+  "stats": {
+   "hp": 40,
+   "attack": 61,
+   "defense": 54,
+   "special-attack": 45,
+   "special-defense": 45,
+   "speed": 65
+  },
+  "flavor": "Its fluffy fur is similar in composition to plants. This Pokémon frequently washes its face to keep it from drying out."
+ },
+ {
+  "id": 907,
+  "name": "floragato",
+  "types": [
+   "grass"
+  ],
+  "height": 9,
+  "weight": 122,
+  "stats": {
+   "hp": 61,
+   "attack": 80,
+   "defense": 63,
+   "special-attack": 60,
+   "special-defense": 63,
+   "speed": 83
+  },
+  "flavor": "Floragato deftly wields the vine hidden beneath its long fur, slamming the hard flower bud against its opponents."
+ },
+ {
+  "id": 908,
+  "name": "meowscarada",
+  "types": [
+   "grass",
+   "dark"
+  ],
+  "height": 15,
+  "weight": 312,
+  "stats": {
+   "hp": 76,
+   "attack": 110,
+   "defense": 70,
+   "special-attack": 81,
+   "special-defense": 70,
+   "speed": 123
+  },
+  "flavor": "This Pokémon uses the reflective fur lining its cape to camouflage the stem of its flower, creating the illusion that the flower is floating."
+ },
+ {
+  "id": 909,
+  "name": "fuecoco",
+  "types": [
+   "fire"
+  ],
+  "height": 4,
+  "weight": 98,
+  "stats": {
+   "hp": 67,
+   "attack": 45,
+   "defense": 59,
+   "special-attack": 63,
+   "special-defense": 40,
+   "speed": 36
+  },
+  "flavor": "It lies on warm rocks and uses the heat absorbed by its square-shaped scales to create fire energy."
+ },
+ {
+  "id": 910,
+  "name": "crocalor",
+  "types": [
+   "fire"
+  ],
+  "height": 10,
+  "weight": 307,
+  "stats": {
+   "hp": 81,
+   "attack": 55,
+   "defense": 78,
+   "special-attack": 90,
+   "special-defense": 58,
+   "speed": 49
+  },
+  "flavor": "The combination of Crocalor’s fire energy and overflowing vitality has caused an egg-shaped fireball to appear on the Pokémon’s head."
+ },
+ {
+  "id": 911,
+  "name": "skeledirge",
+  "types": [
+   "fire",
+   "ghost"
+  ],
+  "height": 16,
+  "weight": 3265,
+  "stats": {
+   "hp": 104,
+   "attack": 75,
+   "defense": 100,
+   "special-attack": 110,
+   "special-defense": 75,
+   "speed": 66
+  },
+  "flavor": "The fiery bird changes shape when Skeledirge sings. Rumor has it that the bird was born when the fireball on Skeledirge’s head gained a soul."
+ },
+ {
+  "id": 912,
+  "name": "quaxly",
+  "types": [
+   "water"
+  ],
+  "height": 5,
+  "weight": 61,
+  "stats": {
+   "hp": 55,
+   "attack": 65,
+   "defense": 45,
+   "special-attack": 50,
+   "special-defense": 45,
+   "speed": 50
+  },
+  "flavor": "This Pokémon migrated to Paldea from distant lands long ago. The gel secreted by its feathers repels water and grime."
+ },
+ {
+  "id": 913,
+  "name": "quaxwell",
+  "types": [
+   "water"
+  ],
+  "height": 12,
+  "weight": 215,
+  "stats": {
+   "hp": 70,
+   "attack": 85,
+   "defense": 65,
+   "special-attack": 65,
+   "special-defense": 60,
+   "speed": 65
+  },
+  "flavor": "These Pokémon constantly run through shallow waters to train their legs, then compete with each other to see which of them kicks most gracefully."
+ },
+ {
+  "id": 914,
+  "name": "quaquaval",
+  "types": [
+   "water",
+   "fighting"
+  ],
+  "height": 18,
+  "weight": 619,
+  "stats": {
+   "hp": 85,
+   "attack": 120,
+   "defense": 80,
+   "special-attack": 85,
+   "special-defense": 75,
+   "speed": 85
+  },
+  "flavor": "A single kick from a Quaquaval can send a truck rolling. This Pokémon uses its powerful legs to perform striking dances from far-off lands."
+ },
+ {
+  "id": 915,
+  "name": "lechonk",
+  "types": [
+   "normal"
+  ],
+  "height": 5,
+  "weight": 102,
+  "stats": {
+   "hp": 54,
+   "attack": 45,
+   "defense": 40,
+   "special-attack": 35,
+   "special-defense": 45,
+   "speed": 35
+  },
+  "flavor": "It searches for food all day. It possesses a keen sense of smell but doesn’t use it for anything other than foraging."
+ },
+ {
+  "id": 916,
+  "name": "oinkologne-male",
+  "types": [
+   "normal"
+  ],
+  "height": 10,
+  "weight": 1200,
+  "stats": {
+   "hp": 110,
+   "attack": 100,
+   "defense": 75,
+   "special-attack": 59,
+   "special-defense": 80,
+   "speed": 65
+  },
+  "flavor": "Oinkologne is proud of its fine, glossy skin. It emits a concentrated scent from the tip of its tail."
+ },
+ {
+  "id": 917,
+  "name": "tarountula",
+  "types": [
+   "bug"
+  ],
+  "height": 3,
+  "weight": 40,
+  "stats": {
+   "hp": 35,
+   "attack": 41,
+   "defense": 45,
+   "special-attack": 29,
+   "special-defense": 40,
+   "speed": 20
+  },
+  "flavor": "The ball of threads wrapped around its body is elastic enough to deflect the scythes of Scyther, this Pokémon’s natural enemy."
+ },
+ {
+  "id": 918,
+  "name": "spidops",
+  "types": [
+   "bug"
+  ],
+  "height": 10,
+  "weight": 165,
+  "stats": {
+   "hp": 60,
+   "attack": 79,
+   "defense": 92,
+   "special-attack": 52,
+   "special-defense": 86,
+   "speed": 35
+  },
+  "flavor": "It clings to branches and ceilings using its threads and moves without a sound. It takes out its prey before the prey even notices it."
+ },
+ {
+  "id": 919,
+  "name": "nymble",
+  "types": [
+   "bug"
+  ],
+  "height": 2,
+  "weight": 10,
+  "stats": {
+   "hp": 33,
+   "attack": 46,
+   "defense": 40,
+   "special-attack": 21,
+   "special-defense": 25,
+   "speed": 45
+  },
+  "flavor": "It has its third set of legs folded up. When it’s in a tough spot, this Pokémon jumps over 30 feet using the strength of its legs."
+ },
+ {
+  "id": 920,
+  "name": "lokix",
+  "types": [
+   "bug",
+   "dark"
+  ],
+  "height": 10,
+  "weight": 175,
+  "stats": {
+   "hp": 71,
+   "attack": 102,
+   "defense": 78,
+   "special-attack": 52,
+   "special-defense": 55,
+   "speed": 92
+  },
+  "flavor": "When it decides to fight all out, it stands on its previously folded legs to enter Showdown Mode. It neutralizes its enemies in short order."
+ },
+ {
+  "id": 921,
+  "name": "pawmi",
+  "types": [
+   "electric"
+  ],
+  "height": 3,
+  "weight": 25,
+  "stats": {
+   "hp": 45,
+   "attack": 50,
+   "defense": 20,
+   "special-attack": 40,
+   "special-defense": 25,
+   "speed": 60
+  },
+  "flavor": "It has underdeveloped electric sacs on its cheeks. These sacs can produce electricity only if Pawmi rubs them furiously with the pads on its forepaws."
+ },
+ {
+  "id": 922,
+  "name": "pawmo",
+  "types": [
+   "electric",
+   "fighting"
+  ],
+  "height": 4,
+  "weight": 65,
+  "stats": {
+   "hp": 60,
+   "attack": 75,
+   "defense": 40,
+   "special-attack": 50,
+   "special-defense": 40,
+   "speed": 85
+  },
+  "flavor": "When its group is attacked, Pawmo is the first to leap into battle, defeating enemies with a fighting technique that utilizes electric shocks."
+ },
+ {
+  "id": 923,
+  "name": "pawmot",
+  "types": [
+   "electric",
+   "fighting"
+  ],
+  "height": 9,
+  "weight": 410,
+  "stats": {
+   "hp": 70,
+   "attack": 115,
+   "defense": 70,
+   "special-attack": 70,
+   "special-defense": 60,
+   "speed": 105
+  },
+  "flavor": "This Pokémon normally is slow to react, but once it enters battle, it will strike down its enemies with lightning-fast movements."
+ },
+ {
+  "id": 924,
+  "name": "tandemaus",
+  "types": [
+   "normal"
+  ],
+  "height": 3,
+  "weight": 18,
+  "stats": {
+   "hp": 50,
+   "attack": 50,
+   "defense": 45,
+   "special-attack": 40,
+   "special-defense": 45,
+   "speed": 75
+  },
+  "flavor": "Exhibiting great teamwork, they use their incisors to cut pieces out of any material that might be useful for a nest, then make off with them."
+ },
+ {
+  "id": 925,
+  "name": "maushold-family-of-four",
+  "types": [
+   "normal"
+  ],
+  "height": 3,
+  "weight": 28,
+  "stats": {
+   "hp": 74,
+   "attack": 75,
+   "defense": 70,
+   "special-attack": 65,
+   "special-defense": 75,
+   "speed": 111
+  },
+  "flavor": "The two little ones just appeared one day. The group might be a family of related Pokémon, but nobody knows for sure."
+ },
+ {
+  "id": 926,
+  "name": "fidough",
+  "types": [
+   "fairy"
+  ],
+  "height": 3,
+  "weight": 109,
+  "stats": {
+   "hp": 37,
+   "attack": 55,
+   "defense": 70,
+   "special-attack": 30,
+   "special-defense": 55,
+   "speed": 65
+  },
+  "flavor": "This Pokémon is smooth and moist to the touch. Yeast in Fidough’s breath induces fermentation in the Pokémon’s vicinity."
+ },
+ {
+  "id": 927,
+  "name": "dachsbun",
+  "types": [
+   "fairy"
+  ],
+  "height": 5,
+  "weight": 149,
+  "stats": {
+   "hp": 57,
+   "attack": 80,
+   "defense": 115,
+   "special-attack": 50,
+   "special-defense": 80,
+   "speed": 95
+  },
+  "flavor": "The pleasant aroma that emanates from this Pokémon’s body helps wheat grow, so Dachsbun has been treasured by farming villages."
+ },
+ {
+  "id": 928,
+  "name": "smoliv",
+  "types": [
+   "grass",
+   "normal"
+  ],
+  "height": 3,
+  "weight": 65,
+  "stats": {
+   "hp": 41,
+   "attack": 35,
+   "defense": 45,
+   "special-attack": 58,
+   "special-defense": 51,
+   "speed": 30
+  },
+  "flavor": "It protects itself from enemies by emitting oil from the fruit on its head. This oil is bitter and astringent enough to make someone flinch."
+ },
+ {
+  "id": 929,
+  "name": "dolliv",
+  "types": [
+   "grass",
+   "normal"
+  ],
+  "height": 6,
+  "weight": 119,
+  "stats": {
+   "hp": 52,
+   "attack": 53,
+   "defense": 60,
+   "special-attack": 78,
+   "special-defense": 78,
+   "speed": 33
+  },
+  "flavor": "Dolliv shares its tasty, fresh-scented oil with others. This species has coexisted with humans since times long gone."
+ },
+ {
+  "id": 930,
+  "name": "arboliva",
+  "types": [
+   "grass",
+   "normal"
+  ],
+  "height": 14,
+  "weight": 482,
+  "stats": {
+   "hp": 78,
+   "attack": 69,
+   "defense": 90,
+   "special-attack": 125,
+   "special-defense": 109,
+   "speed": 39
+  },
+  "flavor": "This calm Pokémon is very compassionate. It will share its delicious, nutrient-rich oil with weakened Pokémon."
+ },
+ {
+  "id": 931,
+  "name": "squawkabilly-green-plumage",
+  "types": [
+   "normal",
+   "flying"
+  ],
+  "height": 6,
+  "weight": 24,
+  "stats": {
+   "hp": 82,
+   "attack": 96,
+   "defense": 51,
+   "special-attack": 45,
+   "special-defense": 51,
+   "speed": 92
+  },
+  "flavor": "These Pokémon prefer to live in cities. They form flocks based on the color of their feathers, and they fight over territory."
+ },
+ {
+  "id": 932,
+  "name": "nacli",
+  "types": [
+   "rock"
+  ],
+  "height": 4,
+  "weight": 160,
+  "stats": {
+   "hp": 55,
+   "attack": 55,
+   "defense": 75,
+   "special-attack": 35,
+   "special-defense": 35,
+   "speed": 25
+  },
+  "flavor": "It was born in a layer of rock salt deep under the earth. This species was particularly treasured in the old days, as they would share precious salt."
+ },
+ {
+  "id": 933,
+  "name": "naclstack",
+  "types": [
+   "rock"
+  ],
+  "height": 6,
+  "weight": 1050,
+  "stats": {
+   "hp": 60,
+   "attack": 60,
+   "defense": 100,
+   "special-attack": 35,
+   "special-defense": 65,
+   "speed": 35
+  },
+  "flavor": "This Pokémon dry cures its prey by spraying salt over them. The curing process steals away the water in the prey’s body."
+ },
+ {
+  "id": 934,
+  "name": "garganacl",
+  "types": [
+   "rock"
+  ],
+  "height": 23,
+  "weight": 2400,
+  "stats": {
+   "hp": 100,
+   "attack": 100,
+   "defense": 130,
+   "special-attack": 45,
+   "special-defense": 90,
+   "speed": 35
+  },
+  "flavor": "Garganacl will rub its fingertips together and sprinkle injured Pokémon with salt. Even severe wounds will promptly heal afterward."
+ },
+ {
+  "id": 935,
+  "name": "charcadet",
+  "types": [
+   "fire"
+  ],
+  "height": 6,
+  "weight": 105,
+  "stats": {
+   "hp": 40,
+   "attack": 50,
+   "defense": 40,
+   "special-attack": 50,
+   "special-defense": 40,
+   "speed": 35
+  },
+  "flavor": "Burnt charcoal came to life and became a Pokémon. Possessing a fiery fighting spirit, Charcadet will battle even tough opponents."
+ },
+ {
+  "id": 936,
+  "name": "armarouge",
+  "types": [
+   "fire",
+   "psychic"
+  ],
+  "height": 15,
+  "weight": 850,
+  "stats": {
+   "hp": 85,
+   "attack": 60,
+   "defense": 100,
+   "special-attack": 125,
+   "special-defense": 80,
+   "speed": 75
+  },
+  "flavor": "Armarouge evolved through the use of a set of armor that belonged to a distinguished warrior. This Pokémon is incredibly loyal."
+ },
+ {
+  "id": 937,
+  "name": "ceruledge",
+  "types": [
+   "fire",
+   "ghost"
+  ],
+  "height": 16,
+  "weight": 620,
+  "stats": {
+   "hp": 75,
+   "attack": 125,
+   "defense": 80,
+   "special-attack": 60,
+   "special-defense": 100,
+   "speed": 85
+  },
+  "flavor": "The fiery blades on its arms burn fiercely with the lingering resentment of a sword wielder who fell before accomplishing their goal."
+ },
+ {
+  "id": 938,
+  "name": "tadbulb",
+  "types": [
+   "electric"
+  ],
+  "height": 3,
+  "weight": 4,
+  "stats": {
+   "hp": 61,
+   "attack": 31,
+   "defense": 41,
+   "special-attack": 59,
+   "special-defense": 35,
+   "speed": 45
+  },
+  "flavor": "Tadbulb shakes its tail to generate electricity. If it senses danger, it will make its head blink on and off to alert its allies."
+ },
+ {
+  "id": 939,
+  "name": "bellibolt",
+  "types": [
+   "electric"
+  ],
+  "height": 12,
+  "weight": 1130,
+  "stats": {
+   "hp": 109,
+   "attack": 64,
+   "defense": 91,
+   "special-attack": 103,
+   "special-defense": 83,
+   "speed": 45
+  },
+  "flavor": "When this Pokémon expands and contracts its wobbly body, the belly-button dynamo in its stomach produces a huge amount of electricity."
+ },
+ {
+  "id": 940,
+  "name": "wattrel",
+  "types": [
+   "electric",
+   "flying"
+  ],
+  "height": 4,
+  "weight": 36,
+  "stats": {
+   "hp": 40,
+   "attack": 40,
+   "defense": 35,
+   "special-attack": 55,
+   "special-defense": 40,
+   "speed": 70
+  },
+  "flavor": "When its wings catch the wind, the bones within produce electricity. This Pokémon dives into the ocean, catching prey by electrocuting them."
+ },
+ {
+  "id": 941,
+  "name": "kilowattrel",
+  "types": [
+   "electric",
+   "flying"
+  ],
+  "height": 14,
+  "weight": 386,
+  "stats": {
+   "hp": 70,
+   "attack": 70,
+   "defense": 60,
+   "special-attack": 105,
+   "special-defense": 60,
+   "speed": 125
+  },
+  "flavor": "Kilowattrel inflates its throat sac to amplify its electricity. By riding the wind, this Pokémon can fly over 430 miles in a day."
+ },
+ {
+  "id": 942,
+  "name": "maschiff",
+  "types": [
+   "dark"
+  ],
+  "height": 5,
+  "weight": 160,
+  "stats": {
+   "hp": 60,
+   "attack": 78,
+   "defense": 60,
+   "special-attack": 40,
+   "special-defense": 51,
+   "speed": 51
+  },
+  "flavor": "It always scowls in an attempt to make opponents take it seriously, but even crying children will burst into laughter when they see Maschiff’s face."
+ },
+ {
+  "id": 943,
+  "name": "mabosstiff",
+  "types": [
+   "dark"
+  ],
+  "height": 11,
+  "weight": 610,
+  "stats": {
+   "hp": 80,
+   "attack": 120,
+   "defense": 90,
+   "special-attack": 60,
+   "special-defense": 70,
+   "speed": 85
+  },
+  "flavor": "This Pokémon can store energy in its large dewlap. Mabosstiff unleashes this energy all at once to blow away enemies."
+ },
+ {
+  "id": 944,
+  "name": "shroodle",
+  "types": [
+   "poison",
+   "normal"
+  ],
+  "height": 2,
+  "weight": 7,
+  "stats": {
+   "hp": 40,
+   "attack": 65,
+   "defense": 35,
+   "special-attack": 40,
+   "special-defense": 35,
+   "speed": 75
+  },
+  "flavor": "Though usually a mellow Pokémon, it will sink its sharp, poison-soaked front teeth into any that anger it, causing paralysis in the object of its ire."
+ },
+ {
+  "id": 945,
+  "name": "grafaiai",
+  "types": [
+   "poison",
+   "normal"
+  ],
+  "height": 7,
+  "weight": 272,
+  "stats": {
+   "hp": 63,
+   "attack": 95,
+   "defense": 65,
+   "special-attack": 80,
+   "special-defense": 72,
+   "speed": 110
+  },
+  "flavor": "The color of the poisonous saliva depends on what the Pokémon eats. Grafaiai covers its fingers in its saliva and draws patterns on trees in forests."
+ },
+ {
+  "id": 946,
+  "name": "bramblin",
+  "types": [
+   "grass",
+   "ghost"
+  ],
+  "height": 6,
+  "weight": 6,
+  "stats": {
+   "hp": 40,
+   "attack": 65,
+   "defense": 30,
+   "special-attack": 45,
+   "special-defense": 35,
+   "speed": 60
+  },
+  "flavor": "A soul unable to move on to the afterlife was blown around by the wind until it got tangled up with dried grass and became a Pokémon."
+ },
+ {
+  "id": 947,
+  "name": "brambleghast",
+  "types": [
+   "grass",
+   "ghost"
+  ],
+  "height": 12,
+  "weight": 60,
+  "stats": {
+   "hp": 55,
+   "attack": 115,
+   "defense": 70,
+   "special-attack": 80,
+   "special-defense": 70,
+   "speed": 90
+  },
+  "flavor": "It will open the branches of its head to envelop its prey. Once it absorbs all the life energy it needs, it expels the prey and discards it."
+ },
+ {
+  "id": 948,
+  "name": "toedscool",
+  "types": [
+   "ground",
+   "grass"
+  ],
+  "height": 9,
+  "weight": 330,
+  "stats": {
+   "hp": 40,
+   "attack": 40,
+   "defense": 35,
+   "special-attack": 50,
+   "special-defense": 100,
+   "speed": 70
+  },
+  "flavor": "Toedscool lives in muggy forests. The flaps that fall from its body are chewy and very delicious."
+ },
+ {
+  "id": 949,
+  "name": "toedscruel",
+  "types": [
+   "ground",
+   "grass"
+  ],
+  "height": 19,
+  "weight": 580,
+  "stats": {
+   "hp": 80,
+   "attack": 70,
+   "defense": 65,
+   "special-attack": 80,
+   "special-defense": 120,
+   "speed": 100
+  },
+  "flavor": "These Pokémon gather into groups and form colonies deep within forests. They absolutely hate it when strangers approach."
+ },
+ {
+  "id": 950,
+  "name": "klawf",
+  "types": [
+   "rock"
+  ],
+  "height": 13,
+  "weight": 790,
+  "stats": {
+   "hp": 70,
+   "attack": 100,
+   "defense": 115,
+   "special-attack": 35,
+   "special-defense": 55,
+   "speed": 75
+  },
+  "flavor": "Klawf hangs upside-down from cliffs, waiting for prey. But Klawf can’t remain in this position for long because its blood rushes to its head."
+ },
+ {
+  "id": 951,
+  "name": "capsakid",
+  "types": [
+   "grass"
+  ],
+  "height": 3,
+  "weight": 30,
+  "stats": {
+   "hp": 50,
+   "attack": 62,
+   "defense": 40,
+   "special-attack": 62,
+   "special-defense": 40,
+   "speed": 50
+  },
+  "flavor": "The more sunlight this Pokémon bathes in, the more spicy chemicals are produced by its body, and thus the spicier its moves become."
+ },
+ {
+  "id": 952,
+  "name": "scovillain",
+  "types": [
+   "grass",
+   "fire"
+  ],
+  "height": 9,
+  "weight": 150,
+  "stats": {
+   "hp": 65,
+   "attack": 108,
+   "defense": 65,
+   "special-attack": 108,
+   "special-defense": 65,
+   "speed": 75
+  },
+  "flavor": "The red head converts spicy chemicals into fire energy and blasts the surrounding area with a super spicy stream of flame."
+ },
+ {
+  "id": 953,
+  "name": "rellor",
+  "types": [
+   "bug"
+  ],
+  "height": 2,
+  "weight": 10,
+  "stats": {
+   "hp": 41,
+   "attack": 50,
+   "defense": 60,
+   "special-attack": 31,
+   "special-defense": 58,
+   "speed": 30
+  },
+  "flavor": "This Pokémon creates a mud ball by mixing sand and dirt with psychic energy. It treasures its mud ball more than its own life."
+ },
+ {
+  "id": 954,
+  "name": "rabsca",
+  "types": [
+   "bug",
+   "psychic"
+  ],
+  "height": 3,
+  "weight": 35,
+  "stats": {
+   "hp": 75,
+   "attack": 50,
+   "defense": 85,
+   "special-attack": 115,
+   "special-defense": 100,
+   "speed": 45
+  },
+  "flavor": "The body that supports the ball barely moves. Therefore, it is thought that the true body of this Pokémon is actually inside the ball."
+ },
+ {
+  "id": 955,
+  "name": "flittle",
+  "types": [
+   "psychic"
+  ],
+  "height": 2,
+  "weight": 15,
+  "stats": {
+   "hp": 30,
+   "attack": 35,
+   "defense": 30,
+   "special-attack": 55,
+   "special-defense": 30,
+   "speed": 75
+  },
+  "flavor": "Flittle’s toes levitate about half an inch above the ground because of the psychic power emitted from the frills on the Pokémon’s belly."
+ },
+ {
+  "id": 956,
+  "name": "espathra",
+  "types": [
+   "psychic"
+  ],
+  "height": 19,
+  "weight": 900,
+  "stats": {
+   "hp": 95,
+   "attack": 60,
+   "defense": 60,
+   "special-attack": 101,
+   "special-defense": 60,
+   "speed": 105
+  },
+  "flavor": "It immobilizes opponents by bathing them in psychic power from its large eyes. Despite its appearance, it has a vicious temperament."
+ },
+ {
+  "id": 957,
+  "name": "tinkatink",
+  "types": [
+   "fairy",
+   "steel"
+  ],
+  "height": 4,
+  "weight": 89,
+  "stats": {
+   "hp": 50,
+   "attack": 45,
+   "defense": 45,
+   "special-attack": 35,
+   "special-defense": 64,
+   "speed": 58
+  },
+  "flavor": "It swings its handmade hammer around to protect itself, but the hammer is often stolen by Pokémon that eat metal."
+ },
+ {
+  "id": 958,
+  "name": "tinkatuff",
+  "types": [
+   "fairy",
+   "steel"
+  ],
+  "height": 7,
+  "weight": 591,
+  "stats": {
+   "hp": 65,
+   "attack": 55,
+   "defense": 55,
+   "special-attack": 45,
+   "special-defense": 82,
+   "speed": 78
+  },
+  "flavor": "This Pokémon will attack groups of Pawniard and Bisharp, gathering metal from them in order to create a large and sturdy hammer."
+ },
+ {
+  "id": 959,
+  "name": "tinkaton",
+  "types": [
+   "fairy",
+   "steel"
+  ],
+  "height": 7,
+  "weight": 1128,
+  "stats": {
+   "hp": 85,
+   "attack": 75,
+   "defense": 77,
+   "special-attack": 70,
+   "special-defense": 105,
+   "speed": 94
+  },
+  "flavor": "This intelligent Pokémon has a very daring disposition. It knocks rocks into the sky with its hammer, aiming for flying Corviknight."
+ },
+ {
+  "id": 960,
+  "name": "wiglett",
+  "types": [
+   "water"
+  ],
+  "height": 12,
+  "weight": 18,
+  "stats": {
+   "hp": 10,
+   "attack": 55,
+   "defense": 25,
+   "special-attack": 35,
+   "special-defense": 25,
+   "speed": 95
+  },
+  "flavor": "This Pokémon can pick up the scent of a Veluza just over 65 feet away and will hide itself in the sand."
+ },
+ {
+  "id": 961,
+  "name": "wugtrio",
+  "types": [
+   "water"
+  ],
+  "height": 12,
+  "weight": 54,
+  "stats": {
+   "hp": 35,
+   "attack": 100,
+   "defense": 50,
+   "special-attack": 50,
+   "special-defense": 70,
+   "speed": 120
+  },
+  "flavor": "It has a vicious temperament, contrary to what its appearance may suggest. It wraps its long bodies around prey, then drags the prey into its den."
+ },
+ {
+  "id": 962,
+  "name": "bombirdier",
+  "types": [
+   "flying",
+   "dark"
+  ],
+  "height": 15,
+  "weight": 429,
+  "stats": {
+   "hp": 70,
+   "attack": 103,
+   "defense": 85,
+   "special-attack": 60,
+   "special-defense": 85,
+   "speed": 82
+  },
+  "flavor": "It gathers things up in an apron made from shed feathers added to the Pokémon’s chest feathers, then drops those things from high places for fun."
+ },
+ {
+  "id": 963,
+  "name": "finizen",
+  "types": [
+   "water"
+  ],
+  "height": 13,
+  "weight": 602,
+  "stats": {
+   "hp": 70,
+   "attack": 45,
+   "defense": 40,
+   "special-attack": 45,
+   "special-defense": 40,
+   "speed": 75
+  },
+  "flavor": "It likes playing with others of its kind using the water ring on its tail. It uses ultrasonic waves to sense the emotions of other living creatures."
+ },
+ {
+  "id": 964,
+  "name": "palafin-zero",
+  "types": [
+   "water"
+  ],
+  "height": 13,
+  "weight": 602,
+  "stats": {
+   "hp": 100,
+   "attack": 70,
+   "defense": 72,
+   "special-attack": 53,
+   "special-defense": 62,
+   "speed": 100
+  },
+  "flavor": "This Pokémon changes its appearance if it hears its allies calling for help. Palafin will never show anybody its moment of transformation."
+ },
+ {
+  "id": 965,
+  "name": "varoom",
+  "types": [
+   "steel",
+   "poison"
+  ],
+  "height": 10,
+  "weight": 350,
+  "stats": {
+   "hp": 45,
+   "attack": 70,
+   "defense": 63,
+   "special-attack": 30,
+   "special-defense": 45,
+   "speed": 47
+  },
+  "flavor": "It is said that this Pokémon was born when an unknown poison Pokémon entered and inspirited an engine left at a scrap-processing factory."
+ },
+ {
+  "id": 966,
+  "name": "revavroom",
+  "types": [
+   "steel",
+   "poison"
+  ],
+  "height": 18,
+  "weight": 1200,
+  "stats": {
+   "hp": 80,
+   "attack": 119,
+   "defense": 90,
+   "special-attack": 54,
+   "special-defense": 67,
+   "speed": 90
+  },
+  "flavor": "It creates a gas out of poison and minerals from rocks. It then detonates the gas in its cylinders—now numbering eight—to generate energy."
+ },
+ {
+  "id": 967,
+  "name": "cyclizar",
+  "types": [
+   "dragon",
+   "normal"
+  ],
+  "height": 16,
+  "weight": 630,
+  "stats": {
+   "hp": 70,
+   "attack": 95,
+   "defense": 65,
+   "special-attack": 85,
+   "special-defense": 65,
+   "speed": 121
+  },
+  "flavor": "Apparently Cyclizar has been allowing people to ride on its back since ancient times. Depictions of this have been found in 10,000-year-old murals."
+ },
+ {
+  "id": 968,
+  "name": "orthworm",
+  "types": [
+   "steel"
+  ],
+  "height": 25,
+  "weight": 3100,
+  "stats": {
+   "hp": 70,
+   "attack": 85,
+   "defense": 145,
+   "special-attack": 60,
+   "special-defense": 55,
+   "speed": 65
+  },
+  "flavor": "When attacked, this Pokémon will wield the tendrils on its body like fists and pelt the opponent with a storm of punches."
+ },
+ {
+  "id": 969,
+  "name": "glimmet",
+  "types": [
+   "rock",
+   "poison"
+  ],
+  "height": 7,
+  "weight": 80,
+  "stats": {
+   "hp": 48,
+   "attack": 35,
+   "defense": 42,
+   "special-attack": 105,
+   "special-defense": 60,
+   "speed": 60
+  },
+  "flavor": "It absorbs nutrients from cave walls. The petals it wears are made of crystallized poison."
+ },
+ {
+  "id": 970,
+  "name": "glimmora",
+  "types": [
+   "rock",
+   "poison"
+  ],
+  "height": 15,
+  "weight": 450,
+  "stats": {
+   "hp": 83,
+   "attack": 55,
+   "defense": 90,
+   "special-attack": 130,
+   "special-defense": 81,
+   "speed": 86
+  },
+  "flavor": "When this Pokémon detects danger, it will open up its crystalline petals and fire beams from its conical body."
+ },
+ {
+  "id": 971,
+  "name": "greavard",
+  "types": [
+   "ghost"
+  ],
+  "height": 6,
+  "weight": 350,
+  "stats": {
+   "hp": 50,
+   "attack": 61,
+   "defense": 60,
+   "special-attack": 30,
+   "special-defense": 55,
+   "speed": 34
+  },
+  "flavor": "It is said that a dog Pokémon that died in the wild without ever interacting with a human was reborn as this Pokémon."
+ },
+ {
+  "id": 972,
+  "name": "houndstone",
+  "types": [
+   "ghost"
+  ],
+  "height": 20,
+  "weight": 150,
+  "stats": {
+   "hp": 72,
+   "attack": 101,
+   "defense": 100,
+   "special-attack": 50,
+   "special-defense": 97,
+   "speed": 68
+  },
+  "flavor": "Houndstone spends most of its time sleeping in graveyards. Among all the dog Pokémon, this one is most loyal to its master."
+ },
+ {
+  "id": 973,
+  "name": "flamigo",
+  "types": [
+   "flying",
+   "fighting"
+  ],
+  "height": 16,
+  "weight": 370,
+  "stats": {
+   "hp": 82,
+   "attack": 115,
+   "defense": 74,
+   "special-attack": 75,
+   "special-defense": 64,
+   "speed": 90
+  },
+  "flavor": "This Pokémon apparently ties the base of its neck into a knot so that energy stored in its belly does not escape from its beak."
+ },
+ {
+  "id": 974,
+  "name": "cetoddle",
+  "types": [
+   "ice"
+  ],
+  "height": 12,
+  "weight": 450,
+  "stats": {
+   "hp": 108,
+   "attack": 68,
+   "defense": 45,
+   "special-attack": 30,
+   "special-defense": 40,
+   "speed": 43
+  },
+  "flavor": "This species left the ocean and began living on land a very long time ago. It seems to be closely related to Wailmer."
+ },
+ {
+  "id": 975,
+  "name": "cetitan",
+  "types": [
+   "ice"
+  ],
+  "height": 45,
+  "weight": 7000,
+  "stats": {
+   "hp": 170,
+   "attack": 113,
+   "defense": 65,
+   "special-attack": 45,
+   "special-defense": 55,
+   "speed": 73
+  },
+  "flavor": "This Pokémon wanders around snowy, icy areas. It protects its body with powerful muscles and a thick layer of fat under its skin."
+ },
+ {
+  "id": 976,
+  "name": "veluza",
+  "types": [
+   "water",
+   "psychic"
+  ],
+  "height": 25,
+  "weight": 900,
+  "stats": {
+   "hp": 90,
+   "attack": 102,
+   "defense": 73,
+   "special-attack": 78,
+   "special-defense": 65,
+   "speed": 70
+  },
+  "flavor": "When Veluza discards unnecessary flesh, its mind becomes honed and its psychic power increases. The spare flesh has a mild but delicious flavor."
+ },
+ {
+  "id": 977,
+  "name": "dondozo",
+  "types": [
+   "water"
+  ],
+  "height": 120,
+  "weight": 2200,
+  "stats": {
+   "hp": 150,
+   "attack": 100,
+   "defense": 115,
+   "special-attack": 65,
+   "special-defense": 65,
+   "speed": 35
+  },
+  "flavor": "This Pokémon is a glutton, but it’s bad at getting food. It teams up with a Tatsugiri to catch prey."
+ },
+ {
+  "id": 978,
+  "name": "tatsugiri-curly",
+  "types": [
+   "dragon",
+   "water"
+  ],
+  "height": 3,
+  "weight": 80,
+  "stats": {
+   "hp": 68,
+   "attack": 50,
+   "defense": 60,
+   "special-attack": 120,
+   "special-defense": 95,
+   "speed": 82
+  },
+  "flavor": "This is a small dragon Pokémon. It lives inside the mouth of Dondozo to protect itself from enemies on the outside."
+ },
+ {
+  "id": 979,
+  "name": "annihilape",
+  "types": [
+   "fighting",
+   "ghost"
+  ],
+  "height": 12,
+  "weight": 560,
+  "stats": {
+   "hp": 110,
+   "attack": 115,
+   "defense": 80,
+   "special-attack": 50,
+   "special-defense": 90,
+   "speed": 90
+  },
+  "flavor": "When its anger rose beyond a critical point, this Pokémon gained power that is unfettered by the limits of its physical body."
+ },
+ {
+  "id": 980,
+  "name": "clodsire",
+  "types": [
+   "poison",
+   "ground"
+  ],
+  "height": 18,
+  "weight": 2230,
+  "stats": {
+   "hp": 130,
+   "attack": 75,
+   "defense": 60,
+   "special-attack": 45,
+   "special-defense": 100,
+   "speed": 20
+  },
+  "flavor": "When attacked, this Pokémon will retaliate by sticking thick spines out from its body. It’s a risky move that puts everything on the line."
+ },
+ {
+  "id": 981,
+  "name": "farigiraf",
+  "types": [
+   "normal",
+   "psychic"
+  ],
+  "height": 32,
+  "weight": 1600,
+  "stats": {
+   "hp": 120,
+   "attack": 90,
+   "defense": 70,
+   "special-attack": 110,
+   "special-defense": 70,
+   "speed": 60
+  },
+  "flavor": "Now that the brain waves from the head and tail are synced up, the psychic power of this Pokémon is 10 times stronger than Girafarig’s."
+ },
+ {
+  "id": 982,
+  "name": "dudunsparce-two-segment",
+  "types": [
+   "normal"
+  ],
+  "height": 36,
+  "weight": 392,
+  "stats": {
+   "hp": 125,
+   "attack": 100,
+   "defense": 80,
+   "special-attack": 85,
+   "special-defense": 75,
+   "speed": 55
+  },
+  "flavor": "This Pokémon uses its hard tail to make its nest by boring holes into bedrock deep underground. The nest can reach lengths of over six miles."
+ },
+ {
+  "id": 983,
+  "name": "kingambit",
+  "types": [
+   "dark",
+   "steel"
+  ],
+  "height": 20,
+  "weight": 1200,
+  "stats": {
+   "hp": 100,
+   "attack": 135,
+   "defense": 120,
+   "special-attack": 60,
+   "special-defense": 85,
+   "speed": 50
+  },
+  "flavor": "Only a Bisharp that stands above all others in its vast army can evolve into Kingambit."
+ },
+ {
+  "id": 984,
+  "name": "great-tusk",
+  "types": [
+   "ground",
+   "fighting"
+  ],
+  "height": 22,
+  "weight": 3200,
+  "stats": {
+   "hp": 115,
+   "attack": 131,
+   "defense": 131,
+   "special-attack": 53,
+   "special-defense": 53,
+   "speed": 87
+  },
+  "flavor": "Sightings of this Pokémon have occurred in recent years. The name Great Tusk was taken from a creature listed in a certain book."
+ },
+ {
+  "id": 985,
+  "name": "scream-tail",
+  "types": [
+   "fairy",
+   "psychic"
+  ],
+  "height": 12,
+  "weight": 80,
+  "stats": {
+   "hp": 115,
+   "attack": 65,
+   "defense": 99,
+   "special-attack": 65,
+   "special-defense": 115,
+   "speed": 111
+  },
+  "flavor": "There has been only one reported sighting of this Pokémon. It resembles a mysterious creature depicted in an old expedition journal."
+ },
+ {
+  "id": 986,
+  "name": "brute-bonnet",
+  "types": [
+   "grass",
+   "dark"
+  ],
+  "height": 12,
+  "weight": 210,
+  "stats": {
+   "hp": 111,
+   "attack": 127,
+   "defense": 99,
+   "special-attack": 79,
+   "special-defense": 99,
+   "speed": 55
+  },
+  "flavor": "It is possible that the creature listed as Brute Bonnet in a certain book could actually be this Pokémon."
+ },
+ {
+  "id": 987,
+  "name": "flutter-mane",
+  "types": [
+   "ghost",
+   "fairy"
+  ],
+  "height": 14,
+  "weight": 40,
+  "stats": {
+   "hp": 55,
+   "attack": 55,
+   "defense": 55,
+   "special-attack": 135,
+   "special-defense": 135,
+   "speed": 135
+  },
+  "flavor": "This Pokémon has characteristics similar to those of Flutter Mane, a creature mentioned in a certain book."
+ },
+ {
+  "id": 988,
+  "name": "slither-wing",
+  "types": [
+   "bug",
+   "fighting"
+  ],
+  "height": 32,
+  "weight": 920,
+  "stats": {
+   "hp": 85,
+   "attack": 135,
+   "defense": 79,
+   "special-attack": 85,
+   "special-defense": 105,
+   "speed": 81
+  },
+  "flavor": "This mysterious Pokémon has some similarities to a creature that an old book introduced as Slither Wing."
+ },
+ {
+  "id": 989,
+  "name": "sandy-shocks",
+  "types": [
+   "electric",
+   "ground"
+  ],
+  "height": 23,
+  "weight": 600,
+  "stats": {
+   "hp": 85,
+   "attack": 81,
+   "defense": 97,
+   "special-attack": 121,
+   "special-defense": 85,
+   "speed": 101
+  },
+  "flavor": "It slightly resembles a Magneton that lived for 10,000 years and was featured in an article in a paranormal magazine."
+ },
+ {
+  "id": 990,
+  "name": "iron-treads",
+  "types": [
+   "ground",
+   "steel"
+  ],
+  "height": 9,
+  "weight": 2400,
+  "stats": {
+   "hp": 90,
+   "attack": 112,
+   "defense": 120,
+   "special-attack": 72,
+   "special-defense": 70,
+   "speed": 106
+  },
+  "flavor": "This Pokémon closely resembles a scientific weapon that a paranormal magazine claimed was sent to this planet by aliens."
+ },
+ {
+  "id": 991,
+  "name": "iron-bundle",
+  "types": [
+   "ice",
+   "water"
+  ],
+  "height": 6,
+  "weight": 110,
+  "stats": {
+   "hp": 56,
+   "attack": 80,
+   "defense": 114,
+   "special-attack": 124,
+   "special-defense": 60,
+   "speed": 136
+  },
+  "flavor": "Its shape is similar to a robot featured in a paranormal magazine article. The robot was said to have been created by an ancient civilization."
+ },
+ {
+  "id": 992,
+  "name": "iron-hands",
+  "types": [
+   "fighting",
+   "electric"
+  ],
+  "height": 18,
+  "weight": 3807,
+  "stats": {
+   "hp": 154,
+   "attack": 140,
+   "defense": 108,
+   "special-attack": 50,
+   "special-defense": 68,
+   "speed": 50
+  },
+  "flavor": "It is very similar to a cyborg covered exclusively by a paranormal magazine. The cyborg was said to be the modified form of a certain athlete."
+ },
+ {
+  "id": 993,
+  "name": "iron-jugulis",
+  "types": [
+   "dark",
+   "flying"
+  ],
+  "height": 13,
+  "weight": 1110,
+  "stats": {
+   "hp": 94,
+   "attack": 80,
+   "defense": 86,
+   "special-attack": 122,
+   "special-defense": 80,
+   "speed": 108
+  },
+  "flavor": "It resembles a certain Pokémon introduced in a paranormal magazine, described as the offspring of a Hydreigon that fell in love with a robot."
+ },
+ {
+  "id": 994,
+  "name": "iron-moth",
+  "types": [
+   "fire",
+   "poison"
+  ],
+  "height": 12,
+  "weight": 360,
+  "stats": {
+   "hp": 80,
+   "attack": 70,
+   "defense": 60,
+   "special-attack": 140,
+   "special-defense": 110,
+   "speed": 110
+  },
+  "flavor": "This Pokémon resembles an unknown object described in a paranormal magazine as a UFO sent to observe humanity."
+ },
+ {
+  "id": 995,
+  "name": "iron-thorns",
+  "types": [
+   "rock",
+   "electric"
+  ],
+  "height": 16,
+  "weight": 3030,
+  "stats": {
+   "hp": 100,
+   "attack": 134,
+   "defense": 110,
+   "special-attack": 70,
+   "special-defense": 84,
+   "speed": 72
+  },
+  "flavor": "It has some similarities to a Pokémon introduced in a dubious magazine as a Tyranitar from one billion years into the future."
+ },
+ {
+  "id": 996,
+  "name": "frigibax",
+  "types": [
+   "dragon",
+   "ice"
+  ],
+  "height": 5,
+  "weight": 170,
+  "stats": {
+   "hp": 65,
+   "attack": 75,
+   "defense": 45,
+   "special-attack": 35,
+   "special-defense": 45,
+   "speed": 55
+  },
+  "flavor": "Frigibax absorbs heat through its dorsal fin and converts the heat into ice energy. The higher the temperature, the more energy Frigibax stores."
+ },
+ {
+  "id": 997,
+  "name": "arctibax",
+  "types": [
+   "dragon",
+   "ice"
+  ],
+  "height": 8,
+  "weight": 300,
+  "stats": {
+   "hp": 90,
+   "attack": 95,
+   "defense": 66,
+   "special-attack": 45,
+   "special-defense": 65,
+   "speed": 62
+  },
+  "flavor": "Arctibax freezes the air around it, protecting its face with an ice mask and turning its dorsal fin into a blade of ice."
+ },
+ {
+  "id": 998,
+  "name": "baxcalibur",
+  "types": [
+   "dragon",
+   "ice"
+  ],
+  "height": 21,
+  "weight": 2100,
+  "stats": {
+   "hp": 115,
+   "attack": 145,
+   "defense": 92,
+   "special-attack": 75,
+   "special-defense": 86,
+   "speed": 87
+  },
+  "flavor": "This Pokémon blasts cryogenic air out from its mouth. This air can instantly freeze even liquid-hot lava."
+ },
+ {
+  "id": 999,
+  "name": "gimmighoul",
+  "types": [
+   "ghost"
+  ],
+  "height": 3,
+  "weight": 50,
+  "stats": {
+   "hp": 45,
+   "attack": 30,
+   "defense": 70,
+   "special-attack": 75,
+   "special-defense": 70,
+   "speed": 10
+  },
+  "flavor": "This Pokémon was born inside a treasure chest about 1,500 years ago. It sucks the life-force out of scoundrels who try to steal the treasure."
+ },
+ {
+  "id": 1000,
+  "name": "gholdengo",
+  "types": [
+   "steel",
+   "ghost"
+  ],
+  "height": 12,
+  "weight": 300,
+  "stats": {
+   "hp": 87,
+   "attack": 60,
+   "defense": 95,
+   "special-attack": 133,
+   "special-defense": 91,
+   "speed": 84
+  },
+  "flavor": "Its body seems to be made up of 1,000 coins. This Pokémon gets along well with others and is quick to make friends with anybody."
+ },
+ {
+  "id": 1001,
+  "name": "wo-chien",
+  "types": [
+   "dark",
+   "grass"
+  ],
+  "height": 15,
+  "weight": 742,
+  "stats": {
+   "hp": 85,
+   "attack": 85,
+   "defense": 100,
+   "special-attack": 95,
+   "special-defense": 135,
+   "speed": 70
+  },
+  "flavor": "The grudge of a person punished for writing the king’s evil deeds upon wooden tablets has clad itself in dead leaves to become a Pokémon."
+ },
+ {
+  "id": 1002,
+  "name": "chien-pao",
+  "types": [
+   "dark",
+   "ice"
+  ],
+  "height": 19,
+  "weight": 1522,
+  "stats": {
+   "hp": 80,
+   "attack": 120,
+   "defense": 80,
+   "special-attack": 90,
+   "special-defense": 65,
+   "speed": 135
+  },
+  "flavor": "This Pokémon can control 100 tons of fallen snow. It plays around innocently by leaping in and out of avalanches it has caused."
+ },
+ {
+  "id": 1003,
+  "name": "ting-lu",
+  "types": [
+   "dark",
+   "ground"
+  ],
+  "height": 27,
+  "weight": 6997,
+  "stats": {
+   "hp": 155,
+   "attack": 110,
+   "defense": 125,
+   "special-attack": 55,
+   "special-defense": 80,
+   "speed": 45
+  },
+  "flavor": "The fear poured into an ancient ritual vessel has clad itself in rocks and dirt to become a Pokémon."
+ },
+ {
+  "id": 1004,
+  "name": "chi-yu",
+  "types": [
+   "dark",
+   "fire"
+  ],
+  "height": 4,
+  "weight": 49,
+  "stats": {
+   "hp": 55,
+   "attack": 80,
+   "defense": 80,
+   "special-attack": 135,
+   "special-defense": 120,
+   "speed": 100
+  },
+  "flavor": "It controls flames burning at over 5,400 degrees Fahrenheit. It casually swims through the sea of lava it creates by melting rock and sand."
+ },
+ {
+  "id": 1005,
+  "name": "roaring-moon",
+  "types": [
+   "dragon",
+   "dark"
+  ],
+  "height": 20,
+  "weight": 3800,
+  "stats": {
+   "hp": 105,
+   "attack": 139,
+   "defense": 71,
+   "special-attack": 55,
+   "special-defense": 101,
+   "speed": 119
+  },
+  "flavor": "It is possible that this is the creature listed as Roaring Moon in an expedition journal that still holds many mysteries."
+ },
+ {
+  "id": 1006,
+  "name": "iron-valiant",
+  "types": [
+   "fairy",
+   "fighting"
+  ],
+  "height": 14,
+  "weight": 350,
+  "stats": {
+   "hp": 74,
+   "attack": 130,
+   "defense": 90,
+   "special-attack": 120,
+   "special-defense": 60,
+   "speed": 116
+  },
+  "flavor": "It has some similarities to a mad scientist’s invention covered in a paranormal magazine."
+ },
+ {
+  "id": 1007,
+  "name": "koraidon",
+  "types": [
+   "fighting",
+   "dragon"
+  ],
+  "height": 25,
+  "weight": 3030,
+  "stats": {
+   "hp": 100,
+   "attack": 135,
+   "defense": 115,
+   "special-attack": 85,
+   "special-defense": 100,
+   "speed": 135
+  },
+  "flavor": "This seems to be the Winged King mentioned in an old expedition journal. It was said to have split the land with its bare fists."
+ },
+ {
+  "id": 1008,
+  "name": "miraidon",
+  "types": [
+   "electric",
+   "dragon"
+  ],
+  "height": 35,
+  "weight": 2400,
+  "stats": {
+   "hp": 100,
+   "attack": 85,
+   "defense": 100,
+   "special-attack": 135,
+   "special-defense": 115,
+   "speed": 135
+  },
+  "flavor": "Much remains unknown about this creature. It resembles Cyclizar, but it is far more ruthless and powerful."
+ },
+ {
+  "id": 1009,
+  "name": "walking-wake",
+  "types": [
+   "water",
+   "dragon"
+  ],
+  "height": 35,
+  "weight": 2800,
+  "stats": {
+   "hp": 99,
+   "attack": 83,
+   "defense": 91,
+   "special-attack": 125,
+   "special-defense": 83,
+   "speed": 109
+  },
+  "flavor": "This ferocious creature is shrouded in mystery. It's named after an aquatic monster mentioned in an old expedition journal."
+ },
+ {
+  "id": 1010,
+  "name": "iron-leaves",
+  "types": [
+   "grass",
+   "psychic"
+  ],
+  "height": 15,
+  "weight": 1250,
+  "stats": {
+   "hp": 90,
+   "attack": 130,
+   "defense": 88,
+   "special-attack": 70,
+   "special-defense": 108,
+   "speed": 104
+  },
+  "flavor": "Many of its physical characteristics match those of a Virizion from the future that was covered in a paranormal magazine."
+ },
+ {
+  "id": 1011,
+  "name": "dipplin",
+  "types": [
+   "grass",
+   "dragon"
+  ],
+  "height": 4,
+  "weight": 97,
+  "stats": {
+   "hp": 80,
+   "attack": 80,
+   "defense": 110,
+   "special-attack": 95,
+   "special-defense": 80,
+   "speed": 40
+  },
+  "flavor": "Dipplin is two creatures in one Pokémon. Its evolution was triggered by a special apple grown only in one place."
+ },
+ {
+  "id": 1012,
+  "name": "poltchageist",
+  "types": [
+   "grass",
+   "ghost"
+  ],
+  "height": 1,
+  "weight": 11,
+  "stats": {
+   "hp": 40,
+   "attack": 45,
+   "defense": 45,
+   "special-attack": 74,
+   "special-defense": 54,
+   "speed": 50
+  },
+  "flavor": "Supposedly, the regrets of a tea ceremony master who died before perfecting his craft lingered in some matcha and became a Pokémon."
+ },
+ {
+  "id": 1013,
+  "name": "sinistcha",
+  "types": [
+   "grass",
+   "ghost"
+  ],
+  "height": 2,
+  "weight": 22,
+  "stats": {
+   "hp": 71,
+   "attack": 60,
+   "defense": 106,
+   "special-attack": 121,
+   "special-defense": 80,
+   "speed": 70
+  },
+  "flavor": "It pretends to be tea, trying to fool people into drinking it so it can drain their life-force. Its ruse is generally unsuccessful."
+ },
+ {
+  "id": 1014,
+  "name": "okidogi",
+  "types": [
+   "poison",
+   "fighting"
+  ],
+  "height": 18,
+  "weight": 922,
+  "stats": {
+   "hp": 88,
+   "attack": 128,
+   "defense": 115,
+   "special-attack": 58,
+   "special-defense": 86,
+   "speed": 80
+  },
+  "flavor": "After all its muscles were stimulated by the toxic chain around its neck, Okidogi transformed and gained a powerful physique."
+ },
+ {
+  "id": 1015,
+  "name": "munkidori",
+  "types": [
+   "poison",
+   "psychic"
+  ],
+  "height": 10,
+  "weight": 122,
+  "stats": {
+   "hp": 88,
+   "attack": 75,
+   "defense": 66,
+   "special-attack": 130,
+   "special-defense": 90,
+   "speed": 106
+  },
+  "flavor": "The chain is made from toxins that enhance capabilities. It stimulated Munkidori's brain and caused the Pokémon's psychic powers to bloom."
+ },
+ {
+  "id": 1016,
+  "name": "fezandipiti",
+  "types": [
+   "poison",
+   "fairy"
+  ],
+  "height": 14,
+  "weight": 301,
+  "stats": {
+   "hp": 88,
+   "attack": 91,
+   "defense": 82,
+   "special-attack": 70,
+   "special-defense": 125,
+   "speed": 99
+  },
+  "flavor": "Fezandipiti owes its beautiful looks and lovely voice to the toxic stimulants emanating from the chain wrapped around its body."
+ },
+ {
+  "id": 1017,
+  "name": "ogerpon",
+  "types": [
+   "grass"
+  ],
+  "height": 12,
+  "weight": 398,
+  "stats": {
+   "hp": 80,
+   "attack": 120,
+   "defense": 84,
+   "special-attack": 60,
+   "special-defense": 96,
+   "speed": 110
+  },
+  "flavor": "This Pokémon's type changes based on which mask it's wearing. It confounds its enemies with nimble movements and kicks."
+ },
+ {
+  "id": 1018,
+  "name": "archaludon",
+  "types": [
+   "steel",
+   "dragon"
+  ],
+  "height": 20,
+  "weight": 600,
+  "stats": {
+   "hp": 90,
+   "attack": 105,
+   "defense": 130,
+   "special-attack": 125,
+   "special-defense": 65,
+   "speed": 85
+  },
+  "flavor": "It gathers static electricity from its surroundings. The beams it launches when down on all fours are tremendously powerful."
+ },
+ {
+  "id": 1019,
+  "name": "hydrapple",
+  "types": [
+   "grass",
+   "dragon"
+  ],
+  "height": 18,
+  "weight": 930,
+  "stats": {
+   "hp": 106,
+   "attack": 80,
+   "defense": 110,
+   "special-attack": 120,
+   "special-defense": 80,
+   "speed": 44
+  },
+  "flavor": "Seven syrpents live inside an apple made of syrup. The syrpent in the center is the commander."
+ },
+ {
+  "id": 1020,
+  "name": "gouging-fire",
+  "types": [
+   "fire",
+   "dragon"
+  ],
+  "height": 35,
+  "weight": 5900,
+  "stats": {
+   "hp": 105,
+   "attack": 115,
+   "defense": 121,
+   "special-attack": 65,
+   "special-defense": 93,
+   "speed": 91
+  },
+  "flavor": "There are scant few reports of this creature being sighted. One short video shows it rampaging and spouting pillars of flame."
+ },
+ {
+  "id": 1021,
+  "name": "raging-bolt",
+  "types": [
+   "electric",
+   "dragon"
+  ],
+  "height": 52,
+  "weight": 4800,
+  "stats": {
+   "hp": 125,
+   "attack": 73,
+   "defense": 91,
+   "special-attack": 137,
+   "special-defense": 89,
+   "speed": 75
+  },
+  "flavor": "It's said to incinerate everything around it with lightning launched from its fur. Very little is known about this creature."
+ },
+ {
+  "id": 1022,
+  "name": "iron-boulder",
+  "types": [
+   "rock",
+   "psychic"
+  ],
+  "height": 15,
+  "weight": 1625,
+  "stats": {
+   "hp": 90,
+   "attack": 120,
+   "defense": 80,
+   "special-attack": 68,
+   "special-defense": 108,
+   "speed": 124
+  },
+  "flavor": "It resembles a Pokémon described in a dubious magazine as a Terrakion that had been modified by an evil organization."
+ },
+ {
+  "id": 1023,
+  "name": "iron-crown",
+  "types": [
+   "steel",
+   "psychic"
+  ],
+  "height": 16,
+  "weight": 1560,
+  "stats": {
+   "hp": 90,
+   "attack": 72,
+   "defense": 100,
+   "special-attack": 122,
+   "special-defense": 108,
+   "speed": 98
+  },
+  "flavor": "It resembles a mysterious object introduced in a paranormal magazine as a cutting-edge weapon shaped like a Cobalion."
+ },
+ {
+  "id": 1024,
+  "name": "terapagos",
+  "types": [
+   "normal"
+  ],
+  "height": 2,
+  "weight": 65,
+  "stats": {
+   "hp": 90,
+   "attack": 65,
+   "defense": 85,
+   "special-attack": 65,
+   "special-defense": 85,
+   "speed": 60
+  },
+  "flavor": "Terapagos protects itself using its power to transform energy into hard crystals. This Pokémon is the source of the Terastal phenomenon."
+ },
+ {
+  "id": 1025,
+  "name": "pecharunt",
+  "types": [
+   "poison",
+   "ghost"
+  ],
+  "height": 3,
+  "weight": 3,
+  "stats": {
+   "hp": 88,
+   "attack": 88,
+   "defense": 160,
+   "special-attack": 88,
+   "special-defense": 88,
+   "speed": 88
+  },
+  "flavor": "It feeds others toxic mochi that draw out desires and capabilities. Those who eat the mochi fall under Pecharunt’s control, chained to its will."
  }
 ]

--- a/src/page/404/page.tsx
+++ b/src/page/404/page.tsx
@@ -9,7 +9,7 @@ export const Page = ({ title, navigation }: Props) => {
       <title>{title}</title>
     <div className={styles["NotFound"]}>
         <h1>{title}</h1>
-        <p>The page you are looking for does not exist. If you were hunting a Pokémon outside gen 1, this deploy may be static-only — clone the repo and run <code>npm run demo</code> for the per-request path.</p>
+        <p>The page you are looking for does not exist. If you were hunting a special form (a Mega, a regional variant), this deploy may be static-only — clone the repo and run <code>npm run demo</code> for the per-request path.</p>
         <Link to={navigation.back.href}>{navigation.back.text}</Link>
       </div>
     </>

--- a/src/page/page.tsx
+++ b/src/page/page.tsx
@@ -37,31 +37,28 @@ export const Page = ({ title, navigation, featured, isGithubPages }: Props) => {
             >
               vite-plugin-react-server
             </a>
-            . All 151 original Pokémon are prerendered to static HTML at build
-            time from a committed dataset — no network, no server needed.
+            . Every Pokémon — all 1025 of them — is prerendered to static HTML
+            at build time from a committed dataset. No network, no server
+            needed.
           </p>
           <p>
-            Every other Pokémon renders <em>per request</em> on the same route,
-            fetched live from PokéAPI. Try{" "}
-            {isGithubPages ? (
-              <a href={navigation.toBidoof.href} className={styles["Url"]}>
-                Bidoof
-              </a>
-            ) : (
-              <Link to={navigation.toBidoof.href} className={styles["Url"]}>
-                Bidoof
-              </Link>
-            )}{" "}
-            — it&apos;s gen 4, so it isn&apos;t in the static build.
+            Special forms — Mega evolutions, regional variants — are not in the
+            dataset. On a server they render <em>per request</em> on the same
+            route, fetched live from PokéAPI.
             {isGithubPages &&
-              " (This deploy is static-only, so Bidoof will 404 here — clone the repo and `npm run demo` to see the live path.)"}
+              " (This deploy is static-only, so forms are not available here — clone the repo and `npm run demo` for the live path.)"}{" "}
+            And of course:{" "}
+            <Link to={navigation.toBidoof.href} className={styles["Url"]}>
+              visit Bidoof
+            </Link>
+            .
           </p>
           <nav>
             <Link to={navigation.toPokedex.href} className={styles["Cta"]}>
               {navigation.toPokedex.text}
             </Link>
           </nav>
-          <h2>Starters</h2>
+          <h2>Featured</h2>
           <ul className={styles["Featured"]}>
             {featured.map((pokemon) => (
               <PokemonCard key={pokemon.id} pokemon={pokemon} />

--- a/src/page/pokedex/page.tsx
+++ b/src/page/pokedex/page.tsx
@@ -14,7 +14,7 @@ export const Page = ({ title, pokedex, navigation, searchAction, namesHref, stat
           {navigation.back.text}
         </Link>
         <h1>Pokédex</h1>
-        <p>The {pokedex.length} originals below — the search finds every Pokémon, not just these.</p>
+        <p>All {pokedex.length} Pokémon, prerendered at build time.</p>
         <PokemonSearch namesHref={namesHref} action={searchAction} staticOnly={staticOnly} />
       </header>
       <ul className={styles["Grid"]}>

--- a/src/page/props.ts
+++ b/src/page/props.ts
@@ -1,6 +1,6 @@
 import { baseHref, gen1 } from "../lib/pokedex.js";
 
-const FEATURED_IDS = [1, 4, 7, 25];
+const FEATURED_IDS = [1, 4, 7, 25, 399];
 
 export const props = (url: string) => {
   const pathname = baseHref();


### PR DESCRIPTION
Keeping the demo static-first, properly: instead of curating gen 1 and apologizing for the rest, the committed dataset now covers every species — 1025 pages prerendered in ~17s, dist/static at 23MB. Searching Bidoof on GitHub Pages finds Bidoof.

The per-request story doesn't disappear, it moves to where it genuinely lives: alternate forms (Mega evolutions, regional variants, costumes) are outside the dataset and render live on the server deploy (`npm run demo`). On the static-only deploy they're hidden from search.

- list page with 1025 cards: 505KB HTML / 728KB flight — compresses to ~50-70KB over the wire; paginating by generation is an easy follow-up if it ever matters
- e2e per-request cases moved to `pikachu-rock-star`; Bidoof became a static case (11/11 green)
- Pages simulation at the base path: bidoof static + searchable, forms hidden, hydration clean

Supersedes #133, which is closed — no more "server only" tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)