### PR TITLE
build: vprs 3.11.1, react 19.2.8, rsl 19.2.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,11 +17,11 @@
         "@vitejs/plugin-react": "^6.0.5",
         "acorn-loose": "^8.5.2",
         "happy-dom": "^20.10.6",
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
         "tsx": "^4.22.4",
         "vite": "^8.2.0",
-        "vite-plugin-react-server": "^3.11.0",
+        "vite-plugin-react-server": "^3.11.1",
         "webpack-sources": "^3.5.0"
       }
     },
@@ -1540,9 +1540,9 @@
       }
     },
     "node_modules/react-server-loader": {
-      "version": "19.2.19",
-      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.19.tgz",
-      "integrity": "sha512-zwRsbVhd/xm5BO6lAVl/d0pVhq+0vlPPjIAV+RyVzMYeZ7qVErQRaR1eLY9T2R3pg+rZ0ahPPsdvibAfl506uQ==",
+      "version": "19.2.20",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.20.tgz",
+      "integrity": "sha512-Av3ZhAgdmdG9hGRAYpQn0vH9U7buq8MLP90o+PQtSLuwbZrwKBloMntVThdaxn+wuCoF1nzWmHK3Z+zSk0yigQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1765,9 +1765,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.11.0.tgz",
-      "integrity": "sha512-AxSsco4CXsDJuL/lI7a/jAt6LyT+jP5CKwQSUl8AEmgvEDcUnnyJod6FgpqsOaw5Y3sNIEvvNAc2x7KEmFK1MA==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.11.1.tgz",
+      "integrity": "sha512-Pc4X9W0DEdYtIw2pQO/m2KjfrklRS75cN76EiPbImyyoFx/MH7/0dSjTpN0zgNqp3rU6wFuEPt1hLPV4ofB8yA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "^19.2.7",
         "tsx": "^4.22.4",
         "vite": "^8.2.0",
-        "vite-plugin-react-server": "^3.10.2",
+        "vite-plugin-react-server": "^3.11.0",
         "webpack-sources": "^3.5.0"
       }
     },
@@ -1765,9 +1765,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.10.2.tgz",
-      "integrity": "sha512-6X8QfNhsexeJYyd0wDE9DB8rMQ/L9nicqp+M2VsvasQ9rAMcX5XPuBWAMVH1vgOwP13m6gkPL4uTQyhbU3aAaQ==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.11.0.tgz",
+      "integrity": "sha512-AxSsco4CXsDJuL/lI7a/jAt6LyT+jP5CKwQSUl8AEmgvEDcUnnyJod6FgpqsOaw5Y3sNIEvvNAc2x7KEmFK1MA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
     "@vitejs/plugin-react": "^6.0.5",
     "acorn-loose": "^8.5.2",
     "happy-dom": "^20.10.6",
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
     "tsx": "^4.22.4",
     "vite": "^8.2.0",
-    "vite-plugin-react-server": "^3.11.0",
+    "vite-plugin-react-server": "^3.11.1",
     "webpack-sources": "^3.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^19.2.7",
     "tsx": "^4.22.4",
     "vite": "^8.2.0",
-    "vite-plugin-react-server": "^3.10.2",
+    "vite-plugin-react-server": "^3.11.0",
     "webpack-sources": "^3.5.0"
   }
 }


### PR DESCRIPTION
Moves the stable train forward: vite-plugin-react-server ^3.11.1 (whose rsl pin resolves to 19.2.20, single deduped copy), react/react-dom ^19.2.8.

Full e2e gate passes on the production build: 12/12 (prerendered pages, per-request route, favorites server action, search, navigation transitions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)