### PR TITLE
build: vite-plugin-react-server 3.10.2 → 3.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "^19.2.7",
         "tsx": "^4.22.4",
         "vite": "^8.2.0",
-        "vite-plugin-react-server": "^3.10.2",
+        "vite-plugin-react-server": "^3.11.0",
         "webpack-sources": "^3.5.0"
       }
     },
@@ -1765,9 +1765,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.10.2.tgz",
-      "integrity": "sha512-6X8QfNhsexeJYyd0wDE9DB8rMQ/L9nicqp+M2VsvasQ9rAMcX5XPuBWAMVH1vgOwP13m6gkPL4uTQyhbU3aAaQ==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.11.0.tgz",
+      "integrity": "sha512-AxSsco4CXsDJuL/lI7a/jAt6LyT+jP5CKwQSUl8AEmgvEDcUnnyJod6FgpqsOaw5Y3sNIEvvNAc2x7KEmFK1MA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^19.2.7",
     "tsx": "^4.22.4",
     "vite": "^8.2.0",
-    "vite-plugin-react-server": "^3.10.2",
+    "vite-plugin-react-server": "^3.11.0",
     "webpack-sources": "^3.5.0"
   }
 }


### PR DESCRIPTION
Routine bump to the new minor: the dev css HMR fix (dual-graph stylesheets cache-bust their linked copy, edits hot-swap without reload dead ends) and the stripHtmlSuffix router knob. Full e2e suite green locally (12/12) against the production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)