### PR TITLE
docs: README tells the technical story — one build, three artifacts, two deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-# Bidoof Template
+# Pokédex demo — vite-plugin-react-server
 
-A static-first Pokédex starter built on [vite-plugin-react-server](https://github.com/nicobrinkkemper/vite-plugin-react-server) — React Server Components with ESM, Vite, and React.
+The official demo for [vite-plugin-react-server](https://github.com/nicobrinkkemper/vite-plugin-react-server):
+React Server Components as a Vite plugin, not a framework. One `vite build`
+produces a fully static site, and the same artifacts serve dynamic
+per-request renders when you put a server behind them.
 
-[See the example hosted on Github pages](https://nicobrinkkemper.github.io/vite-plugin-react-server-demo-official/)
+**[Open the live demo](https://nicobrinkkemper.github.io/vite-plugin-react-server-demo-official/)** (GitHub Pages, the static-only deploy)
 
 The app is small on purpose; every route exists to show one capability:
 
@@ -14,125 +17,91 @@ The app is small on purpose; every route exists to show one capability:
 | `/pokedex/$name/` | **hybrid** | file-router dynamic params: every species is prerendered via `staticPaths`; **special forms (Megas, regional variants) render per request** on the same route, fetched live from PokéAPI |
 | `/404/` | static | `notFound()` thrown from a loader |
 
-The full dex — 1025 pages — prerenders in about 17 seconds. What stays dynamic are the alternate forms (Mega evolutions, regional variants, costumes): they render through the server's live path (`npm run demo`), flash-free, in a single Node isolate with no `--conditions` flag. On the static-only GitHub Pages deploy those URLs answer 404, which is the honest difference between the two render modes.
+## One build, three artifacts
 
-Also demonstrated:
+`npm run build` runs a single `vite build --app` under the `react-server`
+condition and emits everything both deploy modes need:
 
-- `"use server"` actions with a SQLite database — the ★ favorite button on every Pokémon page round-trips through the sealed action gate (persistence proven by the e2e suite via reload)
-- Client-side navigation with typed routes (`Link` autocompletes the route patterns)
-- Client / server boundary: error boundary, `useState`, hydration from the inlined flight payload
-- Static site generation with "headless" `index.rsc` files next to fully static `index.html` files
+- **`dist/static`** — 1,037 prerendered pages (about two seconds on a
+  laptop). Each page is a complete `index.html` with its RSC flight payload
+  inlined, plus a headless `index.rsc` sibling. First paint hydrates from the
+  inlined payload — no extra round-trip; client-side navigation fetches the
+  target's `.rsc`.
+- **`dist/client`** — the browser bundle: client components, the router, the
+  flight decoder.
+- **`dist/server` + `dist/server-edge`** — the production server bundle and a
+  baked single-isolate render pair. The baked pair has server React resolved
+  at build time, so per-request rendering needs **no `--conditions` flag and
+  no worker threads** at runtime.
 
-The dataset is committed (`src/data/pokedex.json`) so builds are deterministic and offline; regenerate it with `node scripts/generate-pokedex.mjs`.
+There is no framework server underneath. `src/server/start.tsx` is the
+production server, in the repo, readable: it mounts the emitted artifacts and
+answers everything else with the prerendered 404.
 
-Clone the repository to see the development process in action.
+## Two deploys from the same build
 
-## Features
+- **GitHub Pages** serves `dist/static` as-is. Static-only: the prerendered
+  dex works fully, and special-form URLs answer 404 — the honest difference
+  between the modes, not papered over.
+- **Cloudflare Workers** serves the same static snapshot as assets and routes
+  everything else through the baked pair (`worker.mjs`), so special forms
+  render per request, flash-free, in one isolate.
 
-- ⚡️ [Vite](https://vitejs.dev/) - Lightning fast build tool
-- ⚛️ [React](https://react.dev/) - The library for web and native user interfaces
-- 🎯 TypeScript support
-- 🔄 Server-side rendering with React Server Components
-- 🎨 CSS Modules support
-- 🚀 Static build with RSC support
-- 🛠️ Development and preview support
+Both deploys ship from CI on every push to `main`.
 
-## Prerequisites
+## Also demonstrated
 
-- Node.js (latest recommended)
-- npm or yarn or pnpm
+- `"use server"` actions with a SQLite database — the ★ favorite button on
+  every Pokémon page round-trips through the sealed action gate (persistence
+  proven by the e2e suite via reload)
+- Client-side navigation with typed routes (`Link` autocompletes the route
+  patterns and carries `data-pending`/`aria-busy` while the target's flight
+  loads — the stale-page dimming is a few lines of CSS on those attributes)
+- Client / server boundary: error boundary, `useState`, hydration from the
+  inlined flight payload
+- A Playwright e2e suite that runs against the real production build on every
+  pull request
 
-## Installation
-
-1. Clone the repository:
+## Quick start
 
 ```bash
 git clone https://github.com/nicobrinkkemper/vite-plugin-react-server-demo-official.git
 cd vite-plugin-react-server-demo-official
-```
-
-2. Install dependencies:
-
-```bash
 npm install
+
+npm run dev        # dev server (server-first: react-server condition in Node)
+npm run dev:ssr    # dev server (client-first: Vite owns the boundary)
+
+npm run build      # the full build: static + client + server + baked pair
+npm run demo       # build, then run the production server at :3000
+npm run preview    # build + serve the static output at :4173
+npm test           # production build + Playwright e2e
 ```
 
-3. Start the development server:
+The two dev modes are the same app under the two execution topologies the
+plugin supports; switching between them is how you convince yourself the
+boundary is real.
 
-```bash
-# Server-first dev (RSC condition active in Node)
-npm run dev:rsc
+## Where things are configured
 
-# Client-first dev (no RSC condition; Vite handles the boundary)
-npm run dev:ssr
-```
+- **`vite.config.ts`** — ordinary Vite config; reads `BASE_URL` so one env
+  var sets the deploy base everywhere (GitHub Pages runs under a subpath).
+- **`vite.react.config.ts`** — the plugin config, and the file to read first:
+  file-based routing with `staticPaths` (the prerender worklist), the flight
+  transport, CSS handling, and the server entry are all declared there in
+  40 lines.
 
-4. Build and preview the static site:
-
-```bash
-# Build (default base / origin)
-npm run build
-
-# Build the GitHub Pages variant (static-only: no per-request Pokémon, no favorites)
-npm run build:gh
-
-# Build + serve a local preview at http://localhost:4173
-npm run preview
-```
-
-## Project Structure
-
-```
-project/
-├── src/                     # Source files
-├── public/                  # Static assets
-├── .github/workflows/       # CI/CD (builds + deploys to GitHub Pages)
-├── vite.config.ts           # Vite configuration
-├── vite.react.config.ts     # Plugin configuration (router, pages, entry)
-└── tsconfig.json            # TypeScript configuration
-```
-
-## Build Commands
-
-The build is split into three passes — static prerender, client bundle, server bundle — and each pass has variants per environment (`dev`, `gh`, `preview`). The aggregate scripts compose them:
-
-```bash
-# Default (uses BASE_URL=/, PUBLIC_ORIGIN unset)
-npm run build              # all three passes
-npm run build:static       # prerender RSC + HTML only
-npm run build:client       # client bundle (vite build --ssr)
-npm run build:server       # server bundle (NODE_OPTIONS='--conditions=react-server')
-
-# GitHub Pages variant (BASE_URL=/vite-plugin-react-server-demo-official/)
-npm run build:gh
-
-# Preview variant (BASE_URL set so vite preview serves correctly)
-npm run build:preview
-npm run preview            # build:preview + preview:start
-
-# Full SSR demo: build + run the production node server
-npm run demo               # http://localhost:3000
-```
-
-## Configuration
-
-The project uses Vite configuration file:
-
-### `vite.config.ts`
-
-Adding `vite-plugin-react-server` to vite
-
-### `vite.react.config.ts`
-
-Configuration for the plugin this demo is for
+The dataset is committed (`src/data/pokedex.json`) so builds are
+deterministic and offline; regenerate it with
+`node scripts/generate-pokedex.mjs`.
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+Contributions are welcome — pull requests run the full e2e suite in CI.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+MIT — see [LICENSE](LICENSE).
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ React Server Components as a Vite plugin, not a framework. One `vite build`
 produces a fully static site, and the same artifacts serve dynamic
 per-request renders when you put a server behind them.
 
-**[Open the live demo](https://nicobrinkkemper.github.io/vite-plugin-react-server-demo-official/)** (GitHub Pages, the static-only deploy)
+**[Open the live demo](https://nicobrinkkemper.github.io/vite-plugin-react-server-demo-official/)** (GitHub Pages, static-only) · **[the hybrid deploy](https://vite-plugin-react-server-demo-official.nico-f6d.workers.dev/)** (Cloudflare Workers — special forms render per request)
 
 The app is small on purpose; every route exists to show one capability:
 
@@ -43,9 +43,11 @@ answers everything else with the prerendered 404.
 - **GitHub Pages** serves `dist/static` as-is. Static-only: the prerendered
   dex works fully, and special-form URLs answer 404 — the honest difference
   between the modes, not papered over.
-- **Cloudflare Workers** serves the same static snapshot as assets and routes
-  everything else through the baked pair (`worker.mjs`), so special forms
-  render per request, flash-free, in one isolate.
+- **[Cloudflare Workers](https://vite-plugin-react-server-demo-official.nico-f6d.workers.dev/)**
+  serves the same static snapshot as assets and routes everything else
+  through the baked pair (`worker.mjs`), so special forms render per
+  request, flash-free, in one isolate — try a URL Pages can't answer:
+  [/pokedex/charizard-mega-x/](https://vite-plugin-react-server-demo-official.nico-f6d.workers.dev/pokedex/charizard-mega-x/).
 
 Both deploys ship from CI on every push to `main`.
 


### PR DESCRIPTION
The second half of the packaging pass (#141 is the first): the README now explains to a first-time reader what mechanically happens — a single `vite build --app` under the react-server condition emitting three artifacts (static snapshot with inlined flight + headless .rsc siblings, browser bundle, baked single-isolate pair) and the two deploys those artifacts serve (Pages static-only with honest 404s, Workers hybrid). The emoji feature list, prerequisites padding, and the stale three-pass build docs are gone; the prerender number is re-measured (1,037 pages in ~2s, the old text said 17s).

All claims checked against the built artifacts: inlined `vprs-flight` payload present in the static pages, `.rsc` siblings emitted, config is exactly 40 lines.

**Merge after #141** — this text references the LICENSE file and the PR e2e workflow, both of which land there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)