### PR TITLE
fix: Pages back on the webpack transport (vprs 3.10.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "^19.2.7",
         "tsx": "^4.22.4",
         "vite": "^8.2.0",
-        "vite-plugin-react-server": "^3.10.0",
+        "vite-plugin-react-server": "^3.10.1",
         "webpack-sources": "^3.5.0"
       }
     },
@@ -1765,9 +1765,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.10.0.tgz",
-      "integrity": "sha512-YjnvKD1iYSs1aO0BubQ3kdtx9rF+mx1Km9Gs932h7kzOoGgAV3B7NrnHItPZww7BwloXAo3iFPmNnHegfr/dkg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.10.1.tgz",
+      "integrity": "sha512-Hxn178A0GmCgCFYBUzjrhuQ9TZFhhNycY06ELxHfVZtLAkZd/J8SJ8YqqqzRndrJ/f9hfxx4GEwV9JATU9Fx7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^19.2.7",
     "tsx": "^4.22.4",
     "vite": "^8.2.0",
-    "vite-plugin-react-server": "^3.10.0",
+    "vite-plugin-react-server": "^3.10.1",
     "webpack-sources": "^3.5.0"
   }
 }

--- a/vite.react.config.ts
+++ b/vite.react.config.ts
@@ -21,14 +21,11 @@ export default {
   // No moduleBaseURL: vprs ≥3.2.3 takes Vite's `base` (vite.config.ts reads
   // BASE_URL), so the deploy base is configured once.
   publicOrigin: process.env.PUBLIC_ORIGIN || "",
-  // One flight flavor PER DEPLOY. The Cloudflare/Node deploys use webpack:
-  // snapshots freeze through the baked pair and the same pair renders per
-  // request, so CDN copies and the Worker serve interchangeably (the worker
-  // consumer bundle only exists under that transport). The GitHub Pages
-  // deploy stays esm: webpack chunk ids are root-relative and the browser
-  // chunk loader does not apply BASE_URL, so a subpath deploy 404s every
-  // client chunk (vprs bug; flip Pages to webpack when it can honor base).
-  transport: process.env.GITHUB_PAGES === "true" ? "esm" : "webpack",
+  // One flight flavor for the whole deploy: snapshots freeze through the
+  // baked webpack pair and the same pair renders per request, so CDN copies
+  // (GitHub Pages included — vprs >=3.10.1 resolves chunk urls against the
+  // deploy's base) and the Cloudflare Worker serve interchangeably.
+  transport: "webpack",
   serverEntry: "src/server/index.ts",
   css: {
     inlineThreshold: 10000,


### PR DESCRIPTION
vprs 3.10.1's chunk loader resolves ids against the deploy's `BASE_URL`, so the subpath Pages deploy works on the webpack transport — this reverts the per-deploy esm split that hotfixed the outage, restoring one flavor for the whole deploy (one thoughtless config line).

Verified before merge:
- Pages-env build (`build:gh`): 1037 pages, webpack-flavored snapshots + transport hint present.
- Subpath browser acceptance against the **released** 3.10.1: served under `/vite-plugin-react-server-demo-official/`, real browser — 3 chunk loads, zero 404s, zero page errors, live client-side navigation.
- Full e2e gate at root: 12/12.

Merging redeploys Pages webpack-flavored — the live end-to-end proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)