### PR TITLE
fix: GitHub Pages deploy stays on the esm transport

### DIFF
--- a/vite.react.config.ts
+++ b/vite.react.config.ts
@@ -21,11 +21,14 @@ export default {
   // No moduleBaseURL: vprs ≥3.2.3 takes Vite's `base` (vite.config.ts reads
   // BASE_URL), so the deploy base is configured once.
   publicOrigin: process.env.PUBLIC_ORIGIN || "",
-  // One flight flavor for the whole deploy: snapshots freeze through the baked
-  // webpack pair and the same pair renders per request, so the CDN copies and
-  // the Cloudflare Worker serve interchangeably (the worker consumer bundle
-  // only exists under this transport).
-  transport: "webpack",
+  // One flight flavor PER DEPLOY. The Cloudflare/Node deploys use webpack:
+  // snapshots freeze through the baked pair and the same pair renders per
+  // request, so CDN copies and the Worker serve interchangeably (the worker
+  // consumer bundle only exists under that transport). The GitHub Pages
+  // deploy stays esm: webpack chunk ids are root-relative and the browser
+  // chunk loader does not apply BASE_URL, so a subpath deploy 404s every
+  // client chunk (vprs bug; flip Pages to webpack when it can honor base).
+  transport: process.env.GITHUB_PAGES === "true" ? "esm" : "webpack",
   serverEntry: "src/server/index.ts",
   css: {
     inlineThreshold: 10000,


### PR DESCRIPTION
## Why

The live Pages demo broke on the last deploy: under `transport: "webpack"`, the flight's chunk ids are root-relative (`/components/…`) and the browser chunk loader fetches them from the **domain root** — on the subpath Pages deploy every client chunk 404s, so pages render but hydration is dead (no walking bidoof, no client nav, no search).

That's an upstream vite-plugin-react-server bug (the webpack browser chunk loader doesn't apply `BASE_URL`), being tracked there. This repo's fix is deploy-scoped transport:

- **GitHub Pages** (`GITHUB_PAGES=true` build): back to the **esm** flavor it served all along — root-relative module URLs work there because the esm client resolves through `moduleBaseURL`.
- **Cloudflare/Node**: keep the **webpack** pair (root-based deploys; the worker consumer only exists under webpack).

Each deploy remains internally one-flavored, which is the actual invariant.

## Verification

Built with the exact Pages env (`npm run build:gh`): 1037 pages, zero webpack chunk-array rows in the snapshots, no webpack transport hint — byte-shape of the long-proven Pages deploy.

Merging redeploys Pages and restores the live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)