### PR TITLE
fix: alternate-form ids use official artwork

### DIFF
--- a/src/lib/sprites.ts
+++ b/src/lib/sprites.ts
@@ -4,7 +4,12 @@
 const SPRITES =
   "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon";
 
-export const sprite = (id: number) => `${SPRITES}/${id}.png`;
-export const spriteBack = (id: number) => `${SPRITES}/back/${id}.png`;
 export const artwork = (id: number) =>
   `${SPRITES}/other/official-artwork/${id}.png`;
+// Alternate forms (ids >= 10000) have no default sprite in the PokeAPI
+// repo — only official artwork exists for them (default 10158 is a 404,
+// official-artwork/10158 is not). Base species keep the small default
+// sprite so grids stay light.
+export const sprite = (id: number) =>
+  id >= 10000 ? artwork(id) : `${SPRITES}/${id}.png`;
+export const spriteBack = (id: number) => `${SPRITES}/back/${id}.png`;


### PR DESCRIPTION
Alternate forms (ids ≥ 10000, e.g. pikachu-rock-star = 10158) have no default sprite in the PokeAPI sprites repo — `sprites/pokemon/10158.png` 404s while `other/official-artwork/10158.png` exists. `sprite()` now routes form ids to the artwork; base species keep the small default sprites so grid pages stay light.

Verified: full e2e gate 12/12 on the production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)