### PR TITLE
build: declare the vprs runner (required from 4.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:preview": "npm run env:preview -- npm run build --app",
     "preview:start": "npm run env:preview -- vite preview",
     "debug-build": "npm run env:dev -- vite build --app --mode=development",
-    "clean-install": "npm install react@^19.2.7 react-dom@^19.2.7",
+    "clean-install": "npm install react@^19.2.8 react-dom@^19.2.8",
     "patch-oss": "patch"
   },
   "author": "Nico Brinkkemper",

--- a/vite.react.config.ts
+++ b/vite.react.config.ts
@@ -1,7 +1,13 @@
 import type { StreamPluginOptions } from "vite-plugin-react-server/types";
+import { getCondition } from "vite-plugin-react-server/config";
 import pokedex from "./src/data/pokedex.json" with { type: "json" };
 
 export default {
+  // This demo deliberately runs BOTH topologies from one config (dev:rsc vs
+  // dev:ssr, build vs build:static), so the declared runner tracks the
+  // launching script's condition. A single-topology app declares a literal
+  // "main" or "isolated" instead. Required from vite-plugin-react-server 4.0.
+  runner: getCondition() === "react-server" ? ("main" as const) : ("isolated" as const),
   moduleBase: "src",
   // File-based routing in one field: scans src/page/** for page.tsx (+ sibling
   // props.ts) and derives Page / props / routePatterns / the prerender


### PR DESCRIPTION
vite-plugin-react-server 4.0 makes the `runner` option required (`main` | `isolated` | `edge`), replacing condition-inferred dispatch with an explicit declaration. This repo deliberately runs both topologies from one config — `dev:rsc` vs `dev:ssr`, `build` (react-server condition) vs `build:static` — so the config derives the runner from the launching script's condition, with a comment saying exactly that; a single-topology app would write a literal.

On today's 3.x the field is optional and validated, so this is a no-op ahead of the requirement. Both `build` and `build:static` verified green with the declaration (1037 pages each). `clean-install` also catches up to the ^19.2.8 React floor the dependencies already use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)