### PR TITLE
fix: Pages back on the webpack transport, vprs 3.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "^19.2.7",
         "tsx": "^4.22.4",
         "vite": "^8.2.0",
-        "vite-plugin-react-server": "^3.10.1",
+        "vite-plugin-react-server": "^3.10.2",
         "webpack-sources": "^3.5.0"
       }
     },
@@ -1765,9 +1765,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.10.1.tgz",
-      "integrity": "sha512-Hxn178A0GmCgCFYBUzjrhuQ9TZFhhNycY06ELxHfVZtLAkZd/J8SJ8YqqqzRndrJ/f9hfxx4GEwV9JATU9Fx7g==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.10.2.tgz",
+      "integrity": "sha512-6X8QfNhsexeJYyd0wDE9DB8rMQ/L9nicqp+M2VsvasQ9rAMcX5XPuBWAMVH1vgOwP13m6gkPL4uTQyhbU3aAaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "^19.2.7",
         "tsx": "^4.22.4",
         "vite": "^8.2.0",
-        "vite-plugin-react-server": "^3.10.0",
+        "vite-plugin-react-server": "^3.10.1",
         "webpack-sources": "^3.5.0"
       }
     },
@@ -1765,9 +1765,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.10.0.tgz",
-      "integrity": "sha512-YjnvKD1iYSs1aO0BubQ3kdtx9rF+mx1Km9Gs932h7kzOoGgAV3B7NrnHItPZww7BwloXAo3iFPmNnHegfr/dkg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.10.1.tgz",
+      "integrity": "sha512-Hxn178A0GmCgCFYBUzjrhuQ9TZFhhNycY06ELxHfVZtLAkZd/J8SJ8YqqqzRndrJ/f9hfxx4GEwV9JATU9Fx7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^19.2.7",
     "tsx": "^4.22.4",
     "vite": "^8.2.0",
-    "vite-plugin-react-server": "^3.10.1",
+    "vite-plugin-react-server": "^3.10.2",
     "webpack-sources": "^3.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^19.2.7",
     "tsx": "^4.22.4",
     "vite": "^8.2.0",
-    "vite-plugin-react-server": "^3.10.0",
+    "vite-plugin-react-server": "^3.10.1",
     "webpack-sources": "^3.5.0"
   }
 }

--- a/vite.react.config.ts
+++ b/vite.react.config.ts
@@ -21,14 +21,11 @@ export default {
   // No moduleBaseURL: vprs ≥3.2.3 takes Vite's `base` (vite.config.ts reads
   // BASE_URL), so the deploy base is configured once.
   publicOrigin: process.env.PUBLIC_ORIGIN || "",
-  // One flight flavor PER DEPLOY. The Cloudflare/Node deploys use webpack:
-  // snapshots freeze through the baked pair and the same pair renders per
-  // request, so CDN copies and the Worker serve interchangeably (the worker
-  // consumer bundle only exists under that transport). The GitHub Pages
-  // deploy stays esm: webpack chunk ids are root-relative and the browser
-  // chunk loader does not apply BASE_URL, so a subpath deploy 404s every
-  // client chunk (vprs bug; flip Pages to webpack when it can honor base).
-  transport: process.env.GITHUB_PAGES === "true" ? "esm" : "webpack",
+  // One flight flavor for the whole deploy: snapshots freeze through the
+  // baked webpack pair and the same pair renders per request, so CDN copies
+  // (GitHub Pages included — vprs >=3.10.1 resolves chunk urls against the
+  // deploy's base) and the Cloudflare Worker serve interchangeably.
+  transport: "webpack",
   serverEntry: "src/server/index.ts",
   css: {
     inlineThreshold: 10000,


### PR DESCRIPTION
Returns the GitHub Pages deploy to the webpack flight transport: since vite-plugin-react-server 3.10.1 the browser chunk loader resolves chunk ids against BASE_URL, which was the blocker that forced the esm fallback in #137.

Verified against the built output served under the Pages subpath (/vite-plugin-react-server-demo-official/): all runtime chunks load same-origin under the base, zero page or hydration errors, transport hint stamped in the prerendered documents. 3.10.2 additionally fixes the protocol-relative script src the esm static path could bake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)