### PR TITLE
feat: Cloudflare Workers deploy — one build, CDN snapshots + per-request isolate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "^19.2.7",
         "tsx": "^4.22.4",
         "vite": "^8.2.0",
-        "vite-plugin-react-server": "^3.9.1",
+        "vite-plugin-react-server": "^3.10.0",
         "webpack-sources": "^3.5.0"
       }
     },
@@ -1765,9 +1765,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.9.1.tgz",
-      "integrity": "sha512-r4nD73hk9pW05HX5bHDeFOiMjeSAnY+R1a8MzDZOhAChePvz4+2yaKN/oqjJzy7izkShzd8jIAipYyHbuYawIQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.10.0.tgz",
+      "integrity": "sha512-YjnvKD1iYSs1aO0BubQ3kdtx9rF+mx1Km9Gs932h7kzOoGgAV3B7NrnHItPZww7BwloXAo3iFPmNnHegfr/dkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^19.2.7",
     "tsx": "^4.22.4",
     "vite": "^8.2.0",
-    "vite-plugin-react-server": "^3.9.1",
+    "vite-plugin-react-server": "^3.10.0",
     "webpack-sources": "^3.5.0"
   }
 }

--- a/src/page/pokedex/props.ts
+++ b/src/page/pokedex/props.ts
@@ -6,7 +6,9 @@ export const props = (url: string) => ({
   generations: GENERATIONS,
   searchAction: `${baseHref()}pokedex/`,
   namesHref: `${baseHref()}names.json`,
-  staticOnly: process.env.GITHUB_PAGES === "true",
+  // Guarded: bare `process` does not exist on edge runtimes (workerd).
+  staticOnly:
+    typeof process !== "undefined" && process.env.GITHUB_PAGES === "true",
   navigation: {
     back: { href: baseHref(), text: "Home" },
   },

--- a/src/page/props.ts
+++ b/src/page/props.ts
@@ -11,7 +11,9 @@ export const props = (url: string) => {
       toPokedex: { href: `${pathname}pokedex/`, text: "Browse the Pokédex" },
     },
     featured: gen1.filter((p) => FEATURED_IDS.includes(p.id)),
-    isGithubPages: process.env.GITHUB_PAGES === "true",
+    // Guarded: bare `process` does not exist on edge runtimes (workerd).
+    isGithubPages:
+      typeof process !== "undefined" && process.env.GITHUB_PAGES === "true",
   };
 };
 

--- a/src/server/actions/favoriteActions.server.ts
+++ b/src/server/actions/favoriteActions.server.ts
@@ -1,7 +1,8 @@
 "use server";
-import { db } from "../db.server.js";
+import { getDb } from "../db.server.js";
 
 export async function getFavorites(): Promise<string[]> {
+  const db = await getDb();
   const stmt = db.prepare("SELECT name FROM favorites ORDER BY created_at ASC");
   return (stmt.all() as { name: string }[]).map((row) => row.name);
 }
@@ -9,6 +10,7 @@ export async function getFavorites(): Promise<string[]> {
 export async function toggleFavorite(
   name: string,
 ): Promise<{ favorite: boolean }> {
+  const db = await getDb();
   const exists = db
     .prepare("SELECT 1 FROM favorites WHERE name = ?")
     .get(name);

--- a/src/server/db.server.ts
+++ b/src/server/db.server.ts
@@ -1,14 +1,22 @@
-import sqlite from "node:sqlite";
+// Lazy on purpose: a top-level `import "node:sqlite"` would be baked into the
+// edge bundle's module scope and crash evaluation on runtimes without node
+// builtins (Cloudflare Workers). Deferring the import keeps the bundle
+// boot-safe everywhere; the import only runs when a favorites action actually
+// executes, which needs a Node host.
+type SqliteDb = import("node:sqlite").DatabaseSync;
 
-const db = new sqlite.DatabaseSync("pokedex.db", {
-  open: true,
-});
+let db: SqliteDb | undefined;
 
-db.exec(`
-  CREATE TABLE IF NOT EXISTS favorites (
-    name TEXT PRIMARY KEY,
-    created_at TEXT DEFAULT CURRENT_TIMESTAMP
-  ) STRICT
-`);
-
-export { db };
+export async function getDb(): Promise<SqliteDb> {
+  if (!db) {
+    const { DatabaseSync } = await import("node:sqlite");
+    db = new DatabaseSync("pokedex.db", { open: true });
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS favorites (
+        name TEXT PRIMARY KEY,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP
+      ) STRICT
+    `);
+  }
+  return db;
+}

--- a/src/server/start.tsx
+++ b/src/server/start.tsx
@@ -95,12 +95,25 @@ async function main() {
   // It also carries the baked server-action gate, so the action dispatch never
   // disk-imports the react-server transport either.
   const edgeBundlePath = path.resolve(buildDir, "server-edge", "render.js");
-  const { renderRouteToDocument, handleRouteAction } = (await import(
+  const { renderRouteToDocument, handleRouteAction, flightTransport, clientManifest } = (await import(
     pathToFileURL(edgeBundlePath).href
   )) as {
     renderRouteToDocument: RenderRouteToDocument;
     handleRouteAction: HandleRouteAction;
+    flightTransport?: "esm" | "webpack";
+    clientManifest?: Record<string, { id: string; chunks: string[]; name: string }>;
   };
+
+  // Under transport:"webpack" the flight carries module-map reference rows the
+  // runtime (esm) consumer cannot resolve — decode + HTML render must go
+  // through the BAKED consumer, which carries client React and the closed
+  // client-module registry. The pair ships together; the esm transport has no
+  // consumer bake and keeps the runtime path.
+  const consumerPath = path.resolve(buildDir, "server-edge", "consumer.js");
+  const { renderFlightToHtml: bakedRenderFlightToHtml } =
+    flightTransport === "webpack"
+      ? await import(pathToFileURL(consumerPath).href)
+      : { renderFlightToHtml: undefined };
 
   // Flash-free per-request document for one URL: full inline-flight HTML in
   // one isolate.
@@ -110,6 +123,16 @@ async function main() {
       moduleBaseURL: ssrModuleBaseURL,
       bootstrapModules,
       getURL: () => route,
+      flightTransport,
+      clientManifest,
+      renderFlightToHtml: bakedRenderFlightToHtml,
+      // The browser's client entry is transport-agnostic and picks its flight
+      // decoder from this inline hint — prerendered documents carry it from
+      // the freeze; a per-request document must stamp it itself.
+      bootstrapScriptContent:
+        flightTransport === "webpack"
+          ? 'self.__vprsFlightTransport="webpack";'
+          : undefined,
     });
 
   const notFoundPage = path.join(staticDir, "404", "index.html");

--- a/vite.react.config.ts
+++ b/vite.react.config.ts
@@ -21,6 +21,11 @@ export default {
   // No moduleBaseURL: vprs ≥3.2.3 takes Vite's `base` (vite.config.ts reads
   // BASE_URL), so the deploy base is configured once.
   publicOrigin: process.env.PUBLIC_ORIGIN || "",
+  // One flight flavor for the whole deploy: snapshots freeze through the baked
+  // webpack pair and the same pair renders per request, so the CDN copies and
+  // the Cloudflare Worker serve interchangeably (the worker consumer bundle
+  // only exists under this transport).
+  transport: "webpack",
   serverEntry: "src/server/index.ts",
   css: {
     inlineThreshold: 10000,

--- a/worker.mjs
+++ b/worker.mjs
@@ -1,0 +1,54 @@
+// Cloudflare Worker entry: the per-request half of the deploy.
+//
+// The prerendered snapshots in dist/static are served by the assets binding
+// BEFORE this worker runs, so only misses land here — a Pokémon that wasn't
+// prerendered, its .rsc payload on client navigation, and server actions.
+// Everything below uses the baked pair alone (dist/server-edge): importing
+// vite-plugin-react-server subpaths here would drag node builtins into the
+// bundle, and the pair needs none.
+import * as bundle from "./dist/server-edge/render.js";
+import { renderFlightToHtml } from "./dist/server-edge/consumer.js";
+
+const RSC_SUFFIX = /\/index\.rsc$/;
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    try {
+      if (request.method === "POST" && request.headers.get("x-rsc-action")) {
+        return await bundle.handleRouteAction(request);
+      }
+
+      if (RSC_SUFFIX.test(url.pathname)) {
+        const route = url.pathname.replace(RSC_SUFFIX, "/");
+        const { headless } = await bundle.renderRouteToDocument(route, {
+          request,
+        });
+        return new Response(headless, {
+          headers: { "content-type": "text/x-component; charset=utf-8" },
+        });
+      }
+
+      const { full } = await bundle.renderRouteToDocument(url.pathname, {
+        request,
+      });
+      const html = await renderFlightToHtml({
+        rscStream: full,
+        bootstrapModules: bundle.bootstrapModules,
+        // The transport hint the client entry reads to pick its flight
+        // decoder — prerendered documents carry it from the freeze; a
+        // per-request document must stamp it itself.
+        bootstrapScriptContent: 'self.__vprsFlightTransport="webpack";',
+      });
+      return new Response(html, {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    } catch (e) {
+      if (/unknown route|not.*baked|no route/i.test(String(e?.message ?? e))) {
+        return new Response("Not found", { status: 404 });
+      }
+      console.error(e);
+      return new Response("Render error", { status: 500 });
+    }
+  },
+};

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,12 @@
+{
+  // Cloudflare Workers deploy: prerendered snapshots from assets, everything
+  // else per-request through worker.mjs (the baked single-isolate pair).
+  // Build: npm run build · Deploy: npx wrangler deploy
+  "name": "vprs-pokedex-demo",
+  "main": "worker.mjs",
+  "compatibility_date": "2026-07-01",
+  "assets": {
+    "directory": "./dist/static",
+    "not_found_handling": "none"
+  }
+}


### PR DESCRIPTION
## What

Connect this repo to a Cloudflare Workers app (build `npm run build`, deploy `npx wrangler deploy`) and the same build serves both halves of the demo:

- **Static half**: the prerendered snapshots (`dist/static`, all 1037 pages) are uploaded as Workers assets and served before the worker runs — CDN behavior, same as the GitHub Pages deploy.
- **Prod half**: anything not prerendered (alternate forms, `.rsc` payloads for client navigation, server actions) lands in `worker.mjs`, which renders per request inside the isolate through the baked pair (`dist/server-edge/render.js` + `consumer.js`). The worker imports the pair alone — no `vite-plugin-react-server` package imports, no node builtins, no `nodejs_compat` flag.

`transport: "webpack"` is what makes the halves interchangeable: one flight flavor across snapshots, per-request documents, and the browser client.

## What the flip surfaced (each fix load-bearing beyond Workers)

1. **`db.server.ts` opens SQLite lazily.** A module-scope `node:sqlite` import gets baked into the edge bundle's top level and crashes module evaluation on runtimes without node builtins. Favorites behave identically on Node; on a runtime without sqlite the action fails loud instead of the whole isolate failing to boot.
2. **`start.tsx` renders through the baked consumer under the webpack transport.** The runtime (esm) consumer resolves references by `import(specifier)` and cannot resolve webpack module-map rows — the live-render path 500'd with "Element type is invalid". It also stamps `self.__vprsFlightTransport` on per-request documents: prerendered documents carry the hint from the freeze, live documents must stamp it themselves or the browser picks the esm decoder and hydration dies with React #306.
3. **Render-time `process.env` reads are guarded** for runtimes with no global `process`.

## Verification

- Full e2e gate **12/12**: prerendered pages, the live per-request PokéAPI page (browser-hydrated), favorites toggle persisting across reload, navigation transition state.
- The baked pair booted and rendered in **real workerd** (miniflare 4, no `nodejs_compat`): home + species documents (`<!DOCTYPE html>`, styles, bootstrap), webpack-flavored `.rsc` for client nav, 404 for unknown routes.

## Deploy

Cloudflare dashboard → Workers → create from this repo (or branch): build command `npm run build`, deploy command `npx wrangler deploy`. Free tier fits comfortably: the pair is ~195 KB gzipped against a 3 MB limit, 2104 static files against a 20k limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)